### PR TITLE
implmement boolean attributes with ?

### DIFF
--- a/packages/rettangoli-fe/docs/view.md
+++ b/packages/rettangoli-fe/docs/view.md
@@ -63,19 +63,57 @@ template:
   # Props: JavaScript values from viewData, passed as component properties
   - another-component#anotherComponent .items=todoItems .onSelect=handleSelect:
   
-  # Mixed: Both attributes and props on same element
-  - user-card#userCard name=John .user=currentUser
+  # Conditional boolean attributes: only added to DOM when condition is truthy
+  - input#myInput ?disabled=isFormDisabled ?required=fieldIsRequired:
+  
+  # Mixed: Attributes, props, and conditional attributes on same element
+  - user-card#userCard name=John .user=currentUser ?hidden=shouldHide
 ```
 
-**Key Difference:**
-- **Attributes** (no dot): Set as HTML attributes (`title="Hello"`) - visible in HTML
-- **Props** (with dot): Set as JavaScript properties on the element - NOT visible in HTML, only accessible via JavaScript
+**Key Differences:**
+- **Attributes** (no prefix): Set as HTML attributes (`title="Hello"`) - visible in HTML
+- **Props** (`.` prefix): Set as JavaScript properties on the element - NOT visible in HTML, only accessible via JavaScript  
+- **Conditional Boolean Attributes** (`?` prefix): Only added to DOM when the value is truthy, always as boolean attributes without values
 
 **Example:**
 ```js
 const userCard = document.getElementById('userCard');
 console.log(userCard.user); // Returns the currentUser object
 console.log(userCard.getAttribute('name')); // Returns "John"
+console.log(userCard.hasAttribute('hidden')); // true if shouldHide was truthy
+```
+
+### Conditional Boolean Attributes
+
+Use the `?` prefix to conditionally add boolean attributes based on viewData values:
+
+```yaml
+template:
+  # These will only appear in DOM if the condition is truthy
+  - input#email ?disabled=${isSubmitting} ?required=true:
+  - dialog#modal ?open=${showModal}:
+  - button#submit ?aria-pressed=${isPressed}:
+```
+
+**How it works:**
+- `?disabled=true` → `<input disabled>` (attribute present)  
+- `?disabled=false` → `<input>` (attribute absent)
+- `?disabled=${isFormDisabled}` → depends on the `isFormDisabled` value from viewData
+
+**Common use cases:**
+```yaml
+template:
+  # Form controls
+  - input ?disabled=${isLoading} ?required=${fieldIsRequired}:
+  
+  # Modal/dialog states  
+  - dialog ?open=${showDialog}:
+  
+  # Interactive elements
+  - button ?aria-pressed=${isToggled} ?disabled=${!canSubmit}:
+  
+  # Custom boolean attributes
+  - my-component ?loading=${isFetching} ?error=${hasError}:
 ```
 
 ## Templating with Jempl

--- a/packages/rettangoli-fe/src/createComponent.js
+++ b/packages/rettangoli-fe/src/createComponent.js
@@ -104,7 +104,9 @@ function createAttrsProxy(source) {
     {
       get(_, prop) {
         if (typeof prop === "string") {
-          return source.getAttribute(prop);
+          const value = source.getAttribute(prop);
+          // Return true for boolean attributes (empty string values)
+          return value === "" ? true : value;
         }
         return undefined;
       },

--- a/packages/rettangoli-ui/src/components/dropdownMenu/dropdownMenu.store.js
+++ b/packages/rettangoli-ui/src/components/dropdownMenu/dropdownMenu.store.js
@@ -5,7 +5,7 @@ export const INITIAL_STATE = Object.freeze({
 export const toViewData = ({ props, attrs }) => {
   return {
     items: props.items || [],
-    open: attrs.open !== null ? true : undefined,
+    open: !!attrs.open,
     x: attrs.x,
     y: attrs.y,
     placement: attrs.placement

--- a/packages/rettangoli-ui/src/components/dropdownMenu/dropdownMenu.view.yaml
+++ b/packages/rettangoli-ui/src/components/dropdownMenu/dropdownMenu.view.yaml
@@ -43,7 +43,7 @@ refs:
         handler: handleClickMenuItem
 
 template:
-  - rtgl-popover#popover open=${open} x=${x} y=${y} placement=${placement}:
+  - rtgl-popover#popover ?open=${open} x=${x} y=${y} placement=${placement}:
     - rtgl-view wh=300 g=xs slot=content bgc=background br=md:
       - $for item, i in items:
         - $if item.type == 'label':

--- a/packages/rettangoli-ui/src/components/sidebar/sidebar.view.yaml
+++ b/packages/rettangoli-ui/src/components/sidebar/sidebar.view.yaml
@@ -174,7 +174,7 @@ template:
               $else:
                 - rtgl-view mt=md h=1 bgc=mu-bg:
           $else:
-            - rtgl-view#item-${item.id} ${item.hrefAttr} h=${itemHeight} av=c ${itemAlignAttr} ph=${itemPadding} w=${itemWidth} h-bgc=${item.itemHoverBgc} br=lg bgc=${item.itemBgc} cur=p title="${item.title}":
+            - rtgl-view#item-${item.id} ${item.hrefAttr} h=${itemHeight} av=c ${itemAlignAttr} ph=${itemPadding} w=${itemWidth} h-bgc=${item.itemHoverBgc} br=lg bgc=${item.itemBgc} cur=p:
               - $if item.icon:
                   - $if showLabels:
                       - rtgl-view d=h ah=${itemContentAlign} g=sm:

--- a/packages/rettangoli-ui/src/primitives/popover.js
+++ b/packages/rettangoli-ui/src/primitives/popover.js
@@ -157,17 +157,23 @@ class RettangoliPopoverElement extends HTMLElement {
     const y = parseFloat(this.getAttribute('y') || '0');
     const placement = this.getAttribute('placement') || 'bottom-start';
 
+    // Remove positioned attribute to hide during repositioning
+    this.removeAttribute('positioned');
+
     // Calculate position based on placement
     // We'll position after the popover is rendered to get its dimensions
     requestAnimationFrame(() => {
       const rect = this._popoverContainer.getBoundingClientRect();
       const { left, top } = this._calculatePosition(x, y, rect.width, rect.height, placement);
 
+      // Set position first
       this._popoverContainer.style.left = `${left}px`;
       this._popoverContainer.style.top = `${top}px`;
 
-      // Mark as positioned to make it visible
-      this.setAttribute('positioned', '');
+      // Then make visible in next frame to prevent flicker
+      requestAnimationFrame(() => {
+        this.setAttribute('positioned', '');
+      });
     });
   }
 

--- a/packages/rettangoli-ui/vt/specs/primitives/dialog/scroll.html
+++ b/packages/rettangoli-ui/vt/specs/primitives/dialog/scroll.html
@@ -3,7 +3,7 @@ title: "Scroll"
 ---
 <rtgl-view g="lg" p="lg" wh="f" fw="w">
   <rtgl-button id="button">Open Dialog</rtgl-button>
-  <rtgl-dialog id="dialog">
+  <rtgl-dialog id="dialog" open>
     <rtgl-view slot="content" g="md">
       <rtgl-text s="lg">Dialog Content</rtgl-text>
       <rtgl-text c="mu">Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam, quos.</rtgl-text>
@@ -62,11 +62,11 @@ title: "Scroll"
 <script>
   const button = document.getElementById('button');
   const dialog = document.getElementById('dialog');
-  
+
   button.addEventListener('click', () => {
     dialog.setAttribute('open', '');
   });
-  
+
   // Listen for dialog close events (overlay click or ESC key)
   dialog.addEventListener('close', () => {
     dialog.removeAttribute('open');


### PR DESCRIPTION
Inspired by lit: https://lit.dev/docs/templates/expressions/#boolean-attribute-expressions
and uhtml https://webreflection.github.io/uhtml/#boolean

**How it works:**
- `<input ?disabled=true>` → `<input disabled>` (attribute present)  
- `<input ?disabled=false>` → `<input>` (attribute absent)
- `<input ?disabled=${isFormDisabled}>` → depends on the `isFormDisabled` value from viewData

**Common use cases:**
```yaml
template:
  # Form controls
  - input ?disabled=${isLoading} ?required=${fieldIsRequired}:
  
  # Modal/dialog states  
  - dialog ?open=${showDialog}:
  
  # Interactive elements
  - button ?aria-pressed=${isToggled} ?disabled=${!canSubmit}:
  
  # Custom boolean attributes
  - my-component ?loading=${isFetching} ?error=${hasError}:

** Breaking changes**

Preavously `<input disabled>` would have been removed and become `<input>` now instead. it will remain  `<input disabled>`.

so now can just write `<rtgl-view sv>` instead of `<rtgl-view sv=true>`