### PR TITLE
Bump UI package to 1.7.6

### DIFF
--- a/packages/rettangoli-ui/package.json
+++ b/packages/rettangoli-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rettangoli/ui",
-  "version": "1.7.5",
+  "version": "1.7.6",
   "description": "A UI component library for building web interfaces.",
   "main": "dist/rettangoli-esm.min.js",
   "type": "module",


### PR DESCRIPTION
Bumps @rettangoli/ui from 1.7.5 to 1.7.6 after the dropdown menu fix merged.\n\nVerified: npm test in packages/rettangoli-ui.