### PR TITLE
use NPM_CONFIG_TOKEN fro bun publish

### DIFF
--- a/.github/workflows/publish-cli.yaml
+++ b/.github/workflows/publish-cli.yaml
@@ -32,4 +32,4 @@ jobs:
         run: bun publish
         working-directory: ./packages/rettangoli-cli
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+          NPM_CONFIG_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}

--- a/.github/workflows/publish-fe.yaml
+++ b/.github/workflows/publish-fe.yaml
@@ -32,4 +32,4 @@ jobs:
         run: bun publish
         working-directory: ./packages/rettangoli-fe
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+          NPM_CONFIG_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}

--- a/.github/workflows/publish-sites.yaml
+++ b/.github/workflows/publish-sites.yaml
@@ -32,4 +32,4 @@ jobs:
         run: bun publish
         working-directory: ./packages/rettangoli-sites
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+          NPM_CONFIG_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}

--- a/.github/workflows/publish-ui.yaml
+++ b/.github/workflows/publish-ui.yaml
@@ -36,4 +36,4 @@ jobs:
         run: bun publish
         working-directory: ./packages/rettangoli-ui
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+          NPM_CONFIG_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}

--- a/.github/workflows/publish-vt.yaml
+++ b/.github/workflows/publish-vt.yaml
@@ -32,4 +32,4 @@ jobs:
         run: bun publish
         working-directory: ./packages/rettangoli-vt
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+          NPM_CONFIG_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}

--- a/packages/rettangoli-ui/.npmrc
+++ b/packages/rettangoli-ui/.npmrc
@@ -1,1 +1,0 @@
-//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}

--- a/packages/rettangoli-ui/package.json
+++ b/packages/rettangoli-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rettangoli/ui",
-  "version": "0.1.1-rc1",
+  "version": "0.1.1",
   "description": "A UI component library for building web interfaces.",
   "main": "dist/rettangoli-esm.min.js",
   "type": "module",


### PR DESCRIPTION
`bun publish` used different env var than `npm publish`
https://bun.sh/docs/cli/publish#otp