### PR TITLE
Fix input event timing and update site dependencies

### DIFF
--- a/packages/rettangoli-ui/package.json
+++ b/packages/rettangoli-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rettangoli/ui",
-  "version": "0.1.1",
+  "version": "0.1.2-rc1",
   "description": "A UI component library for building web interfaces.",
   "main": "dist/rettangoli-esm.min.js",
   "type": "module",

--- a/packages/rettangoli-ui/src/components/form/form.view.yaml
+++ b/packages/rettangoli-ui/src/components/form/form.view.yaml
@@ -132,7 +132,7 @@ refs:
         handler: handleActionClick
   input-*:
     eventListeners:
-      input-keydown:
+      input-change:
         handler: handleInputChange
   select-*:
     eventListeners:

--- a/packages/rettangoli-ui/src/primitives/input.js
+++ b/packages/rettangoli-ui/src/primitives/input.js
@@ -78,7 +78,7 @@ class RettangoliInputElement extends HTMLElement {
     this.shadow.appendChild(this._inputElement);
 
     // Bind event handler
-    this._inputElement.addEventListener('keydown', this._onChange);
+    this._inputElement.addEventListener('input', this._onChange);
   }
 
   static get observedAttributes() {
@@ -106,7 +106,7 @@ class RettangoliInputElement extends HTMLElement {
   }
 
   _onChange = (event) => {
-    this.dispatchEvent(new CustomEvent('input-keydown', {
+    this.dispatchEvent(new CustomEvent('input-change', {
       detail: {
         value: this._inputElement.value,
       },


### PR DESCRIPTION
## Summary
- Fixed input event timing issue where keydown was capturing old values instead of new values
- Updated input primitive to use 'input' event instead of 'keydown' for real-time value changes
- Fixed rettangoli.dev site by updating CDN URL to use correct @rettangoli/ui version
- Added npm scripts to rettangoli.dev app for easier development
- Updated GitHub workflow to install rtgl CLI globally
- Bumped package versions appropriately

## Test plan
- [ ] Verify input fields in forms now capture updated values correctly
- [ ] Test rettangoli.dev site loads with working web components
- [ ] Confirm build and deployment workflow works