### PR TITLE
fix(fe): preserve native style for style prop

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -41,16 +41,16 @@
     },
     "packages/rettangoli-cli": {
       "name": "rtgl",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "bin": {
         "rtgl": "cli.js",
       },
       "dependencies": {
         "@rettangoli/be": "1.0.2",
         "@rettangoli/check": "0.1.2",
-        "@rettangoli/fe": "1.1.2",
+        "@rettangoli/fe": "1.1.3",
         "@rettangoli/sites": "1.0.1",
-        "@rettangoli/ui": "1.0.11",
+        "@rettangoli/ui": "1.4.2",
         "@rettangoli/vt": "1.0.5",
         "commander": "^14.0.0",
         "js-yaml": "^4.1.0",
@@ -58,7 +58,7 @@
     },
     "packages/rettangoli-fe": {
       "name": "@rettangoli/fe",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "dependencies": {
         "immer": "^10.1.1",
         "jempl": "1.0.1",
@@ -114,9 +114,9 @@
     },
     "packages/rettangoli-ui": {
       "name": "@rettangoli/ui",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "dependencies": {
-        "@rettangoli/fe": "1.1.2",
+        "@rettangoli/fe": "1.1.3",
         "jempl": "1.0.1",
       },
       "devDependencies": {
@@ -946,8 +946,6 @@
 
     "rtgl/@rettangoli/be": ["@rettangoli/be@1.0.2", "", { "dependencies": { "ajv": "^8.17.1", "chokidar": "^4.0.3", "js-yaml": "^4.1.0" } }, "sha512-hjzXT02gZOlET/ncZINdyt2z6QxQgVt4/F25azPocY1L+X9VPUo8EdMEuHZyHYwhd2dbZzWQmW9NC2GCKFm9+w=="],
 
-    "rtgl/@rettangoli/ui": ["@rettangoli/ui@1.0.11", "", { "dependencies": { "@rettangoli/fe": "1.1.0", "jempl": "1.0.1" } }, "sha512-wwdCxRbmf7vpfEmTKfnMZcC8ApeXsJY47vS6fddo+FKsEXpXiYcIlwJJJR6p2naZCQME9V29hbVMGHkzsBRuMQ=="],
-
     "rtgl/commander": ["commander@14.0.0", "", {}, "sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA=="],
 
     "serve/ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
@@ -1021,8 +1019,6 @@
     "looks-same/sharp/semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
 
     "prebuild-install/tar-fs/tar-stream": ["tar-stream@2.2.0", "", { "dependencies": { "bl": "^4.0.3", "end-of-stream": "^1.4.1", "fs-constants": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.1.1" } }, "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ=="],
-
-    "rtgl/@rettangoli/ui/jempl": ["jempl@1.0.1", "", {}, "sha512-aeOlPrZV1KVhwtMYidkH1vGLlLrCTZ8fk3LlDxLGyTFsZUMHDtvSuqmrCimJL0u2LZFg1rtoE4/1NzGjwmIoUw=="],
 
     "ansi-align/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 

--- a/packages/rettangoli-cli/package.json
+++ b/packages/rettangoli-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rtgl",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "CLI tool for Rettangoli - A frontend framework and development toolkit",
   "type": "module",
   "bin": {
@@ -49,9 +49,9 @@
     "js-yaml": "^4.1.0",
     "@rettangoli/check": "0.1.2",
     "@rettangoli/be": "1.0.2",
-    "@rettangoli/fe": "1.1.2",
+    "@rettangoli/fe": "1.1.3",
     "@rettangoli/sites": "1.0.1",
     "@rettangoli/vt": "1.0.5",
-    "@rettangoli/ui": "1.0.11"
+    "@rettangoli/ui": "1.4.2"
   }
 }

--- a/packages/rettangoli-fe/package.json
+++ b/packages/rettangoli-fe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rettangoli/fe",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Frontend framework for building reactive web components",
   "type": "module",
   "main": "./src/index.js",

--- a/packages/rettangoli-fe/src/core/runtime/props.js
+++ b/packages/rettangoli-fe/src/core/runtime/props.js
@@ -29,6 +29,51 @@ export const readPropFallbackFromAttributes = (source, propName) => {
 };
 
 const REACTIVE_PROP_VALUES = Symbol("rtglReactivePropValues");
+const NATIVE_HOST_STYLE = Symbol("rtglNativeHostStyle");
+
+const findPrototypePropertyDescriptor = (source, propName) => {
+  let current = Object.getPrototypeOf(source);
+
+  while (current) {
+    const descriptor = Object.getOwnPropertyDescriptor(current, propName);
+    if (descriptor) {
+      return descriptor;
+    }
+    current = Object.getPrototypeOf(current);
+  }
+
+  return undefined;
+};
+
+export const getNativeHostStyle = (source) => {
+  if (!source || typeof source !== "object") {
+    return undefined;
+  }
+
+  if (Object.prototype.hasOwnProperty.call(source, NATIVE_HOST_STYLE)) {
+    return source[NATIVE_HOST_STYLE];
+  }
+
+  const styleDescriptor = findPrototypePropertyDescriptor(source, "style");
+  let nativeStyle;
+
+  if (typeof styleDescriptor?.get === "function") {
+    nativeStyle = styleDescriptor.get.call(source);
+  } else if (source.style && typeof source.style === "object") {
+    nativeStyle = source.style;
+  }
+
+  if (nativeStyle && typeof nativeStyle === "object") {
+    Object.defineProperty(source, NATIVE_HOST_STYLE, {
+      value: nativeStyle,
+      enumerable: false,
+      configurable: false,
+      writable: false,
+    });
+  }
+
+  return nativeStyle;
+};
 
 const ensureReactivePropValues = (source) => {
   if (!Object.prototype.hasOwnProperty.call(source, REACTIVE_PROP_VALUES)) {
@@ -49,6 +94,10 @@ export const installReactiveProps = ({
   onPropChange,
 }) => {
   const reactiveValues = ensureReactivePropValues(source);
+
+  if (allowedKeys.includes("style")) {
+    getNativeHostStyle(source);
+  }
 
   allowedKeys.forEach((propName) => {
     if (typeof propName !== "string" || propName.length === 0) {

--- a/packages/rettangoli-fe/src/web/componentDom.js
+++ b/packages/rettangoli-fe/src/web/componentDom.js
@@ -1,3 +1,5 @@
+import { getNativeHostStyle } from "../core/runtime/props.js";
+
 const COMMON_LINK_STYLE_TEXT = `
   a, a:link, a:visited, a:hover, a:active {
     display: contents;
@@ -98,7 +100,10 @@ export const initializeComponentDom = ({
   if (renderTarget.parentNode !== shadow) {
     shadow.appendChild(renderTarget);
   }
-  host.style.display = "contents";
+  const hostStyle = getNativeHostStyle(host);
+  if (hostStyle && typeof hostStyle === "object") {
+    hostStyle.display = "contents";
+  }
 
   return {
     shadow,

--- a/packages/rettangoli-fe/test/runtime/create-component.contract.test.js
+++ b/packages/rettangoli-fe/test/runtime/create-component.contract.test.js
@@ -359,6 +359,24 @@ describe("createComponent runtime contracts", () => {
     expect(instance.props.value).toBe("updated");
   });
 
+  it("keeps native host style available when a prop is named style", () => {
+    const TestComponent = createComponentClass({
+      propsSchema: {
+        style: {},
+      },
+    });
+    const instance = new TestComponent();
+    const propStyle = Object.freeze({
+      variant: "waveform",
+    });
+
+    instance.style = propStyle;
+
+    expect(() => instance.connectedCallback()).not.toThrow();
+    expect(instance.props.style).toBe(propStyle);
+    expect(instance.renderTarget.parentNode).toBe(instance.shadow);
+  });
+
   it("reuses the existing shadow root when the element reconnects", () => {
     const TestComponent = createComponentClass();
     const instance = new TestComponent();

--- a/packages/rettangoli-ui/package.json
+++ b/packages/rettangoli-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rettangoli/ui",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "A UI component library for building web interfaces.",
   "main": "dist/rettangoli-esm.min.js",
   "type": "module",
@@ -62,7 +62,7 @@
   },
   "homepage": "https://github.com/yuusoft-org/rettangoli#readme",
   "dependencies": {
-    "@rettangoli/fe": "1.1.2",
+    "@rettangoli/fe": "1.1.3",
     "jempl": "1.0.1"
   }
 }


### PR DESCRIPTION
## Summary
- preserve access to the native host `style` object when a component schema defines a prop named `style`
- update DOM initialization to use the cached native host style so `connectedCallback()` no longer crashes on `host.style.display = "contents"`
- add a regression test for components with a `style` prop
- bump `@rettangoli/fe` to `1.1.3`, `@rettangoli/ui` to `1.4.2`, and `rtgl` to `1.1.2`
- update `@rettangoli/ui` and `rtgl` to consume the new `@rettangoli/fe`, and update `rtgl` to consume `@rettangoli/ui@1.4.2`

## Testing
- `npm test` in `packages/rettangoli-fe`
- `npm test` in `packages/rettangoli-ui`
- `node packages/rettangoli-cli/cli.js --help`