### PR TITLE
fix(fe): reuse shadow root on reconnect

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -41,24 +41,24 @@
     },
     "packages/rettangoli-cli": {
       "name": "rtgl",
-      "version": "1.0.13",
+      "version": "1.1.1",
       "bin": {
         "rtgl": "cli.js",
       },
       "dependencies": {
         "@rettangoli/be": "1.0.2",
         "@rettangoli/check": "0.1.2",
-        "@rettangoli/fe": "1.1.0",
+        "@rettangoli/fe": "1.1.2",
         "@rettangoli/sites": "1.0.1",
         "@rettangoli/ui": "1.0.11",
-        "@rettangoli/vt": "1.0.4",
+        "@rettangoli/vt": "1.0.5",
         "commander": "^14.0.0",
         "js-yaml": "^4.1.0",
       },
     },
     "packages/rettangoli-fe": {
       "name": "@rettangoli/fe",
-      "version": "1.1.0",
+      "version": "1.1.2",
       "dependencies": {
         "immer": "^10.1.1",
         "jempl": "1.0.1",
@@ -73,7 +73,7 @@
     },
     "packages/rettangoli-sitekit": {
       "name": "@rettangoli/sitekit",
-      "version": "1.0.3",
+      "version": "1.0.5",
       "devDependencies": {
         "serve": "^14.2.6",
       },
@@ -114,9 +114,9 @@
     },
     "packages/rettangoli-ui": {
       "name": "@rettangoli/ui",
-      "version": "1.0.13",
+      "version": "1.4.0",
       "dependencies": {
-        "@rettangoli/fe": "1.1.0",
+        "@rettangoli/fe": "1.1.1",
         "jempl": "1.0.1",
       },
       "devDependencies": {
@@ -131,7 +131,7 @@
     },
     "packages/rettangoli-vt": {
       "name": "@rettangoli/vt",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "dependencies": {
         "commander": "^13.1.0",
         "js-yaml": "^4.1.0",
@@ -911,6 +911,8 @@
     "@rettangoli/sites/yahtml": ["yahtml@0.0.4", "", {}, "sha512-9QuyogoLkvpq1ETyiETeHtcFVqUUI0pl3RjgfJ8mlpeAvkP8f1risDDJ0s9rZ8H8TwAA9hegw3mzr2eTsdRT3g=="],
 
     "@rettangoli/tui/puty": ["puty@0.1.2", "", { "dependencies": { "js-yaml": "~4.1.0" }, "peerDependencies": { "vitest": ">=1.0.0" } }, "sha512-VNEwqORf0u/LiVdjyHPsIOKWC5z4uNuHhMgYu9WGea6u3YCP4OimQHQfWkw0DB/tE3KuWgPO0dhkM8uH4Yweig=="],
+
+    "@rettangoli/ui/@rettangoli/fe": ["@rettangoli/fe@1.1.1", "", { "dependencies": { "immer": "^10.1.1", "jempl": "1.0.1", "js-yaml": "^4.1.0", "snabbdom": "^3.6.2", "vite": "^6.3.5" } }, "sha512-EW5+b2zz7//sO0MYN4PVVGjbkvm6fI2GObqK5NjpBR0anO3ihYCJeIOzF9gEfa3g9VRQMgSZDg2QNuGC614i9Q=="],
 
     "@rettangoli/ui/esbuild": ["esbuild@0.20.2", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.20.2", "@esbuild/android-arm": "0.20.2", "@esbuild/android-arm64": "0.20.2", "@esbuild/android-x64": "0.20.2", "@esbuild/darwin-arm64": "0.20.2", "@esbuild/darwin-x64": "0.20.2", "@esbuild/freebsd-arm64": "0.20.2", "@esbuild/freebsd-x64": "0.20.2", "@esbuild/linux-arm": "0.20.2", "@esbuild/linux-arm64": "0.20.2", "@esbuild/linux-ia32": "0.20.2", "@esbuild/linux-loong64": "0.20.2", "@esbuild/linux-mips64el": "0.20.2", "@esbuild/linux-ppc64": "0.20.2", "@esbuild/linux-riscv64": "0.20.2", "@esbuild/linux-s390x": "0.20.2", "@esbuild/linux-x64": "0.20.2", "@esbuild/netbsd-x64": "0.20.2", "@esbuild/openbsd-x64": "0.20.2", "@esbuild/sunos-x64": "0.20.2", "@esbuild/win32-arm64": "0.20.2", "@esbuild/win32-ia32": "0.20.2", "@esbuild/win32-x64": "0.20.2" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-WdOOppmUNU+IbZ0PaDiTst80zjnrOkyJNHoKupIcVyU8Lvla3Ugx94VzkQ32Ijqd7UhHJy75gNWDMUekcrSJ6g=="],
 

--- a/packages/rettangoli-cli/package.json
+++ b/packages/rettangoli-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rtgl",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "CLI tool for Rettangoli - A frontend framework and development toolkit",
   "type": "module",
   "bin": {
@@ -49,7 +49,7 @@
     "js-yaml": "^4.1.0",
     "@rettangoli/check": "0.1.2",
     "@rettangoli/be": "1.0.2",
-    "@rettangoli/fe": "1.1.1",
+    "@rettangoli/fe": "1.1.2",
     "@rettangoli/sites": "1.0.1",
     "@rettangoli/vt": "1.0.5",
     "@rettangoli/ui": "1.0.11"

--- a/packages/rettangoli-fe/package.json
+++ b/packages/rettangoli-fe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rettangoli/fe",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Frontend framework for building reactive web components",
   "type": "module",
   "main": "./src/index.js",

--- a/packages/rettangoli-fe/src/web/componentDom.js
+++ b/packages/rettangoli-fe/src/web/componentDom.js
@@ -95,8 +95,8 @@ export const initializeComponentDom = ({
     }
   }
 
-  if (!renderTarget.parentNode) {
-    host.appendChild(renderTarget);
+  if (renderTarget.parentNode !== shadow) {
+    shadow.appendChild(renderTarget);
   }
   host.style.display = "contents";
 

--- a/packages/rettangoli-fe/test/runtime/component-dom.test.js
+++ b/packages/rettangoli-fe/test/runtime/component-dom.test.js
@@ -1,17 +1,42 @@
 import { describe, expect, it } from "vitest";
 import { initializeComponentDom } from "../../src/web/componentDom.js";
 
+const createShadowStub = () => {
+  const shadow = {
+    adoptedStyleSheets: [],
+    children: [],
+    firstElementChild: null,
+    querySelector: (selector) => {
+      if (selector !== "[data-rtgl-render-target]") {
+        return null;
+      }
+
+      return shadow.children.find(
+        (child) => child.getAttribute?.("data-rtgl-render-target") !== null,
+      ) ?? null;
+    },
+    appendChild: (child) => {
+      if (!shadow.children.includes(child)) {
+        shadow.children.push(child);
+      }
+      child.parentNode = shadow;
+      shadow.firstElementChild = shadow.children[0] ?? null;
+      return child;
+    },
+  };
+
+  return shadow;
+};
+
 const createHostStub = () => {
   const host = {
     style: { display: "" },
     appendedChildren: [],
+    attachShadowCalls: 0,
     attachShadow: () => {
-      host.shadow = {
-        adoptedStyleSheets: [],
-        appendChild: (child) => {
-          child.parentNode = host.shadow;
-        },
-      };
+      host.attachShadowCalls += 1;
+      host.shadow = createShadowStub();
+      host.shadowRoot = host.shadow;
       return host.shadow;
     },
     appendChild: (child) => {
@@ -84,5 +109,91 @@ describe("initializeComponentDom", () => {
     });
 
     expect(result.adoptedStyleSheets).toHaveLength(1);
+  });
+
+  it("reuses the existing shadow root and render target on reconnect", () => {
+    const host = createHostStub();
+    const { createStyleSheet } = createStyleSheetFactory();
+    const createdElements = [];
+
+    const firstDom = initializeComponentDom({
+      host,
+      cssText: ".root { color: red; }",
+      createStyleSheet,
+      createElement: (tagName) => {
+        const element = {
+          tagName,
+          style: { cssText: "" },
+          parentNode: null,
+          __attrs: new Map(),
+          setAttribute(name, value) {
+            this.__attrs.set(name, String(value));
+          },
+          getAttribute(name) {
+            if (!this.__attrs.has(name)) {
+              return null;
+            }
+            return this.__attrs.get(name);
+          },
+        };
+        createdElements.push(element);
+        return element;
+      },
+    });
+
+    const secondDom = initializeComponentDom({
+      host,
+      cssText: ".root { color: red; }",
+      createStyleSheet,
+      createElement: (tagName) => ({
+        tagName,
+        style: { cssText: "" },
+        parentNode: null,
+      }),
+    });
+
+    expect(host.attachShadowCalls).toBe(1);
+    expect(secondDom.shadow).toBe(firstDom.shadow);
+    expect(secondDom.renderTarget).toBe(firstDom.renderTarget);
+    expect(createdElements).toHaveLength(1);
+  });
+
+  it("reattaches an existing render target to the shadow root", () => {
+    const host = createHostStub();
+    const { createStyleSheet } = createStyleSheetFactory();
+    const shadow = createShadowStub();
+    const renderTarget = {
+      style: { cssText: "" },
+      parentNode: null,
+      __attrs: new Map([
+        ["data-rtgl-render-target", ""],
+      ]),
+      setAttribute(name, value) {
+        this.__attrs.set(name, String(value));
+      },
+      getAttribute(name) {
+        if (!this.__attrs.has(name)) {
+          return null;
+        }
+        return this.__attrs.get(name);
+      },
+    };
+
+    shadow.firstElementChild = renderTarget;
+    host.shadow = shadow;
+    host.shadowRoot = shadow;
+
+    initializeComponentDom({
+      host,
+      cssText: "",
+      createStyleSheet,
+      createElement: () => ({
+        style: { cssText: "" },
+        parentNode: null,
+      }),
+    });
+
+    expect(renderTarget.parentNode).toBe(shadow);
+    expect(host.appendedChildren).toHaveLength(0);
   });
 });

--- a/packages/rettangoli-fe/test/runtime/create-component.contract.test.js
+++ b/packages/rettangoli-fe/test/runtime/create-component.contract.test.js
@@ -359,6 +359,32 @@ describe("createComponent runtime contracts", () => {
     expect(instance.props.value).toBe("updated");
   });
 
+  it("reuses the existing shadow root when the element reconnects", () => {
+    const TestComponent = createComponentClass();
+    const instance = new TestComponent();
+    const originalAttachShadow = instance.attachShadow.bind(instance);
+    const attachShadowSpy = vi.fn((options) => {
+      if (instance.shadowRoot) {
+        throw new Error("attachShadow called twice");
+      }
+
+      const shadow = originalAttachShadow(options);
+      instance.shadowRoot = shadow;
+      return shadow;
+    });
+
+    instance.attachShadow = attachShadowSpy;
+
+    expect(() => {
+      instance.connectedCallback();
+      instance.disconnectedCallback();
+      instance.connectedCallback();
+    }).not.toThrow();
+
+    expect(attachShadowSpy).toHaveBeenCalledTimes(1);
+    expect(instance.renderTarget.parentNode).toBe(instance.shadowRoot);
+  });
+
   it("routes post-mount property writes through handleOnUpdate", () => {
     const handleOnUpdate = vi.fn();
     const TestComponent = createComponentClass({


### PR DESCRIPTION
## Summary
- reuse an existing shadow root and keep the render target attached to it during reconnects
- add reconnect regression coverage for component DOM initialization and web component lifecycle
- bump `@rettangoli/fe` to `1.1.2` and `rtgl` to `1.1.1`, updating the CLI pin to the new FE version

## Testing
- `npm test` in `packages/rettangoli-fe`
- `node packages/rettangoli-cli/cli.js --help`