### PR TITLE
feat(tui): add rtgl-progress-bar primitive

### DIFF
--- a/apps/rettangoli.dev/pages/tui/docs/guides/primitives.md
+++ b/apps/rettangoli.dev/pages/tui/docs/guides/primitives.md
@@ -17,6 +17,7 @@ sidebarId: tui-primitives
 | `rtgl-textarea` | Multiline field with cursor | `label`, `value`, `placeholder`, `w`, `h`, `active`, `cursorRow`, `cursorCol` |
 | `rtgl-divider` | Horizontal/vertical line | `w` (horizontal), `o=v` + `h` (vertical), `c` (custom char) |
 | `rtgl-image` | Terminal image rendering (kitty protocol) | `src` (PNG), `:data` (base64 PNG), `w`, `h`, `alt` |
+| `rtgl-progress-bar` | Progress visualization | `value`, `max`, `percent`, `w`, `label`, `showPercent`, `status`, `color` |
 | `rtgl-selector-dialog` | Floating selector overlay | `open`, `title`, `:options`, `:selectedIndex`, `size`, `x`, `y` |
 | `rtgl-list` | Row list with highlight | `:items`, `:selectedIndex`, `w`, `marker`, `n` |
 | `rtgl-table` | Full-width table with row highlight | `:data`, `:selectedIndex`, `w`, `variant`, `showHeader`, `highlight` |
@@ -29,6 +30,7 @@ template:
       - rtgl-text w=bold: "Tasks"
       - rtgl-divider w=72: null
       - rtgl-image src="./assets/logo.png" w=16 h=6 alt="[image]": null
+      - rtgl-progress-bar label="Build" value=42 max=100 w=24 status=doing: null
       - rtgl-list :items=taskListItems :selectedIndex=selectedTaskIndex w=f: null
       - rtgl-table :data=taskTableData :selectedIndex=selectedTaskIndex w=f cw=28: null
       - rtgl-selector-dialog open=${selectorOpen} size=md title="Pick Environment" :options=selectorOptions :selectedIndex=selectorIndex:

--- a/apps/rettangoli.dev/pages/tui/docs/introduction/introduction.md
+++ b/apps/rettangoli.dev/pages/tui/docs/introduction/introduction.md
@@ -19,7 +19,7 @@ You keep the same mental model, but render to a real terminal instead of the bro
 - Reuse FE component structure and conventions in terminal apps.
 - Build interactive TUIs with declarative YAML views.
 - Keep state updates in store actions and event orchestration in handlers.
-- Use native terminal primitives (`rtgl-selector-dialog`, `rtgl-textarea`, `rtgl-list`, `rtgl-table`, `rtgl-image`) without ASCII hacks.
+- Use native terminal primitives (`rtgl-selector-dialog`, `rtgl-textarea`, `rtgl-list`, `rtgl-table`, `rtgl-image`, `rtgl-progress-bar`) without ASCII hacks.
 
 ## Runtime flow
 
@@ -45,6 +45,7 @@ import { createComponent, createTuiRuntime } from "@rettangoli/tui";
 - `rtgl-list`
 - `rtgl-table`
 - `rtgl-image`
+- `rtgl-progress-bar`
 
 ## What is different from FE
 

--- a/packages/rettangoli-tui/README.md
+++ b/packages/rettangoli-tui/README.md
@@ -28,6 +28,7 @@ Included core primitives:
 - `rtgl-input`
 - `rtgl-list`
 - `rtgl-image`
+- `rtgl-progress-bar`
 - `rtgl-table`
 - `rtgl-textarea`
 - `rtgl-divider`
@@ -56,6 +57,16 @@ Included core primitives:
 - `RETTANGOLI_TUI_DISABLE_KITTY=1` to force fallback text
 
 Auto-detection targets Kitty-compatible environments (`kitty`, `ghostty`, and `wezterm`).
+
+`rtgl-progress-bar` supports:
+
+- `value` + `max` (or `total`) to compute percentage
+- explicit `percent` / `p` override
+- `w` for bar width in terminal cells
+- optional `label`
+- `showPercent=false` to hide trailing percent text
+- `status` (`todo`, `doing`, `done`) or `color` (`green`, `yellow`, `cyan`, `blue`, `magenta`, `gray`)
+- optional `fill` / `empty` characters
 
 `rtgl-table` supports:
 

--- a/packages/rettangoli-tui/examples/showcase/components/showcase/showcase.store.js
+++ b/packages/rettangoli-tui/examples/showcase/components/showcase/showcase.store.js
@@ -150,6 +150,7 @@ export const selectViewData = ({ state }) => {
   const selectorOptions = Array.isArray(state.selectorOptions) ? state.selectorOptions : [];
   const selectedSelectorIndex = findOptionIndexById(selectorOptions, state.selectedEnvironment);
   const selectedSelectorOption = selectorOptions[selectedSelectorIndex] || null;
+  const taskCompletedCount = tasks.filter((task) => Boolean(task.done)).length;
 
   return {
     ...state,
@@ -158,6 +159,7 @@ export const selectViewData = ({ state }) => {
     taskCount: tasks.length,
     selectedTaskIndex: safeSelectedTaskIndex,
     selectedTaskId: tasks[safeSelectedTaskIndex]?.id || "-",
+    taskCompletedCount,
     selectorOptions,
     selectorIndex: selectedSelectorIndex,
     selectorSelectedLabel: selectedSelectorOption?.label || "(none)",

--- a/packages/rettangoli-tui/examples/showcase/components/showcase/showcase.view.yaml
+++ b/packages/rettangoli-tui/examples/showcase/components/showcase/showcase.view.yaml
@@ -16,6 +16,7 @@ template:
       - rtgl-text: "- rtgl-input"
       - rtgl-text: "- rtgl-list"
       - rtgl-text: "- rtgl-image"
+      - rtgl-text: "- rtgl-progress-bar"
       - rtgl-text: "- rtgl-table"
       - rtgl-text: "- rtgl-textarea"
       - rtgl-text: "- rtgl-divider"
@@ -49,6 +50,10 @@ template:
       - rtgl-text: "Image demo (Kitty protocol)"
       - rtgl-text: "Source: yuusoft.com/public/img/favicon.png"
       - rtgl-image :src=showcaseImageSrc w=20 h=10 alt="[image unavailable - terminal does not support kitty graphics]": null
+      - rtgl-divider w=72: null
+      - rtgl-text: "Progress bar demo"
+      - rtgl-progress-bar label="Tasks Done" :value=taskCompletedCount :max=taskCount w=32 status=doing: null
+      - rtgl-progress-bar label="Deploy" percent=78 w=24 color=green: null
       - rtgl-divider w=72: null
       - rtgl-text: "Message: ${message}"
       - rtgl-text: "Last Key: ${lastKey}"

--- a/packages/rettangoli-tui/src/primitives/index.js
+++ b/packages/rettangoli-tui/src/primitives/index.js
@@ -2,6 +2,7 @@ import renderDivider from "./divider.js";
 import renderImage from "./image.js";
 import renderInput from "./input.js";
 import renderList from "./list.js";
+import renderProgressBar from "./progressBar.js";
 import renderSelectorDialog from "./selectorDialog.js";
 import renderTable from "./table.js";
 import renderTextarea from "./textarea.js";
@@ -14,6 +15,7 @@ export const createDefaultTuiPrimitives = () => {
     "rtgl-image": renderImage,
     "rtgl-input": renderInput,
     "rtgl-list": renderList,
+    "rtgl-progress-bar": renderProgressBar,
     "rtgl-selector-dialog": renderSelectorDialog,
     "rtgl-table": renderTable,
     "rtgl-textarea": renderTextarea,

--- a/packages/rettangoli-tui/src/primitives/progressBar.js
+++ b/packages/rettangoli-tui/src/primitives/progressBar.js
@@ -1,0 +1,150 @@
+import { ansi } from "../tui/ansi.js";
+import { resolveTerminalWidth, resolveTextContent } from "./common.js";
+
+const DEFAULT_BAR_WIDTH = 24;
+const YES_VALUES = new Set(["", "1", "true", "yes", "on"]);
+
+const COLOR_MAP = {
+  blue: ansi.fgBlue,
+  cyan: ansi.fgCyan,
+  gray: ansi.fgGray,
+  green: ansi.fgGreen,
+  magenta: ansi.fgMagenta,
+  yellow: ansi.fgYellow,
+};
+
+const STATUS_COLOR_MAP = {
+  done: ansi.fgGreen,
+  doing: ansi.fgCyan,
+  "in-progress": ansi.fgCyan,
+  todo: ansi.fgYellow,
+};
+
+const clamp = (value, min, max) => {
+  return Math.min(Math.max(value, min), max);
+};
+
+const toNumber = (value) => {
+  const numericValue = Number(value);
+  if (!Number.isFinite(numericValue)) {
+    return null;
+  }
+  return numericValue;
+};
+
+const isTrue = (value, fallback = false) => {
+  if (value === undefined || value === null) {
+    return fallback;
+  }
+  if (value === true || value === 1) {
+    return true;
+  }
+  if (value === false || value === 0) {
+    return false;
+  }
+  if (typeof value !== "string") {
+    return fallback;
+  }
+  return YES_VALUES.has(value.trim().toLowerCase());
+};
+
+const resolvePrecision = ({ attrs, props }) => {
+  const numericValue = toNumber(props.precision ?? attrs.precision);
+  if (numericValue === null) {
+    return 0;
+  }
+  return clamp(Math.floor(numericValue), 0, 2);
+};
+
+const resolvePercent = ({ attrs, props }) => {
+  const explicitPercent = toNumber(
+    props.percent
+      ?? attrs.percent
+      ?? props.p
+      ?? attrs.p,
+  );
+
+  if (explicitPercent !== null) {
+    return clamp(explicitPercent, 0, 100);
+  }
+
+  const value = toNumber(props.value ?? attrs.value ?? 0) ?? 0;
+  const max = toNumber(props.max ?? attrs.max ?? props.total ?? attrs.total ?? 100) ?? 100;
+  if (max <= 0) {
+    return 0;
+  }
+  return clamp((value / max) * 100, 0, 100);
+};
+
+const resolveColorFn = ({ attrs, props }) => {
+  const colorToken = String(props.color ?? attrs.color ?? "").trim().toLowerCase();
+  if (COLOR_MAP[colorToken]) {
+    return COLOR_MAP[colorToken];
+  }
+
+  const statusToken = String(props.status ?? attrs.status ?? "").trim().toLowerCase();
+  if (STATUS_COLOR_MAP[statusToken]) {
+    return STATUS_COLOR_MAP[statusToken];
+  }
+
+  return (value) => value;
+};
+
+const resolveLabel = ({ attrs, props, text, joinChildren }) => {
+  const explicitLabel = props.label ?? attrs.label;
+  if (explicitLabel !== undefined && explicitLabel !== null) {
+    return String(explicitLabel).trim();
+  }
+
+  const safeJoinChildren = typeof joinChildren === "function"
+    ? joinChildren
+    : () => "";
+  return String(resolveTextContent({ text, joinChildren: safeJoinChildren })).trim();
+};
+
+const resolveFillChars = ({ attrs, props }) => {
+  const fillCharToken = String(props.fill ?? attrs.fill ?? "█");
+  const emptyCharToken = String(props.empty ?? attrs.empty ?? "░");
+
+  return {
+    fillChar: fillCharToken[0] || "█",
+    emptyChar: emptyCharToken[0] || "░",
+  };
+};
+
+const formatPercentText = (percent, precision) => {
+  if (precision <= 0) {
+    return `${Math.round(percent)}%`;
+  }
+  return `${percent.toFixed(precision)}%`;
+};
+
+const renderProgressBar = ({ attrs = {}, props = {}, text, joinChildren }) => {
+  const precision = resolvePrecision({ attrs, props });
+  const percent = resolvePercent({ attrs, props });
+  const barWidth = resolveTerminalWidth(props.w ?? attrs.w, DEFAULT_BAR_WIDTH);
+  const showPercent = isTrue(
+    props.showPercent ?? attrs.showPercent ?? props.showValue ?? attrs.showValue,
+    true,
+  );
+  const label = resolveLabel({ attrs, props, text, joinChildren });
+  const { fillChar, emptyChar } = resolveFillChars({ attrs, props });
+  const colorFn = resolveColorFn({ attrs, props });
+
+  const filledCells = clamp(
+    Math.round((percent / 100) * barWidth),
+    0,
+    barWidth,
+  );
+
+  const filled = colorFn(fillChar.repeat(filledCells));
+  const empty = emptyChar.repeat(Math.max(0, barWidth - filledCells));
+  const bar = `[${filled}${empty}]`;
+  const percentText = showPercent
+    ? formatPercentText(percent, precision)
+    : "";
+
+  return [label, bar, percentText].filter(Boolean).join(" ");
+};
+
+export default renderProgressBar;

--- a/packages/rettangoli-tui/test/tui/progress-bar-primitive.test.js
+++ b/packages/rettangoli-tui/test/tui/progress-bar-primitive.test.js
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+
+import renderProgressBar from "../../src/primitives/progressBar.js";
+
+const stripAnsi = (value) => String(value || "").replace(/\u001b\[[0-9;]*[A-Za-z]/g, "");
+
+describe("rtgl-progress-bar primitive", () => {
+  it("renders value/max progress with default percent label", () => {
+    const output = renderProgressBar({
+      attrs: {},
+      props: {
+        label: "Upload",
+        value: 30,
+        max: 100,
+        w: 10,
+      },
+    });
+
+    const clean = stripAnsi(output);
+    expect(clean).toContain("Upload");
+    expect(clean).toContain("[███░░░░░░░]");
+    expect(clean).toContain("30%");
+  });
+
+  it("supports explicit percent and color", () => {
+    const output = renderProgressBar({
+      attrs: {},
+      props: {
+        percent: 78,
+        w: 10,
+        color: "green",
+      },
+    });
+
+    const clean = stripAnsi(output);
+    expect(output).toContain("\u001b[32m");
+    expect(clean).toContain("[████████░░]");
+    expect(clean).toContain("78%");
+  });
+
+  it("clamps out-of-range values and can hide percent text", () => {
+    const output = renderProgressBar({
+      attrs: {},
+      props: {
+        value: 999,
+        max: 10,
+        w: 8,
+        showPercent: false,
+      },
+    });
+
+    const clean = stripAnsi(output);
+    expect(clean).toContain("[████████]");
+    expect(clean).not.toContain("%");
+  });
+
+  it("falls back to zero percent when max is invalid", () => {
+    const output = renderProgressBar({
+      attrs: {},
+      props: {
+        value: 5,
+        max: 0,
+        w: 6,
+      },
+    });
+
+    const clean = stripAnsi(output);
+    expect(clean).toContain("[░░░░░░]");
+    expect(clean).toContain("0%");
+  });
+});

--- a/packages/rettangoli-tui/test/tui/runtime-render.test.js
+++ b/packages/rettangoli-tui/test/tui/runtime-render.test.js
@@ -32,6 +32,7 @@ const view = {
         },
         { "rtgl-text": "users: ${users}" },
         { "rtgl-input label=Search value=${query}": null },
+        { "rtgl-progress-bar label='Users Loaded' :value=users max=20 w=12": null },
         { "rtgl-list :items=items :selectedIndex=1 w=f": null },
         { "rtgl-table :data=tableData :selectedIndex=1 w=f cw=12": null },
         {
@@ -123,6 +124,8 @@ describe("tui runtime", () => {
     expect(output).toContain("│");
     expect(output).toContain("users: 12");
     expect(output).toContain("Search:");
+    expect(output).toContain("Users Loaded");
+    expect(output).toContain("60%");
     expect(output).toContain("• [ ] ship v1");
     expect(output).toContain("• [x] release notes");
     expect(output).toContain("┌");


### PR DESCRIPTION
## Summary
- add new `rtgl-progress-bar` primitive to `@rettangoli/tui`
- support progress rendering via `value`/`max` (or `total`) and explicit `percent`
- support width, label, percent visibility, fill/empty chars, precision, and status/color styling
- register primitive in default TUI primitive map
- add showcase examples for task completion and deploy progress
- update docs (package README + TUI docs site) to include `rtgl-progress-bar`
- add primitive unit tests and runtime render integration assertion

## Files
- `packages/rettangoli-tui/src/primitives/progressBar.js` (new)
- `packages/rettangoli-tui/src/primitives/index.js`
- `packages/rettangoli-tui/test/tui/progress-bar-primitive.test.js` (new)
- `packages/rettangoli-tui/test/tui/runtime-render.test.js`
- `packages/rettangoli-tui/examples/showcase/components/showcase/showcase.store.js`
- `packages/rettangoli-tui/examples/showcase/components/showcase/showcase.view.yaml`
- `packages/rettangoli-tui/README.md`
- `apps/rettangoli.dev/pages/tui/docs/introduction/introduction.md`
- `apps/rettangoli.dev/pages/tui/docs/guides/primitives.md`

## Validation
- ran `npm test` in `packages/rettangoli-tui`
- result: `8 passed`, `30 passed`
