### PR TITLE
Feat Selector Add Option

### DIFF
--- a/packages/rettangoli-ui/package.json
+++ b/packages/rettangoli-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rettangoli/ui",
-  "version": "0.1.2-rc27",
+  "version": "0.1.2-rc28",
   "description": "A UI component library for building web interfaces.",
   "main": "dist/rettangoli-esm.min.js",
   "type": "module",

--- a/packages/rettangoli-ui/src/components/form/form.handlers.js
+++ b/packages/rettangoli-ui/src/components/form/form.handlers.js
@@ -187,15 +187,16 @@ export const handleWaveformClick = (e, deps) => {
   );
 };
 
-export const handleAddOptionSelected = (e, deps) => {
-  const { dispatchEvent } = deps;
+export const handleSelectAddOption = (e, deps) => {
+  const { store, dispatchEvent } = deps;
   const name = e.currentTarget.id.replace("select-", "");
   dispatchEvent(
-    new CustomEvent("add-option-selected", {
+    new CustomEvent("action-click", {
       detail: {
-        fieldName: name,
+        actionId: 'select-options-add',
+        name: name,
+        formValues: store.selectFormValues(),
       },
-      bubbles: true,
     }),
   );
 };

--- a/packages/rettangoli-ui/src/components/form/form.handlers.js
+++ b/packages/rettangoli-ui/src/components/form/form.handlers.js
@@ -186,3 +186,16 @@ export const handleWaveformClick = (e, deps) => {
     }),
   );
 };
+
+export const handleAddOptionSelected = (e, deps) => {
+  const { dispatchEvent } = deps;
+  const name = e.currentTarget.id.replace("select-", "");
+  dispatchEvent(
+    new CustomEvent("add-option-selected", {
+      detail: {
+        fieldName: name,
+      },
+      bubbles: true,
+    }),
+  );
+};

--- a/packages/rettangoli-ui/src/components/form/form.view.yaml
+++ b/packages/rettangoli-ui/src/components/form/form.view.yaml
@@ -52,10 +52,11 @@ propsSchema:
                     type: string
                   noClear:
                     type: boolean
-                  showAddOption:
-                    type: boolean
-                  addOptionLabel:
-                    type: string
+                  addOption:
+                    type: object
+                    properties:
+                      label:
+                        type: string
                   options:
                     type: array
                     items:
@@ -213,7 +214,7 @@ refs:
       select-change:
         handler: handleSelectChange
       add-option-selected:
-        handler: handleAddOptionSelected
+        handler: handleSelectAddOption
   colorpicker-*:
     eventListeners:
       colorpicker-change:
@@ -246,6 +247,7 @@ refs:
 events:
   form-change: {}
   extra-event: {}
+  action-click: {}
 
 template:
   - rtgl-view w=f p=md g=lg ${containerAttrString}:
@@ -265,7 +267,7 @@ template:
                   - $if field.inputType == "popover-input":
                       - rtgl-popover-input#popover-input-${field.name} label="${field.label}" .defaultValue=fields[${i}].defaultValue:
                   - $if field.inputType == "select":
-                      - rtgl-select#select-${field.name} key=${key} w=f .options=fields[${i}].options .placeholder=fields[${i}].placeholder .selectedValue=fields[${i}].defaultValue ?no-clear=fields[${i}].noClear .showAddOption=fields[${i}].showAddOption .addOptionLabel=fields[${i}].addOptionLabel:
+                      - rtgl-select#select-${field.name} key=${key} w=f .options=fields[${i}].options .placeholder=fields[${i}].placeholder .selectedValue=fields[${i}].defaultValue ?no-clear=fields[${i}].noClear .addOption=fields[${i}].addOption:
                   - $if field.inputType == "colorPicker":
                       - rtgl-color-picker#colorpicker-${field.name} key=${key} value=${field.defaultValue}:
                   - $if field.inputType == "slider":

--- a/packages/rettangoli-ui/src/components/form/form.view.yaml
+++ b/packages/rettangoli-ui/src/components/form/form.view.yaml
@@ -52,6 +52,10 @@ propsSchema:
                     type: string
                   noClear:
                     type: boolean
+                  showAddOption:
+                    type: boolean
+                  addOptionLabel:
+                    type: string
                   options:
                     type: array
                     items:
@@ -208,6 +212,8 @@ refs:
     eventListeners:
       select-change:
         handler: handleSelectChange
+      add-option-selected:
+        handler: handleAddOptionSelected
   colorpicker-*:
     eventListeners:
       colorpicker-change:
@@ -259,7 +265,7 @@ template:
                   - $if field.inputType == "popover-input":
                       - rtgl-popover-input#popover-input-${field.name} label="${field.label}" .defaultValue=fields[${i}].defaultValue:
                   - $if field.inputType == "select":
-                      - rtgl-select#select-${field.name} key=${key} w=f .options=fields[${i}].options .placeholder=fields[${i}].placeholder .selectedValue=fields[${i}].defaultValue ?no-clear=fields[${i}].noClear:
+                      - rtgl-select#select-${field.name} key=${key} w=f .options=fields[${i}].options .placeholder=fields[${i}].placeholder .selectedValue=fields[${i}].defaultValue ?no-clear=fields[${i}].noClear .showAddOption=fields[${i}].showAddOption .addOptionLabel=fields[${i}].addOptionLabel:
                   - $if field.inputType == "colorPicker":
                       - rtgl-color-picker#colorpicker-${field.name} key=${key} value=${field.defaultValue}:
                   - $if field.inputType == "slider":

--- a/packages/rettangoli-ui/src/components/select/select.handlers.js
+++ b/packages/rettangoli-ui/src/components/select/select.handlers.js
@@ -138,3 +138,38 @@ export const handleClearClick = (e, deps) => {
 
   render();
 }
+
+export const handleAddOptionClick = (e, deps) => {
+  const { store, render, dispatchEvent, props } = deps;
+
+  // Clear the selected value
+  store.clearSelectedValue();
+  
+  // Close the popover
+  store.closeOptionsPopover();
+
+  // Dispatch custom event for add option
+  dispatchEvent(new CustomEvent('add-option-selected', {
+    bubbles: true
+  }));
+
+  // Also dispatch select-change event with undefined value
+  dispatchEvent(new CustomEvent('select-change', {
+    detail: { selectedValue: undefined },
+    bubbles: true
+  }));
+
+  render();
+}
+
+export const handleAddOptionMouseEnter = (e, deps) => {
+  const { store, render } = deps;
+  store.setHoveredAddOption(true);
+  render();
+}
+
+export const handleAddOptionMouseLeave = (e, deps) => {
+  const { store, render } = deps;
+  store.setHoveredAddOption(false);
+  render();
+}

--- a/packages/rettangoli-ui/src/components/select/select.handlers.js
+++ b/packages/rettangoli-ui/src/components/select/select.handlers.js
@@ -140,7 +140,7 @@ export const handleClearClick = (e, deps) => {
 }
 
 export const handleAddOptionClick = (e, deps) => {
-  const { store, render, dispatchEvent, props } = deps;
+  const { store, render, dispatchEvent } = deps;
 
   // Clear the selected value
   store.clearSelectedValue();
@@ -148,7 +148,7 @@ export const handleAddOptionClick = (e, deps) => {
   // Close the popover
   store.closeOptionsPopover();
 
-  // Dispatch custom event for add option
+  // Dispatch custom event for add option (no detail)
   dispatchEvent(new CustomEvent('add-option-selected', {
     bubbles: true
   }));

--- a/packages/rettangoli-ui/src/components/select/select.handlers.js
+++ b/packages/rettangoli-ui/src/components/select/select.handlers.js
@@ -141,21 +141,12 @@ export const handleClearClick = (e, deps) => {
 
 export const handleAddOptionClick = (e, deps) => {
   const { store, render, dispatchEvent } = deps;
-
-  // Clear the selected value
-  store.clearSelectedValue();
   
   // Close the popover
   store.closeOptionsPopover();
 
   // Dispatch custom event for add option (no detail)
   dispatchEvent(new CustomEvent('add-option-selected', {
-    bubbles: true
-  }));
-
-  // Also dispatch select-change event with undefined value
-  dispatchEvent(new CustomEvent('select-change', {
-    detail: { selectedValue: undefined },
     bubbles: true
   }));
 

--- a/packages/rettangoli-ui/src/components/select/select.store.js
+++ b/packages/rettangoli-ui/src/components/select/select.store.js
@@ -31,6 +31,7 @@ export const INITIAL_STATE = Object.freeze({
   },
   selectedValue: null,
   hoveredOptionId: null,
+  hoveredAddOption: false,
 });
 
 export const toViewData = ({ state, props, attrs }) => {
@@ -72,7 +73,10 @@ export const toViewData = ({ state, props, attrs }) => {
     selectedLabelColor: isPlaceholderLabel ? "mu-fg" : "fg",
     placeholder: props.placeholder || 'Select an option',
     hasValue: currentValue !== null && currentValue !== undefined,
-    showClear: !attrs['no-clear'] && !props['no-clear'] && (currentValue !== null && currentValue !== undefined)
+    showClear: !attrs['no-clear'] && !props['no-clear'] && (currentValue !== null && currentValue !== undefined),
+    showAddOption: props.showAddOption || false,
+    addOptionLabel: props.addOptionLabel || 'Add...',
+    addOptionBgc: state.hoveredAddOption ? 'ac' : ''
   };
 }
 
@@ -117,6 +121,10 @@ export const clearHoveredOption = (state) => {
 
 export const clearSelectedValue = (state) => {
   state.selectedValue = undefined;
+}
+
+export const setHoveredAddOption = (state, isHovered) => {
+  state.hoveredAddOption = isHovered;
 }
 
 

--- a/packages/rettangoli-ui/src/components/select/select.store.js
+++ b/packages/rettangoli-ui/src/components/select/select.store.js
@@ -75,7 +75,7 @@ export const toViewData = ({ state, props, attrs }) => {
     hasValue: currentValue !== null && currentValue !== undefined,
     showClear: !attrs['no-clear'] && !props['no-clear'] && (currentValue !== null && currentValue !== undefined),
     showAddOption: props.showAddOption || false,
-    addOptionLabel: props.addOptionLabel || 'Add...',
+    addOptionLabel: props.addOptionLabel || '+ Add',
     addOptionBgc: state.hoveredAddOption ? 'ac' : ''
   };
 }

--- a/packages/rettangoli-ui/src/components/select/select.store.js
+++ b/packages/rettangoli-ui/src/components/select/select.store.js
@@ -74,8 +74,8 @@ export const toViewData = ({ state, props, attrs }) => {
     placeholder: props.placeholder || 'Select an option',
     hasValue: currentValue !== null && currentValue !== undefined,
     showClear: !attrs['no-clear'] && !props['no-clear'] && (currentValue !== null && currentValue !== undefined),
-    showAddOption: props.showAddOption || false,
-    addOptionLabel: props.addOptionLabel || '+ Add',
+    showAddOption: !!props.addOption,
+    addOptionLabel: props.addOption?.label ? `+ ${props.addOption.label}` : '+ Add',
     addOptionBgc: state.hoveredAddOption ? 'ac' : ''
   };
 }

--- a/packages/rettangoli-ui/src/components/select/select.view.yaml
+++ b/packages/rettangoli-ui/src/components/select/select.view.yaml
@@ -23,6 +23,10 @@ propsSchema:
       type: function
     no-clear:
       type: boolean
+    showAddOption:
+      type: boolean
+    addOptionLabel:
+      type: string
 
 refs:
   select-button:
@@ -45,6 +49,14 @@ refs:
         handler: handleOptionMouseEnter
       mouseleave:
         handler: handleOptionMouseLeave
+  option-add:
+    eventListeners:
+      click:
+        handler: handleAddOptionClick
+      mouseenter:
+        handler: handleAddOptionMouseEnter
+      mouseleave:
+        handler: handleAddOptionMouseLeave
 
 events: {}
 
@@ -61,3 +73,7 @@ template:
           - $for option, i in options:
               - rtgl-view#option-${i} w=f ph=lg pv=md cur=p br=md bgc=${option.bgc}:
                   - rtgl-text: ${option.label}
+          - $if showAddOption:
+              - rtgl-view w=f bw=xs bc=mu-bg bt=sm:
+              - rtgl-view#option-add w=f ph=lg pv=md cur=p br=md bgc=${addOptionBgc}:
+                  - rtgl-text c=ac: ${addOptionLabel}

--- a/packages/rettangoli-ui/src/components/select/select.view.yaml
+++ b/packages/rettangoli-ui/src/components/select/select.view.yaml
@@ -23,10 +23,11 @@ propsSchema:
       type: function
     no-clear:
       type: boolean
-    showAddOption:
-      type: boolean
-    addOptionLabel:
-      type: string
+    addOption:
+      type: object
+      properties:
+        label:
+          type: string
 
 refs:
   select-button:

--- a/packages/rettangoli-ui/vt/specs/components/form/form-with-add-option.html
+++ b/packages/rettangoli-ui/vt/specs/components/form/form-with-add-option.html
@@ -1,0 +1,94 @@
+---
+title: Form with Select Add Option
+---
+<rtgl-view g="lg" p="lg" wh="f" fw="w">
+  <rtgl-form id="form-with-add" w="400" />
+</rtgl-view>
+
+<script>
+  const form = document.getElementById('form-with-add');
+  
+  form.form = {
+    title: 'Product Configuration',
+    description: 'Configure your product with the option to add custom values',
+    fields: [
+      {
+        name: 'productName',
+        label: 'Product Name',
+        description: 'Enter the product name',
+        inputType: 'inputText',
+        placeholder: 'e.g., Widget Pro',
+        defaultValue: ''
+      },
+      {
+        name: 'category',
+        label: 'Category',
+        description: 'Select a category or add a new one',
+        inputType: 'select',
+        placeholder: 'Choose a category',
+        options: [
+          { value: 'electronics', label: 'Electronics' },
+          { value: 'clothing', label: 'Clothing' },
+          { value: 'food', label: 'Food & Beverages' },
+          { value: 'books', label: 'Books' }
+        ],
+        showAddOption: true,
+        addOptionLabel: '+ Add new category',
+        defaultValue: null
+      },
+      {
+        name: 'size',
+        label: 'Size',
+        description: 'Select size (no add option)',
+        inputType: 'select',
+        placeholder: 'Choose size',
+        options: [
+          { value: 'small', label: 'Small' },
+          { value: 'medium', label: 'Medium' },
+          { value: 'large', label: 'Large' },
+          { value: 'xl', label: 'Extra Large' }
+        ],
+        showAddOption: false,
+        noClear: true,
+        defaultValue: 'medium'
+      },
+      {
+        name: 'tags',
+        label: 'Tags',
+        description: 'Select tags or create custom ones',
+        inputType: 'select',
+        placeholder: 'Select a tag',
+        options: [
+          { value: 'featured', label: 'Featured' },
+          { value: 'sale', label: 'On Sale' },
+          { value: 'new', label: 'New Arrival' },
+          { value: 'bestseller', label: 'Best Seller' }
+        ],
+        showAddOption: true,
+        addOptionLabel: '+ Create custom tag',
+        defaultValue: null
+      }
+    ],
+    actions: {
+      buttons: [
+        { id: 'save', content: 'Save Configuration' },
+        { id: 'reset', content: 'Reset Form' }
+      ]
+    }
+  };
+
+  form.render();
+
+  // Listen for form events
+  form.addEventListener('form-change', (e) => {
+    console.log('form-change', e.detail);
+  });
+
+  form.addEventListener('add-option-selected', (e) => {
+    console.log('add-option-selected for field:', e.detail.fieldName);
+  });
+
+  form.addEventListener('action-click', (e) => {
+    console.log('action-click', e.detail);
+  });
+</script>

--- a/packages/rettangoli-ui/vt/specs/components/form/form-with-add-option.html
+++ b/packages/rettangoli-ui/vt/specs/components/form/form-with-add-option.html
@@ -32,8 +32,7 @@ title: Form with Select Add Option
           { value: 'food', label: 'Food & Beverages' },
           { value: 'books', label: 'Books' }
         ],
-        showAddOption: true,
-        addOptionLabel: '+ Add new category',
+        addOption: { label: 'Add new category' },
         defaultValue: null
       },
       {
@@ -48,7 +47,6 @@ title: Form with Select Add Option
           { value: 'large', label: 'Large' },
           { value: 'xl', label: 'Extra Large' }
         ],
-        showAddOption: false,
         noClear: true,
         defaultValue: 'medium'
       },
@@ -64,8 +62,7 @@ title: Form with Select Add Option
           { value: 'new', label: 'New Arrival' },
           { value: 'bestseller', label: 'Best Seller' }
         ],
-        showAddOption: true,
-        addOptionLabel: '+ Create custom tag',
+        addOption: { label: 'Create custom tag' },
         defaultValue: null
       }
     ],
@@ -84,11 +81,10 @@ title: Form with Select Add Option
     console.log('form-change', e.detail);
   });
 
-  form.addEventListener('add-option-selected', (e) => {
-    console.log('add-option-selected for field:', e.detail.fieldName);
-  });
-
   form.addEventListener('action-click', (e) => {
     console.log('action-click', e.detail);
+    if (e.detail.actionId === 'select-options-add') {
+      console.log('Add option selected for field:', e.detail.name);
+    }
   });
 </script>

--- a/packages/rettangoli-ui/vt/specs/components/select/select-with-add-option.html
+++ b/packages/rettangoli-ui/vt/specs/components/select/select-with-add-option.html
@@ -1,0 +1,58 @@
+---
+title: Select with Add Option
+---
+<rtgl-view g="lg" p="lg" wh="f" fw="w">
+  <rtgl-select id="select-with-add" />
+  <rtgl-select id="select-custom-label" />
+</rtgl-view>
+
+<script>
+  // Select with default "Add..." option
+  const selectWithAdd = document.getElementById('select-with-add');
+  selectWithAdd.placeholder = 'Select or add an option';
+  selectWithAdd.options = [
+    { value: "1", label: 'Option 1' },
+    { value: "2", label: 'Option 2' },
+    { value: "3", label: 'Option 3' },
+  ];
+  selectWithAdd.showAddOption = true;
+  selectWithAdd.render();
+
+  // Select with custom add label
+  const selectCustomLabel = document.getElementById('select-custom-label');
+  selectCustomLabel.placeholder = 'Choose a fruit';
+  selectCustomLabel.options = [
+    { value: "apple", label: 'Apple' },
+    { value: "banana", label: 'Banana' },
+    { value: "orange", label: 'Orange' },
+  ];
+  selectCustomLabel.showAddOption = true;
+  selectCustomLabel.addOptionLabel = 'Add new fruit...';
+  selectCustomLabel.render();
+
+  // Listen for events
+  selectWithAdd.addEventListener('option-selected', (e) => {
+    console.log('option-selected', e.detail);
+  });
+
+  selectWithAdd.addEventListener('add-option-selected', (e) => {
+    console.log('add-option-selected triggered');
+  });
+
+  selectWithAdd.addEventListener('select-change', (e) => {
+    console.log('select-change', e.detail);
+  });
+
+  selectCustomLabel.addEventListener('add-option-selected', (e) => {
+    console.log('custom select add-option-selected triggered');
+  });
+
+  // Optional callback functions
+  selectWithAdd.onAddOption = () => {
+    console.log('onAddOption callback triggered');
+  };
+
+  selectCustomLabel.onAddOption = () => {
+    console.log('custom onAddOption callback triggered');
+  };
+</script>

--- a/packages/rettangoli-ui/vt/specs/components/select/select-with-add-option.html
+++ b/packages/rettangoli-ui/vt/specs/components/select/select-with-add-option.html
@@ -15,7 +15,7 @@ title: Select with Add Option
     { value: "2", label: 'Option 2' },
     { value: "3", label: 'Option 3' },
   ];
-  selectWithAdd.showAddOption = true;
+  selectWithAdd.addOption = {};  // Use default label
   selectWithAdd.render();
 
   // Select with custom add label
@@ -26,8 +26,7 @@ title: Select with Add Option
     { value: "banana", label: 'Banana' },
     { value: "orange", label: 'Orange' },
   ];
-  selectCustomLabel.showAddOption = true;
-  selectCustomLabel.addOptionLabel = 'Add new fruit...';
+  selectCustomLabel.addOption = { label: 'Add new fruit' };
   selectCustomLabel.render();
 
   // Listen for events
@@ -46,13 +45,4 @@ title: Select with Add Option
   selectCustomLabel.addEventListener('add-option-selected', (e) => {
     console.log('custom select add-option-selected triggered');
   });
-
-  // Optional callback functions
-  selectWithAdd.onAddOption = () => {
-    console.log('onAddOption callback triggered');
-  };
-
-  selectCustomLabel.onAddOption = () => {
-    console.log('custom onAddOption callback triggered');
-  };
 </script>


### PR DESCRIPTION
## selector

- new props:
  - `showAddOption`: boolean, if true will show the add option
  - `addOptionLabel`: string, default '+ Add'
- new event
  - `add-option-selected`: no detail

## form

- new props
  - when `inputType=select`, `showAddOption` & `addOptionLabel` for field object prop is available.
- new event
  - `add-option-selected`: detail contains `fieldName`

<img width="440" height="427" alt="image" src="https://github.com/user-attachments/assets/02db9f25-8c7f-4ac7-8c29-8f2a0f63f98f" />
