### PR TITLE
Add inline sites.config data and bump Sites/Sitekit releases

### DIFF
--- a/apps/rettangoli.dev/pages/sites/docs/reference/built-in-templates-and-partials.md
+++ b/apps/rettangoli.dev/pages/sites/docs/reference/built-in-templates-and-partials.md
@@ -130,6 +130,7 @@ themeBodyClass: dark
 ```
 
 Use `rtgl >= 1.1.3` or `@rettangoli/sites >= 1.0.2` with these fields. The published templates rely on the built-in `default()` helper added in that renderer release.
+For site-wide defaults via `sites.config.yaml data`, use `rtgl >= 1.1.4` or `@rettangoli/sites >= 1.0.3`.
 
 For machine-readable contracts, use:
 

--- a/apps/rettangoli.dev/pages/sites/docs/reference/configuration.md
+++ b/apps/rettangoli.dev/pages/sites/docs/reference/configuration.md
@@ -16,6 +16,8 @@ Configure Sites with `sites.config.yaml` or `sites.config.yml` in project root.
 | `markdownit` | object | Recommended key for markdown config |
 | `markdown` | object | Legacy alias for `markdownit` |
 | `build` | object | Build-specific options |
+| `imports` | object | Remote template and partial alias maps |
+| `data` | object | Inline global data for small site-wide values |
 
 Use only one of `markdownit` or `markdown`.
 
@@ -44,6 +46,12 @@ markdownit:
     fallback: section
 build:
   keepMarkdownFiles: false
+imports:
+  templates:
+    docs: https://cdn.jsdelivr.net/npm/@rettangoli/sitekit@<version>/sitekit/templates/docs.yaml
+data:
+  themeCssHref: /public/theme.css
+  themeBodyClass: dark
 ```
 
 ## `markdownit.shiki`
@@ -85,6 +93,12 @@ Example:
 - `pages/docs/intro.md` ->
   - `_site/docs/intro/index.html`
   - `_site/docs/intro.md`
+
+## `data`
+
+Use top-level `data` for small global values that do not deserve their own `data/*.yaml` file.
+Inline config data and `data/*.yaml` are merged, with config values winning on conflicts.
+Inline config data requires `rtgl >= 1.1.4` or `@rettangoli/sites >= 1.0.3`.
 
 ## JS config support
 

--- a/apps/rettangoli.dev/pages/sites/docs/reference/configuration.md
+++ b/apps/rettangoli.dev/pages/sites/docs/reference/configuration.md
@@ -97,7 +97,7 @@ Example:
 ## `data`
 
 Use top-level `data` for small global values that do not deserve their own `data/*.yaml` file.
-Inline config data and `data/*.yaml` are merged, with config values winning on conflicts.
+Inline config data and `data/*.yaml` are merged, with `data/*.yaml` winning on conflicts.
 Inline config data requires `rtgl >= 1.1.4` or `@rettangoli/sites >= 1.0.3`.
 
 ## JS config support

--- a/apps/rettangoli.dev/pages/sites/docs/reference/themes-and-css.md
+++ b/apps/rettangoli.dev/pages/sites/docs/reference/themes-and-css.md
@@ -46,6 +46,7 @@ data:
   themeBodyClass: dark
 ```
 
+If the same key also exists in `data/*.yaml`, the file data wins.
 This site-wide config path requires `rtgl >= 1.1.4` or `@rettangoli/sites >= 1.0.3`.
 
 ## Available Classes

--- a/apps/rettangoli.dev/pages/sites/docs/reference/themes-and-css.md
+++ b/apps/rettangoli.dev/pages/sites/docs/reference/themes-and-css.md
@@ -38,6 +38,16 @@ themeBodyClass: dark
 ---
 ```
 
+For a site-wide override, keep those values in `sites.config.yaml` instead of creating one-line data files:
+
+```yaml
+data:
+  themeCssHref: /public/theme.css
+  themeBodyClass: dark
+```
+
+This site-wide config path requires `rtgl >= 1.1.4` or `@rettangoli/sites >= 1.0.3`.
+
 ## Available Classes
 
 - `mono-light`

--- a/packages/rettangoli-cli/package.json
+++ b/packages/rettangoli-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rtgl",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "CLI tool for Rettangoli - A frontend framework and development toolkit",
   "type": "module",
   "bin": {
@@ -50,7 +50,7 @@
     "@rettangoli/check": "0.1.2",
     "@rettangoli/be": "1.0.2",
     "@rettangoli/fe": "1.1.3",
-    "@rettangoli/sites": "1.0.2",
+    "@rettangoli/sites": "1.0.3",
     "@rettangoli/vt": "1.0.5",
     "@rettangoli/ui": "1.4.2"
   }

--- a/packages/rettangoli-sitekit/README.md
+++ b/packages/rettangoli-sitekit/README.md
@@ -108,7 +108,8 @@ Copy them from:
 
 UI runtime assets still come from `@rettangoli/ui` CDN inside the templates.
 Built-in templates default to `/public/theme-rtgl-themes.css` and `slate-dark`, and can be overridden per page with `themeCssHref` and `themeBodyClass`.
-For site-wide defaults, prefer `sites.config.yaml data` instead of creating one-line files under `data/`.
+For site-wide defaults, use `sites.config.yaml data` instead of creating one-line files under `data/`.
+If the same key also exists in `data/*.yaml`, the file data wins.
 That site-wide config path requires `rtgl >= 1.1.4` or `@rettangoli/sites >= 1.0.3`.
 
 ## Published Asset Index

--- a/packages/rettangoli-sitekit/README.md
+++ b/packages/rettangoli-sitekit/README.md
@@ -108,6 +108,8 @@ Copy them from:
 
 UI runtime assets still come from `@rettangoli/ui` CDN inside the templates.
 Built-in templates default to `/public/theme-rtgl-themes.css` and `slate-dark`, and can be overridden per page with `themeCssHref` and `themeBodyClass`.
+For site-wide defaults, prefer `sites.config.yaml data` instead of creating one-line files under `data/`.
+That site-wide config path requires `rtgl >= 1.1.4` or `@rettangoli/sites >= 1.0.3`.
 
 ## Published Asset Index
 

--- a/packages/rettangoli-sitekit/package.json
+++ b/packages/rettangoli-sitekit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rettangoli/sitekit",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Curated Rettangoli site themes, templates, partials, and VT coverage.",
   "author": {
     "name": "Luciano Hanyon Wu",

--- a/packages/rettangoli-sitekit/sitekit/README.md
+++ b/packages/rettangoli-sitekit/sitekit/README.md
@@ -158,6 +158,9 @@ imports:
     landing-features-section: https://cdn.jsdelivr.net/npm/@rettangoli/sitekit@<version>/sitekit/partials/landing-features-section.yaml
     landing-cta: https://cdn.jsdelivr.net/npm/@rettangoli/sitekit@<version>/sitekit/partials/landing-cta.yaml
     footer: https://cdn.jsdelivr.net/npm/@rettangoli/sitekit@<version>/sitekit/partials/footer.yaml
+data:
+  themeCssHref: /public/theme.css
+  themeBodyClass: dark
 ```
 
 ## Theme Overrides
@@ -177,9 +180,21 @@ themeBodyClass: dark
 ---
 ```
 
+For site-wide overrides, prefer inline config data over one-file-per-value globals:
+
+```yaml
+imports:
+  templates:
+    docs: https://cdn.jsdelivr.net/npm/@rettangoli/sitekit@<version>/sitekit/templates/docs.yaml
+data:
+  themeCssHref: /public/theme.css
+  themeBodyClass: dark
+```
+
 Compatibility:
 
-- use `rtgl >= 1.1.3` or `@rettangoli/sites >= 1.0.2`
+- per-page `themeCssHref` / `themeBodyClass` frontmatter works with `rtgl >= 1.1.3` or `@rettangoli/sites >= 1.0.2`
+- site-wide `sites.config.yaml data` overrides require `rtgl >= 1.1.4` or `@rettangoli/sites >= 1.0.3`
 - these templates rely on the built-in `default()` helper added in that renderer release
 
 ## Data Contracts

--- a/packages/rettangoli-sitekit/sitekit/README.md
+++ b/packages/rettangoli-sitekit/sitekit/README.md
@@ -180,7 +180,7 @@ themeBodyClass: dark
 ---
 ```
 
-For site-wide overrides, prefer inline config data over one-file-per-value globals:
+For site-wide overrides, use inline config data instead of one-file-per-value globals:
 
 ```yaml
 imports:
@@ -195,6 +195,7 @@ Compatibility:
 
 - per-page `themeCssHref` / `themeBodyClass` frontmatter works with `rtgl >= 1.1.3` or `@rettangoli/sites >= 1.0.2`
 - site-wide `sites.config.yaml data` overrides require `rtgl >= 1.1.4` or `@rettangoli/sites >= 1.0.3`
+- when the same key exists in `data/*.yaml`, the file data wins over `sites.config.yaml data`
 - these templates rely on the built-in `default()` helper added in that renderer release
 
 ## Data Contracts

--- a/packages/rettangoli-sitekit/src/pages/docs/getting-started.md
+++ b/packages/rettangoli-sitekit/src/pages/docs/getting-started.md
@@ -34,6 +34,9 @@ imports:
     docs: https://cdn.jsdelivr.net/npm/@rettangoli/sitekit@<version>/sitekit/templates/docs.yaml
   partials:
     docs-sidebar: https://cdn.jsdelivr.net/npm/@rettangoli/sitekit@<version>/sitekit/partials/docs-sidebar.yaml
+data:
+  themeCssHref: /public/theme.css
+  themeBodyClass: dark
 ```
 
 ### Build
@@ -54,6 +57,9 @@ themeCssHref: /public/theme.css
 themeBodyClass: dark
 ---
 ```
+
+If the same theme applies across the whole site, keep those values in `sites.config.yaml data` instead of creating one-line files under `data/`.
+That pattern requires `rtgl >= 1.1.4` or `@rettangoli/sites >= 1.0.3`.
 
 ## Validate
 

--- a/packages/rettangoli-sitekit/src/pages/docs/getting-started.md
+++ b/packages/rettangoli-sitekit/src/pages/docs/getting-started.md
@@ -59,6 +59,7 @@ themeBodyClass: dark
 ```
 
 If the same theme applies across the whole site, keep those values in `sites.config.yaml data` instead of creating one-line files under `data/`.
+If the same key also exists in `data/*.yaml`, the file data wins.
 That pattern requires `rtgl >= 1.1.4` or `@rettangoli/sites >= 1.0.3`.
 
 ## Validate

--- a/packages/rettangoli-sitekit/src/pages/docs/reference/configuration.md
+++ b/packages/rettangoli-sitekit/src/pages/docs/reference/configuration.md
@@ -48,6 +48,19 @@ imports:
 
 The build uses cached import files when available. Local files under `templates/` and `partials/` override imported aliases with the same name.
 
+## Inline Data
+
+Use top-level `data` in `sites.config.yaml` for small global values:
+
+```yaml
+data:
+  themeCssHref: /public/theme.css
+  themeBodyClass: dark
+```
+
+This is the preferred way to set Sitekit theme defaults for a whole site without creating one-line files under `data/`.
+Inline config data requires `rtgl >= 1.1.4` or `@rettangoli/sites >= 1.0.3`.
+
 ## Template Theme Overrides
 
 Imported built-in templates also accept optional frontmatter fields for theming:
@@ -61,6 +74,7 @@ themeBodyClass: dark
 ```
 
 This keeps the built-in Sitekit layout while letting the project supply its own theme stylesheet and body class.
+If the same override should apply to every page, prefer `sites.config.yaml data` instead of repeating frontmatter or adding scalar data files.
 
 ## Navbar Contract
 

--- a/packages/rettangoli-sitekit/src/pages/docs/reference/configuration.md
+++ b/packages/rettangoli-sitekit/src/pages/docs/reference/configuration.md
@@ -58,7 +58,8 @@ data:
   themeBodyClass: dark
 ```
 
-This is the preferred way to set Sitekit theme defaults for a whole site without creating one-line files under `data/`.
+This is the right place for small Sitekit theme defaults for a whole site without creating one-line files under `data/`.
+If the same key exists in `data/*.yaml`, the file data wins.
 Inline config data requires `rtgl >= 1.1.4` or `@rettangoli/sites >= 1.0.3`.
 
 ## Template Theme Overrides
@@ -74,7 +75,7 @@ themeBodyClass: dark
 ```
 
 This keeps the built-in Sitekit layout while letting the project supply its own theme stylesheet and body class.
-If the same override should apply to every page, prefer `sites.config.yaml data` instead of repeating frontmatter or adding scalar data files.
+If the same override should apply to every page, use `sites.config.yaml data` instead of repeating frontmatter or adding scalar data files.
 
 ## Navbar Contract
 

--- a/packages/rettangoli-sites/README.md
+++ b/packages/rettangoli-sites/README.md
@@ -101,7 +101,7 @@ Example mappings:
 - template/page content: `$partial: docs/nav`
 
 Use top-level `data` in `sites.config.yaml` for small global values that do not deserve their own `data/*.yaml` file.
-`data/*.yaml` and `sites.config.yaml data` are merged, with inline config data winning on conflicts.
+`sites.config.yaml data` and `data/*.yaml` are merged, with `data/*.yaml` winning on conflicts.
 Inline config data requires `rtgl >= 1.1.4` or `@rettangoli/sites >= 1.0.3`.
 
 Imported files are cached on disk under `.rettangoli/sites/imports/{templates|partials}/` (hashed filenames).

--- a/packages/rettangoli-sites/README.md
+++ b/packages/rettangoli-sites/README.md
@@ -33,7 +33,7 @@ my-site/
 - YAML pages rendered through `jempl` + `yahtml`
 - Markdown pages rendered through `markdown-it` + Shiki (default `rtglMarkdown`)
 - Frontmatter (`template`, `tags`, arbitrary page metadata)
-- Global data (`data/*.yaml`) merged with page frontmatter
+- Global data from `data/*.yaml` and optional inline `sites.config.yaml data`
 - Collections built from page tags
 - `$if`, `$for`, `$partial`, template functions
 - Static file copying from `static/` to `_site/`
@@ -75,6 +75,9 @@ imports:
     docs: https://example.com/templates/docs.yaml
   partials:
     docs/nav: https://example.com/partials/docs-nav.yaml
+data:
+  themeCssHref: /public/theme.css
+  themeBodyClass: dark
 ```
 
 In the default starter template, CDN runtime scripts are controlled via `data/site.yaml`:
@@ -96,6 +99,10 @@ Example mappings:
 `imports` lets you map aliases to remote YAML files (HTTP/HTTPS only). Use aliases in pages/templates:
 - page frontmatter: `template: base` or `template: docs`
 - template/page content: `$partial: docs/nav`
+
+Use top-level `data` in `sites.config.yaml` for small global values that do not deserve their own `data/*.yaml` file.
+`data/*.yaml` and `sites.config.yaml data` are merged, with inline config data winning on conflicts.
+Inline config data requires `rtgl >= 1.1.4` or `@rettangoli/sites >= 1.0.3`.
 
 Imported files are cached on disk under `.rettangoli/sites/imports/{templates|partials}/` (hashed filenames).
 Alias/url/hash mapping is tracked in `.rettangoli/sites/imports/index.yaml`.

--- a/packages/rettangoli-sites/package.json
+++ b/packages/rettangoli-sites/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rettangoli/sites",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Generate static sites using Markdown and YAML for docs, blogs, and marketing sites.",
   "author": {
     "name": "Luciano Hanyon Wu",

--- a/packages/rettangoli-sites/spec/createSiteBuilder.output.spec.js
+++ b/packages/rettangoli-sites/spec/createSiteBuilder.output.spec.js
@@ -733,4 +733,60 @@ describe('createSiteBuilder output behavior', () => {
     expect(customHtml).toContain('href="/public/custom-theme.css"');
     expect(customHtml).toContain('<body class="nord-dark">');
   });
+
+  it('applies inline site data to imported template defaults', async () => {
+    const vol = new Volume();
+    const memfs = createFsFromVolume(vol);
+
+    vol.fromJSON({
+      '/pages/index.md': [
+        '---',
+        'template: docs',
+        'title: Inline Theme',
+        '---',
+        'Body'
+      ].join('\n')
+    });
+
+    const remoteFiles = {
+      'https://example.com/templates/docs.yaml': [
+        '- html:',
+        '    - head:',
+        '        - link rel="stylesheet" href="${default(themeCssHref, \'/public/theme-rtgl-themes.css\')}":',
+        '    - body class="${default(themeBodyClass, \'slate-dark\')}":',
+        '        - h1: ${title}',
+        '        - "${content}"'
+      ].join('\n')
+    };
+
+    const fetchImpl = vi.fn(async (url) => {
+      const content = remoteFiles[url];
+      if (!content) {
+        return { ok: false, status: 404, statusText: 'Not Found', text: async () => '' };
+      }
+      return { ok: true, status: 200, statusText: 'OK', text: async () => content };
+    });
+
+    const build = createSiteBuilder({
+      fs: memfs,
+      rootDir: '/',
+      quiet: true,
+      data: {
+        themeCssHref: '/public/theme.css',
+        themeBodyClass: 'dark'
+      },
+      imports: {
+        templates: {
+          docs: 'https://example.com/templates/docs.yaml'
+        }
+      },
+      fetchImpl
+    });
+
+    await build();
+
+    const html = memfs.readFileSync('/_site/index.html', 'utf8');
+    expect(html).toContain('href="/public/theme.css"');
+    expect(html).toContain('<body class="dark">');
+  });
 });

--- a/packages/rettangoli-sites/spec/createSiteBuilder.output.spec.js
+++ b/packages/rettangoli-sites/spec/createSiteBuilder.output.spec.js
@@ -789,4 +789,30 @@ describe('createSiteBuilder output behavior', () => {
     expect(html).toContain('href="/public/theme.css"');
     expect(html).toContain('<body class="dark">');
   });
+
+  it('replaces scalar file data with inline config objects on key conflicts', async () => {
+    const vol = new Volume();
+    const memfs = createFsFromVolume(vol);
+
+    vol.fromJSON({
+      '/data/site.yaml': 'RouteVN\n',
+      '/pages/index.yaml': '- p: ${site.title}'
+    });
+
+    const build = createSiteBuilder({
+      fs: memfs,
+      rootDir: '/',
+      quiet: true,
+      data: {
+        site: {
+          title: 'RouteVN'
+        }
+      }
+    });
+
+    await build();
+
+    const html = memfs.readFileSync('/_site/index.html', 'utf8');
+    expect(html).toContain('<p>RouteVN</p>');
+  });
 });

--- a/packages/rettangoli-sites/spec/createSiteBuilder.output.spec.js
+++ b/packages/rettangoli-sites/spec/createSiteBuilder.output.spec.js
@@ -790,13 +790,13 @@ describe('createSiteBuilder output behavior', () => {
     expect(html).toContain('<body class="dark">');
   });
 
-  it('replaces scalar file data with inline config objects on key conflicts', async () => {
+  it('prefers file data over inline config on key conflicts', async () => {
     const vol = new Volume();
     const memfs = createFsFromVolume(vol);
 
     vol.fromJSON({
       '/data/site.yaml': 'RouteVN\n',
-      '/pages/index.yaml': '- p: ${site.title}'
+      '/pages/index.yaml': '- p: ${site}'
     });
 
     const build = createSiteBuilder({

--- a/packages/rettangoli-sites/spec/loadSiteConfig.spec.js
+++ b/packages/rettangoli-sites/spec/loadSiteConfig.spec.js
@@ -267,6 +267,46 @@ describe('loadSiteConfig', () => {
     });
   });
 
+  it('loads inline global data from sites.config.yaml', async () => {
+    await withTempDir(async (tempDir) => {
+      fs.writeFileSync(
+        path.join(tempDir, 'sites.config.yaml'),
+        [
+          'data:',
+          '  themeCssHref: /public/theme.css',
+          '  themeBodyClass: dark',
+          '  site:',
+          '    title: RouteVN'
+        ].join('\n')
+      );
+
+      const config = await loadSiteConfig(tempDir);
+      expect(config).toEqual({
+        data: {
+          themeCssHref: '/public/theme.css',
+          themeBodyClass: 'dark',
+          site: {
+            title: 'RouteVN'
+          }
+        }
+      });
+    });
+  });
+
+  it('throws on invalid top-level data config', async () => {
+    await withTempDir(async (tempDir) => {
+      fs.writeFileSync(
+        path.join(tempDir, 'sites.config.yaml'),
+        [
+          'data:',
+          '  - dark'
+        ].join('\n')
+      );
+
+      await expect(loadSiteConfig(tempDir)).rejects.toThrow('Invalid data config');
+    });
+  });
+
   it('throws on unsupported imports group', async () => {
     await withTempDir(async (tempDir) => {
       fs.writeFileSync(

--- a/packages/rettangoli-sites/src/cli/build.js
+++ b/packages/rettangoli-sites/src/cli/build.js
@@ -31,6 +31,7 @@ export const buildSite = async (options = {}) => {
     markdown: config.markdown || {},
     keepMarkdownFiles: config.build?.keepMarkdownFiles === true,
     imports: config.imports || {},
+    data: config.data || {},
     functions: functions || {},
     quiet,
     isScreenshotMode

--- a/packages/rettangoli-sites/src/createSiteBuilder.js
+++ b/packages/rettangoli-sites/src/createSiteBuilder.js
@@ -434,7 +434,7 @@ export function createSiteBuilder({
       });
     }
 
-    const globalData = deepMerge(fileData, data);
+    const globalData = deepMerge(data, fileData);
 
     // Read all templates and create a JSON object
     const templatesDir = path.join(rootDir, 'templates');

--- a/packages/rettangoli-sites/src/createSiteBuilder.js
+++ b/packages/rettangoli-sites/src/createSiteBuilder.js
@@ -314,6 +314,7 @@ export function createSiteBuilder({
   markdown = {},
   keepMarkdownFiles = false,
   imports = {},
+  data = {},
   fetchImpl,
   functions = {},
   quiet = false,
@@ -409,9 +410,13 @@ export function createSiteBuilder({
       readPartialsRecursively(partialsDir);
     }
 
+    if (!isObject(data)) {
+      throw new Error('Invalid site data: expected an object.');
+    }
+
     // Read all data files and create a JSON object
     const dataDir = path.join(rootDir, 'data');
-    const globalData = {};
+    const fileData = {};
 
     if (fs.existsSync(dataDir)) {
       const files = fs.readdirSync(dataDir);
@@ -421,10 +426,12 @@ export function createSiteBuilder({
           const fileContent = fs.readFileSync(filePath, 'utf8');
           const nameWithoutExt = path.basename(file, path.extname(file));
           // Load YAML content and store under filename key
-          globalData[nameWithoutExt] = yaml.load(fileContent, { schema: yaml.JSON_SCHEMA });
+          fileData[nameWithoutExt] = yaml.load(fileContent, { schema: yaml.JSON_SCHEMA });
         }
       });
     }
+
+    const globalData = deepMerge(fileData, data);
 
     // Read all templates and create a JSON object
     const templatesDir = path.join(rootDir, 'templates');

--- a/packages/rettangoli-sites/src/createSiteBuilder.js
+++ b/packages/rettangoli-sites/src/createSiteBuilder.js
@@ -17,22 +17,25 @@ const MATTER_OPTIONS = {
 
 // Deep merge utility function
 function deepMerge(target, source) {
-  const output = { ...target };
-  
-  if (isObject(target) && isObject(source)) {
-    Object.keys(source).forEach(key => {
-      if (isObject(source[key])) {
-        if (!(key in target)) {
-          Object.assign(output, { [key]: source[key] });
-        } else {
-          output[key] = deepMerge(target[key], source[key]);
-        }
-      } else {
-        Object.assign(output, { [key]: source[key] });
-      }
-    });
+  if (!isObject(source)) {
+    return source;
   }
-  
+
+  if (!isObject(target)) {
+    return { ...source };
+  }
+
+  const output = { ...target };
+
+  Object.keys(source).forEach(key => {
+    if (isObject(source[key]) && isObject(target[key])) {
+      output[key] = deepMerge(target[key], source[key]);
+      return;
+    }
+
+    Object.assign(output, { [key]: source[key] });
+  });
+
   return output;
 }
 

--- a/packages/rettangoli-sites/src/utils/loadSiteConfig.js
+++ b/packages/rettangoli-sites/src/utils/loadSiteConfig.js
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import yaml from 'js-yaml';
 
-const ALLOWED_TOP_LEVEL_KEYS = new Set(['markdown', 'markdownit', 'build', 'imports']);
+const ALLOWED_TOP_LEVEL_KEYS = new Set(['markdown', 'markdownit', 'build', 'imports', 'data']);
 const MARKDOWN_BOOLEAN_KEYS = new Set(['html', 'linkify', 'typographer', 'breaks', 'xhtmlOut']);
 const MARKDOWN_STRING_KEYS = new Set(['langPrefix', 'quotes', 'preset']);
 const MARKDOWN_NUMBER_KEYS = new Set(['maxNesting']);
@@ -121,6 +121,25 @@ function validateBuildConfig(value, configPath) {
   return { ...value };
 }
 
+function validateDataConfig(value, configPath) {
+  if (!isPlainObject(value)) {
+    throw new Error(`Invalid data config in "${configPath}": expected an object.`);
+  }
+
+  const normalized = {};
+
+  for (const [rawKey, rawValue] of Object.entries(value)) {
+    const key = String(rawKey).trim();
+    if (key === '') {
+      throw new Error(`Invalid data config in "${configPath}": keys must be non-empty.`);
+    }
+
+    normalized[key] = rawValue;
+  }
+
+  return normalized;
+}
+
 function validateImportUrl(url, configPath, groupKey, alias) {
   if (typeof url !== 'string' || url.trim() === '') {
     throw new Error(`Invalid imports.${groupKey} value for alias "${alias}" in "${configPath}": expected a non-empty URL string.`);
@@ -200,7 +219,7 @@ function validateConfig(rawConfig, configPath) {
   for (const key of Object.keys(config)) {
     if (!ALLOWED_TOP_LEVEL_KEYS.has(key)) {
       throw new Error(
-        `Unsupported key "${key}" in "${configPath}". Supported keys: markdownit (recommended), markdown (legacy alias), build, imports.`
+        `Unsupported key "${key}" in "${configPath}". Supported keys: markdownit (recommended), markdown (legacy alias), build, imports, data.`
       );
     }
   }
@@ -290,6 +309,10 @@ function validateConfig(rawConfig, configPath) {
 
   if (config.imports !== undefined) {
     normalizedConfig.imports = validateImportsConfig(config.imports, configPath);
+  }
+
+  if (config.data !== undefined) {
+    normalizedConfig.data = validateDataConfig(config.data, configPath);
   }
 
   return normalizedConfig;


### PR DESCRIPTION
## Summary
- add top-level data support to sites.config.yaml and merge it with data/*.yaml
- let imported Sitekit templates consume site-wide theme defaults without one-file-per-scalar globals
- bump @rettangoli/sites to 1.0.3, rtgl to 1.1.4, and @rettangoli/sitekit to 1.0.7
- update Sites and Sitekit docs to show the new config pattern and the minimum compatible versions

## Verification
- bun test packages/rettangoli-sites/spec/loadSiteConfig.spec.js packages/rettangoli-sites/spec/createSiteBuilder.output.spec.js