### PR TITLE
Add backend agent verification loop metadata

### DIFF
--- a/packages/rettangoli-be/README.md
+++ b/packages/rettangoli-be/README.md
@@ -77,10 +77,11 @@ rtgl be watch
 This keeps wiring in the framework so users do not maintain index/registry files.
 
 `rtgl be manifest` prints deterministic JSON for contracts, examples, handlers,
-hashes, schemas, error catalogs, and example coverage.
+hashes, schemas, error catalogs, proof cases, and example coverage.
 
 `rtgl be verify --json` runs the closed loop: check, build, manifest hash, and
-executable examples.
+executable examples. JSON output includes scope, failed phase, affected files,
+rerun argv, diagnostics, and the next action for agent iteration.
 
 ## Handler outcome contract
 

--- a/packages/rettangoli-be/docs/application-specification.md
+++ b/packages/rettangoli-be/docs/application-specification.md
@@ -368,17 +368,21 @@ out: {}
 Rules:
 
 - `case` MUST be stable and descriptive.
-- `proves.result: success` marks a success example.
-- `proves.error: <ERROR_CODE>` marks an expected domain error example.
+- success examples MUST include `proves.result: success`.
+- expected domain error examples MUST include `proves.error: <ERROR_CODE>`.
+- examples MUST NOT include both `proves.result` and `proves.error`.
 - `in` MUST call the handler with one argument: `{ payload, context, deps }`.
 - `out` MUST match success output or expected domain error output.
 - `throws` MAY be used only for unexpected failures and invariants.
 - `mocks` SHOULD be used for dependency calls.
 
-Each method SHOULD include spec cases for:
+Each method MUST include spec cases for:
 
 - one successful result;
 - each expected domain error code;
+
+Each method SHOULD also include cases for:
+
 - important validation/business branches;
 - dependency edge cases that affect contract behavior.
 
@@ -664,6 +668,15 @@ Target behavior:
 - generated changes have dry-run output;
 - progress and failures are machine-readable;
 - compatibility failures are deterministic.
+
+Agent-facing JSON output MUST include enough information to close the loop:
+
+- the verification scope;
+- the failed phase;
+- stable rule ids;
+- affected files;
+- exact rerun argv;
+- a next action object.
 
 ## Migration Notes
 

--- a/packages/rettangoli-be/docs/framework-dream-state.md
+++ b/packages/rettangoli-be/docs/framework-dream-state.md
@@ -263,6 +263,7 @@ The framework proves:
 - success outputs match the result schema;
 - error outputs match the named error catalog;
 - error details match the error details schema;
+- every method has at least one explicit success proof;
 - every public error has at least one example;
 - mocks match declared dependency interactions when relevant;
 - examples can run repeatedly with deterministic results.

--- a/packages/rettangoli-be/src/cli/agentLoop.js
+++ b/packages/rettangoli-be/src/cli/agentLoop.js
@@ -1,0 +1,214 @@
+import path from 'node:path';
+
+const asArray = (value) => Array.isArray(value) ? value : [];
+
+export const toPosixRelativePath = (cwd, filePath) => {
+  if (typeof filePath !== 'string' || !filePath) {
+    return undefined;
+  }
+
+  if (!path.isAbsolute(filePath)) {
+    return filePath.replaceAll(path.sep, '/');
+  }
+
+  return path.relative(cwd, filePath).replaceAll(path.sep, '/');
+};
+
+export const createScope = ({ method, methods = [] } = {}) => {
+  const scopedMethods = method
+    ? [method]
+    : [...new Set(methods)].sort();
+
+  return {
+    type: method ? 'method' : 'project',
+    methods: scopedMethods,
+    provesProject: !method,
+  };
+};
+
+const appendOption = (args, flag, value, defaultValue) => {
+  if (typeof value === 'string' && value && value !== defaultValue) {
+    args.push(flag, value);
+  }
+};
+
+export const createBackendCommands = ({
+  method,
+  middlewareDir,
+  setup,
+  outdir,
+  config,
+  testConfig,
+  executable,
+  packageManager,
+} = {}) => {
+  const methodArgs = method ? ['--method', method] : [];
+  const middlewareArgs = [];
+  appendOption(middlewareArgs, '--middleware-dir', middlewareDir, './src/middleware');
+
+  const testArgs = [...methodArgs, ...middlewareArgs];
+  appendOption(testArgs, '--config', config ?? testConfig, './vitest.config.js');
+  appendOption(testArgs, '--runner', executable);
+  appendOption(testArgs, '--package-manager', packageManager);
+
+  const verifyArgs = [...methodArgs, ...middlewareArgs];
+  appendOption(verifyArgs, '--setup-path', setup, './src/setup.js');
+  appendOption(verifyArgs, '--outdir', outdir, './.rtgl-be/generated');
+  appendOption(verifyArgs, '--test-config', testConfig ?? config, './vitest.config.js');
+  appendOption(verifyArgs, '--runner', executable);
+  appendOption(verifyArgs, '--package-manager', packageManager);
+
+  return [
+    {
+      id: 'check',
+      argv: ['rtgl', 'be', 'check', ...methodArgs, ...middlewareArgs, '--format', 'json'],
+    },
+    {
+      id: 'manifest',
+      argv: ['rtgl', 'be', 'manifest', ...methodArgs, ...middlewareArgs, '--json'],
+    },
+    {
+      id: 'test',
+      argv: ['rtgl', 'be', 'test', ...testArgs, '--json'],
+    },
+    {
+      id: 'verify',
+      argv: ['rtgl', 'be', 'verify', ...verifyArgs, '--json'],
+    },
+  ];
+};
+
+export const findCommand = (commands, id) => {
+  return commands.find((command) => command.id === id);
+};
+
+const createFixHint = (ruleId) => {
+  const hints = {
+    'RTGL-BE-CONTRACT-005': 'Create exactly one .examples.yaml file next to the method contract.',
+    'RTGL-BE-CONTRACT-027': 'Edit the example payload so it matches the params schema.',
+    'RTGL-BE-CONTRACT-029': 'Mark the success example with proves.result: success.',
+    'RTGL-BE-CONTRACT-031': 'Declare the domain error in the contract or change the example output code.',
+    'RTGL-BE-CONTRACT-034': 'Set proves.error to the same domain error code returned by the example.',
+    'RTGL-BE-CONTRACT-035': 'Add a proving example for the declared domain error.',
+    'RTGL-BE-CONTRACT-036': 'Use an existing method id or create the missing method contract package.',
+    'RTGL-BE-CONTRACT-037': 'Add at least one successful example with proves.result: success.',
+    'RTGL-BE-CONTRACT-038': 'Add at least one case document to the examples file.',
+    'RTGL-BE-CONTRACT-039': "Set 'in' to an array with exactly one object argument.",
+    'RTGL-BE-CONTRACT-040': 'Use either proves.result or proves.error, not both.',
+    'RTGL-BE-TEST-001': 'Add a .examples.yaml file with at least one proving case.',
+    'RTGL-BE-TEST-002': 'Fix the failing executable example, handler, or test dependency.',
+  };
+
+  return hints[ruleId];
+};
+
+export const normalizeDiagnostic = ({
+  cwd = process.cwd(),
+  error,
+  phase,
+  method,
+  command,
+  extra = {},
+}) => {
+  const ruleId = error?.code || error?.ruleId || 'UNKNOWN';
+  const filePath = toPosixRelativePath(cwd, error?.filePath);
+
+  return {
+    ruleId,
+    code: ruleId,
+    severity: 'error',
+    phase,
+    method: error?.method ?? method,
+    filePath,
+    file: filePath ? { path: filePath } : undefined,
+    case: error?.case,
+    message: error?.message || 'Unknown error.',
+    fix: createFixHint(ruleId),
+    rerun: command,
+    ...extra,
+  };
+};
+
+export const normalizeDiagnostics = ({
+  cwd = process.cwd(),
+  errors = [],
+  phase,
+  method,
+  command,
+} = {}) => {
+  return asArray(errors).map((error) => normalizeDiagnostic({
+    cwd,
+    error,
+    phase,
+    method,
+    command,
+  }));
+};
+
+export const createNextAction = ({
+  ok,
+  failedPhase,
+  diagnostics = [],
+  commands = [],
+  final = false,
+} = {}) => {
+  const verifyCommand = findCommand(commands, 'verify');
+
+  if (ok) {
+    if (!final) {
+      return {
+        kind: 'verify',
+        message: 'Phase passed. Run full backend verification before stopping.',
+        argv: verifyCommand?.argv,
+      };
+    }
+
+    return {
+      kind: 'done',
+      message: 'Verification passed.',
+      argv: verifyCommand?.argv,
+    };
+  }
+
+  const phaseCommandId = failedPhase === 'contracts'
+    ? 'check'
+    : failedPhase === 'examples'
+      ? 'test'
+      : failedPhase;
+  const command = findCommand(commands, phaseCommandId) ?? verifyCommand;
+  const ruleIds = [...new Set(diagnostics.map((diagnostic) => diagnostic.ruleId).filter(Boolean))].sort();
+  const targets = [...new Set(
+    diagnostics.flatMap((diagnostic) => [
+      diagnostic.filePath,
+      ...asArray(diagnostic.files),
+    ].filter(Boolean)),
+  )].sort();
+  const target = failedPhase === 'test'
+    ? 'examples-or-handler'
+    : failedPhase === 'build'
+      ? 'backend-build'
+      : 'contract-package';
+
+  return {
+    kind: 'fix',
+    phase: failedPhase,
+    target,
+    ruleIds,
+    files: targets,
+    argv: command?.argv,
+  };
+};
+
+export const collectSourceFilesFromManifest = (manifest) => {
+  const files = [];
+
+  Object.values(manifest?.methods ?? {}).forEach((method) => {
+    Object.values(method.source ?? {}).forEach((filePath) => {
+      if (typeof filePath === 'string' && filePath) {
+        files.push(filePath);
+      }
+    });
+  });
+
+  return [...new Set(files)].sort();
+};

--- a/packages/rettangoli-be/src/cli/check.js
+++ b/packages/rettangoli-be/src/cli/check.js
@@ -1,16 +1,46 @@
 import { formatContractFailureReport } from './contracts.js';
 import { analyzeBackendContracts } from './contractScope.js';
+import {
+  createBackendCommands,
+  createNextAction,
+  createScope,
+  findCommand,
+  normalizeDiagnostics,
+} from './agentLoop.js';
 
 export const runBackendCheck = (options = {}) => {
   const analysis = analyzeBackendContracts(options);
+  const methods = options.method
+    ? analysis.contracts.map((contract) => contract.method)
+    : analysis.allContracts.map((contract) => contract.method);
+  const commands = createBackendCommands({
+    method: options.method,
+    middlewareDir: options.middlewareDir,
+  });
+  const diagnostics = normalizeDiagnostics({
+    cwd: options.cwd ?? process.cwd(),
+    errors: analysis.errors,
+    phase: 'contracts',
+    method: options.method,
+    command: findCommand(commands, 'check'),
+  });
 
   return {
+    schemaVersion: 'rettangoli.check/v1',
     ok: analysis.ok,
     prefix: '[Check]',
     method: analysis.method,
+    scope: createScope({ method: options.method, methods }),
     methodCount: options.method ? analysis.contracts.length : analysis.allContracts.length,
     summary: analysis.summary,
     errors: analysis.errors,
+    diagnostics,
+    nextAction: createNextAction({
+      ok: analysis.ok,
+      failedPhase: analysis.ok ? undefined : 'contracts',
+      diagnostics,
+      commands,
+    }),
   };
 };
 

--- a/packages/rettangoli-be/src/cli/manifest.js
+++ b/packages/rettangoli-be/src/cli/manifest.js
@@ -3,6 +3,11 @@ import { createHash } from 'node:crypto';
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { formatContractFailureReport } from './contracts.js';
 import { analyzeBackendContracts } from './contractScope.js';
+import { runBackendCheck } from './check.js';
+import {
+  createBackendCommands,
+  createNextAction,
+} from './agentLoop.js';
 
 const isPlainObject = (value) => !!value && typeof value === 'object' && !Array.isArray(value);
 
@@ -57,32 +62,77 @@ const hashFile = (filePath) => {
   return `sha256:${hash.digest('hex')}`;
 };
 
-const summarizeExamples = (methodEntry) => {
+const summarizeExamples = (methodEntry, rpc) => {
   const summary = {
     success: 0,
     errors: {},
+    cases: [],
   };
 
   const documents = methodEntry.examplesDocuments[0]?.documents ?? [];
   documents
     .filter((doc) => isPlainObject(doc) && Object.prototype.hasOwnProperty.call(doc, 'case'))
     .forEach((caseDoc) => {
+      const caseName = typeof caseDoc.case === 'string' ? caseDoc.case : '<unnamed>';
       if (Object.prototype.hasOwnProperty.call(caseDoc, 'throws')) {
+        summary.cases.push({
+          case: caseName,
+          proves: {
+            kind: 'throws',
+          },
+        });
         return;
       }
 
-      const output = caseDoc.out;
-
-      if (isPlainObject(output) && output._error === true) {
-        const errorCode = output.code;
-        if (typeof errorCode === 'string' && errorCode.trim()) {
-          summary.errors[errorCode] = (summary.errors[errorCode] ?? 0) + 1;
-        }
+      if (caseDoc.proves?.result === 'success') {
+        summary.success += 1;
+        summary.cases.push({
+          case: caseName,
+          proves: {
+            kind: 'result',
+            target: 'success',
+          },
+        });
         return;
       }
 
-      summary.success += 1;
+      if (typeof caseDoc.proves?.error === 'string' && caseDoc.proves.error.trim()) {
+        const errorCode = caseDoc.proves.error;
+        summary.errors[errorCode] = (summary.errors[errorCode] ?? 0) + 1;
+        summary.cases.push({
+          case: caseName,
+          proves: {
+            kind: 'error',
+            target: errorCode,
+          },
+        });
+        return;
+      }
+
+      summary.cases.push({
+        case: caseName,
+        proves: {
+          kind: 'none',
+        },
+      });
     });
+
+  const declaredErrors = Object.keys(rpc.errors ?? {}).sort();
+  const provenErrors = Object.keys(summary.errors).sort();
+  const missingErrors = declaredErrors.filter((errorCode) => !provenErrors.includes(errorCode));
+
+  summary.coverage = {
+    ok: summary.success > 0 && missingErrors.length === 0,
+    success: {
+      proved: summary.success > 0,
+      count: summary.success,
+    },
+    errors: {
+      declared: declaredErrors,
+      proved: provenErrors,
+      missing: missingErrors,
+    },
+  };
 
   return summary;
 };
@@ -131,6 +181,9 @@ export const createBackendManifest = ({
     const rpc = contract.rpc;
 
     methods[contract.method] = {
+      domain: contract.domain,
+      action: contract.action,
+      setupDependencyPath: `setup.deps.${contract.domain}`,
       source: {
         contract: toPosixRelativePath(cwd, contract.contractPath),
         examples: toPosixRelativePath(cwd, contract.examplesPath),
@@ -149,7 +202,7 @@ export const createBackendManifest = ({
       params: rpc.params,
       result: rpc.result,
       errors: rpc.errors ?? {},
-      examples: summarizeExamples(methodEntry),
+      examples: summarizeExamples(methodEntry, rpc),
     };
   });
 
@@ -168,6 +221,42 @@ export const createBackendManifest = ({
 };
 
 const manifestRettangoliBackend = (options = {}) => {
+  const outputFormat = options.format === 'json' || options.json ? 'json' : 'text';
+  const check = runBackendCheck(options);
+
+  if (!check.ok) {
+    const commands = createBackendCommands({
+      method: options.method,
+      middlewareDir: options.middlewareDir,
+    });
+    const result = {
+      schemaVersion: 'rettangoli.manifest/v1',
+      ok: false,
+      phase: 'contracts',
+      scope: check.scope,
+      summary: check.summary,
+      errors: check.errors,
+      diagnostics: check.diagnostics,
+      nextAction: createNextAction({
+        ok: false,
+        failedPhase: 'contracts',
+        diagnostics: check.diagnostics,
+        commands,
+      }),
+    };
+
+    if (outputFormat === 'json') {
+      process.stdout.write(stringifyStableJson(result));
+      process.exitCode = 1;
+      return result;
+    }
+
+    throw new Error(formatContractFailureReport({
+      errorPrefix: '[Manifest]',
+      errors: check.errors,
+    }));
+  }
+
   const manifest = createBackendManifest(options);
   const json = stringifyStableJson(manifest);
 

--- a/packages/rettangoli-be/src/cli/test.js
+++ b/packages/rettangoli-be/src/cli/test.js
@@ -2,9 +2,19 @@ import path from 'node:path';
 import { existsSync } from 'node:fs';
 import { spawnSync } from 'node:child_process';
 import { analyzeBackendContracts } from './contractScope.js';
+import {
+  createBackendCommands,
+  createNextAction,
+  createScope,
+  findCommand,
+  normalizeDiagnostic,
+  normalizeDiagnostics,
+  toPosixRelativePath,
+} from './agentLoop.js';
 
-const toPosixRelativePath = (cwd, filePath) => {
-  return path.relative(cwd, filePath).replaceAll(path.sep, '/');
+const toOutputTail = (value, maxLength = 4000) => {
+  const text = String(value ?? '');
+  return text.length > maxLength ? text.slice(-maxLength) : text;
 };
 
 const createPackageRunner = ({ executable, packageManager, env = process.env } = {}) => {
@@ -59,32 +69,83 @@ export const runBackendTests = (options = {}) => {
     middlewareDir,
     method,
   });
+  const methods = method
+    ? analysis.contracts.map((contract) => contract.method)
+    : analysis.allContracts.map((contract) => contract.method);
+  const scope = createScope({ method, methods });
+  const commands = createBackendCommands({
+    method,
+    middlewareDir,
+    config,
+    executable,
+    packageManager,
+  });
+  const testCommand = findCommand(commands, 'test');
 
   if (!analysis.ok) {
+    const diagnostics = normalizeDiagnostics({
+      cwd,
+      errors: analysis.errors,
+      phase: 'contracts',
+      method,
+      command: findCommand(commands, 'check'),
+    });
+
     return {
+      schemaVersion: 'rettangoli.test/v1',
       ok: false,
       prefix: '[Test]',
       method,
+      scope,
       phase: 'contracts',
+      commands,
       summary: analysis.summary,
       errors: analysis.errors,
+      diagnostics,
+      nextAction: createNextAction({
+        ok: false,
+        failedPhase: 'contracts',
+        diagnostics,
+        commands,
+      }),
     };
   }
 
   const files = analysis.contracts.map((contract) => toPosixRelativePath(cwd, contract.examplesPath));
   if (files.length === 0) {
+    const error = {
+      code: 'RTGL-BE-TEST-001',
+      message: method
+        ? `No backend examples found for method '${method}'.`
+        : 'No backend examples found to test.',
+    };
+    const diagnostics = [
+      normalizeDiagnostic({
+        cwd,
+        error,
+        phase: 'examples',
+        method,
+        command: testCommand,
+      }),
+    ];
+
     return {
+      schemaVersion: 'rettangoli.test/v1',
       ok: false,
       prefix: '[Test]',
       method,
+      scope,
       phase: 'examples',
+      commands,
       files,
-      error: {
-        code: 'RTGL-BE-TEST-001',
-        message: method
-          ? `No backend examples found for method '${method}'.`
-          : 'No backend examples found to test.',
-      },
+      error,
+      diagnostics,
+      nextAction: createNextAction({
+        ok: false,
+        failedPhase: 'examples',
+        diagnostics,
+        commands,
+      }),
     };
   }
 
@@ -104,20 +165,53 @@ export const runBackendTests = (options = {}) => {
     stdio: captureOutput ? 'pipe' : 'inherit',
   });
   const exitCode = typeof result.status === 'number' ? result.status : 1;
+  const ok = exitCode === 0;
+  const stdout = result.stdout ?? '';
+  const stderr = result.stderr ?? '';
+  const failureDiagnostic = ok ? undefined : normalizeDiagnostic({
+    cwd,
+    error: {
+      code: 'RTGL-BE-TEST-002',
+      message: `Backend examples failed with exit code ${exitCode}.`,
+      filePath: files.length === 1 ? files[0] : undefined,
+    },
+    phase: 'test',
+    method,
+    command: testCommand,
+    extra: {
+      files,
+      outputTail: {
+        stdout: toOutputTail(stdout),
+        stderr: toOutputTail(stderr),
+      },
+    },
+  });
+  const diagnostics = failureDiagnostic ? [failureDiagnostic] : [];
 
   return {
-    ok: exitCode === 0,
+    schemaVersion: 'rettangoli.test/v1',
+    ok,
     prefix: '[Test]',
     method,
+    scope,
     phase: 'test',
+    commands,
     files,
     command: {
       executable: runner.executable,
       args,
+      argv: [runner.executable, ...args],
     },
     exitCode,
-    stdout: captureOutput && includeOutput ? result.stdout ?? '' : undefined,
-    stderr: captureOutput && includeOutput ? result.stderr ?? '' : undefined,
+    diagnostics,
+    nextAction: createNextAction({
+      ok,
+      failedPhase: ok ? undefined : 'test',
+      diagnostics,
+      commands,
+    }),
+    stdout: captureOutput && includeOutput ? stdout : undefined,
+    stderr: captureOutput && includeOutput ? stderr : undefined,
   };
 };
 

--- a/packages/rettangoli-be/src/cli/verify.js
+++ b/packages/rettangoli-be/src/cli/verify.js
@@ -6,6 +6,14 @@ import {
   stringifyStableJson,
 } from './manifest.js';
 import { runBackendTests } from './test.js';
+import {
+  collectSourceFilesFromManifest,
+  createBackendCommands,
+  createNextAction,
+  createScope,
+  findCommand,
+  normalizeDiagnostic,
+} from './agentLoop.js';
 
 const hashJson = (value) => {
   const hash = createHash('sha256');
@@ -20,6 +28,23 @@ const createStepFailure = (name, error) => ({
     message: error.message,
   },
 });
+
+const createSteps = ({ check, buildResult, manifestResult, test }) => {
+  return [
+    { id: 'check', ok: check.ok },
+    { id: 'build', ok: buildResult?.ok === true, skipped: buildResult === undefined },
+    { id: 'manifest', ok: manifestResult?.ok === true, skipped: manifestResult === undefined },
+    { id: 'test', ok: test?.ok === true, skipped: test === undefined },
+  ];
+};
+
+const findFailedPhase = ({ steps, test }) => {
+  const failedStep = steps.find((step) => !step.skipped && !step.ok);
+  if (failedStep?.id === 'test' && test?.phase && test.phase !== 'contracts') {
+    return test.phase;
+  }
+  return failedStep?.id;
+};
 
 export const runBackendVerify = (options = {}) => {
   const {
@@ -42,13 +67,46 @@ export const runBackendVerify = (options = {}) => {
     middlewareDir,
     method,
   };
+  const commands = createBackendCommands({
+    method,
+    middlewareDir,
+    setup,
+    outdir,
+    testConfig,
+    executable,
+    packageManager,
+  });
   const check = runBackendCheck(sharedOptions);
+  const checkMethods = method
+    ? check.scope.methods
+    : check.scope.methods;
 
   if (!check.ok) {
+    const steps = createSteps({ check });
+    const failedPhase = findFailedPhase({ steps });
+    const diagnostics = check.diagnostics ?? [];
+    const ok = false;
+
     return {
       schemaVersion: 'rettangoli.verify/v1',
-      ok: false,
+      ok,
+      scope: createScope({ method, methods: checkMethods }),
       method,
+      failedPhase,
+      steps,
+      commands,
+      files: {
+        owned: [...new Set(diagnostics.map((diagnostic) => diagnostic.filePath).filter(Boolean))].sort(),
+        write: [],
+      },
+      diagnostics,
+      nextAction: createNextAction({
+        ok,
+        failedPhase,
+        diagnostics,
+        commands,
+        final: true,
+      }),
       check,
       build: undefined,
       manifest: undefined,
@@ -88,18 +146,21 @@ export const runBackendVerify = (options = {}) => {
   }
 
   let manifestResult;
+  let manifestValue;
   try {
-    const value = createBackendManifest({
+    manifestValue = createBackendManifest({
       cwd,
       dirs,
       middlewareDir,
       method,
     });
+    const scopeHash = hashJson(manifestValue);
     manifestResult = {
       ok: true,
-      hash: hashJson(value),
-      methodCount: Object.keys(value.methods).length,
-      methods: Object.keys(value.methods).sort(),
+      hash: scopeHash,
+      scopeHash,
+      methodCount: Object.keys(manifestValue.methods).length,
+      methods: Object.keys(manifestValue.methods).sort(),
     };
   } catch (error) {
     manifestResult = createStepFailure('manifest', error);
@@ -115,11 +176,67 @@ export const runBackendVerify = (options = {}) => {
     packageManager,
     env,
   });
+  const steps = createSteps({ check, buildResult, manifestResult, test });
+  const failedPhase = findFailedPhase({ steps, test });
+  const diagnostics = [
+    ...(check.diagnostics ?? []),
+    ...(buildResult.ok ? [] : [
+      normalizeDiagnostic({
+        cwd,
+        error: {
+          code: 'RTGL-BE-BUILD-001',
+          message: buildResult.error?.message ?? 'Backend build failed.',
+        },
+        phase: 'build',
+        method,
+        command: findCommand(commands, 'verify'),
+      }),
+    ]),
+    ...(manifestResult.ok ? [] : [
+      normalizeDiagnostic({
+        cwd,
+        error: {
+          code: 'RTGL-BE-MANIFEST-001',
+          message: manifestResult.error?.message ?? 'Backend manifest failed.',
+        },
+        phase: 'manifest',
+        method,
+        command: findCommand(commands, 'manifest'),
+      }),
+    ]),
+    ...(test.diagnostics ?? []),
+  ];
+  const ok = check.ok && buildResult.ok && manifestResult.ok && test.ok;
+  const ownedFiles = manifestValue
+    ? collectSourceFilesFromManifest(manifestValue)
+    : [...new Set(diagnostics.map((diagnostic) => diagnostic.filePath).filter(Boolean))].sort();
+  const writeFiles = method
+    ? []
+    : [
+      buildResult.registryPath,
+      buildResult.appEntryPath,
+    ].filter(Boolean);
 
   return {
     schemaVersion: 'rettangoli.verify/v1',
-    ok: check.ok && buildResult.ok && manifestResult.ok && test.ok,
+    ok,
+    scope: createScope({ method, methods: manifestResult.methods ?? checkMethods }),
     method,
+    failedPhase,
+    steps,
+    commands,
+    files: {
+      owned: ownedFiles,
+      write: writeFiles,
+    },
+    diagnostics,
+    nextAction: createNextAction({
+      ok,
+      failedPhase,
+      diagnostics,
+      commands,
+      final: true,
+    }),
     check,
     build: buildResult,
     manifest: manifestResult,

--- a/packages/rettangoli-be/src/commonBuild.js
+++ b/packages/rettangoli-be/src/commonBuild.js
@@ -3,7 +3,7 @@ import path from 'node:path';
 
 export const getAllFiles = (dirPaths = [], files = []) => {
   dirPaths.forEach((dirPath) => {
-    const entries = readdirSync(dirPath);
+    const entries = readdirSync(dirPath).sort((a, b) => a.localeCompare(b));
 
     entries.forEach((entry) => {
       const fullPath = path.join(dirPath, entry);

--- a/packages/rettangoli-be/src/core/contracts/rpcFiles.js
+++ b/packages/rettangoli-be/src/core/contracts/rpcFiles.js
@@ -359,6 +359,16 @@ const validateExamplesAgainstContract = ({
   const caseDocuments = documents.filter((doc) => isPlainObject(doc) && Object.prototype.hasOwnProperty.call(doc, 'case'));
   const ajv = createAjv();
 
+  if (caseDocuments.length === 0) {
+    errors.push({
+      code: 'RTGL-BE-CONTRACT-038',
+      method: rpcObject.method,
+      message: `Method '${rpcObject.method}' examples file must contain at least one case document.`,
+      filePath: examplesFilePath,
+    });
+    return;
+  }
+
   const paramsValidator = compileSchemaForCheck({
     ajv,
     schema: resolveParamsSchema(rpcObject),
@@ -382,23 +392,53 @@ const validateExamplesAgainstContract = ({
 
   const errorCatalog = resolveErrorCatalog(rpcObject) ?? {};
   const provedErrorCodes = new Set();
+  let provedSuccessCount = 0;
+
+  const pushExampleError = ({ code, message, caseName }) => {
+    errors.push({
+      code,
+      method: rpcObject.method,
+      case: caseName,
+      message,
+      filePath: examplesFilePath,
+    });
+  };
 
   caseDocuments.forEach((caseDoc) => {
     const caseName = typeof caseDoc.case === 'string' ? caseDoc.case : '<unnamed>';
-    const input = Array.isArray(caseDoc.in) ? caseDoc.in[0] : undefined;
-    const payload = isPlainObject(input) && Object.prototype.hasOwnProperty.call(input, 'payload')
-      ? input.payload
-      : {};
+    const hasValidInput = Array.isArray(caseDoc.in)
+      && caseDoc.in.length === 1
+      && isPlainObject(caseDoc.in[0]);
+    if (!hasValidInput) {
+      pushExampleError({
+        code: 'RTGL-BE-CONTRACT-039',
+        caseName,
+        message: `Example '${caseName}' must call the handler with exactly one object argument in 'in'.`,
+      });
+      return;
+    }
+
+    const input = caseDoc.in[0];
+    const payload = Object.prototype.hasOwnProperty.call(input, 'payload') ? input.payload : {};
 
     if (!paramsValidator(payload)) {
-      errors.push({
+      pushExampleError({
         code: 'RTGL-BE-CONTRACT-027',
+        caseName,
         message: `Example '${caseName}' payload does not match params schema: ${formatAjvErrors(paramsValidator.errors)}`,
-        filePath: examplesFilePath,
       });
     }
 
     if (Object.prototype.hasOwnProperty.call(caseDoc, 'throws')) {
+      return;
+    }
+
+    if (caseDoc.proves?.result !== undefined && caseDoc.proves?.error !== undefined) {
+      pushExampleError({
+        code: 'RTGL-BE-CONTRACT-040',
+        caseName,
+        message: `Example '${caseName}' must not include both proves.result and proves.error.`,
+      });
       return;
     }
 
@@ -407,39 +447,43 @@ const validateExamplesAgainstContract = ({
 
     if (!isDomainError) {
       if (!resultValidator(output)) {
-        errors.push({
+        pushExampleError({
           code: 'RTGL-BE-CONTRACT-028',
+          caseName,
           message: `Example '${caseName}' output does not match result schema: ${formatAjvErrors(resultValidator.errors)}`,
-          filePath: examplesFilePath,
         });
       }
 
-      if (caseDoc.proves?.result !== undefined && caseDoc.proves.result !== 'success') {
-        errors.push({
+      if (caseDoc.proves?.result !== 'success') {
+        pushExampleError({
           code: 'RTGL-BE-CONTRACT-029',
-          message: `Example '${caseName}' proves.result must be 'success' when provided.`,
-          filePath: examplesFilePath,
+          caseName,
+          message: caseDoc.proves?.result === undefined
+            ? `Example '${caseName}' success output must include proves.result: success.`
+            : `Example '${caseName}' proves.result must be 'success'.`,
         });
+      } else {
+        provedSuccessCount += 1;
       }
       return;
     }
 
     const errorCode = output.code;
     if (typeof errorCode !== 'string' || !errorCode.trim()) {
-      errors.push({
+      pushExampleError({
         code: 'RTGL-BE-CONTRACT-030',
+        caseName,
         message: `Example '${caseName}' domain error output must include code.`,
-        filePath: examplesFilePath,
       });
       return;
     }
 
     const errorEntry = errorCatalog[errorCode];
     if (!isPlainObject(errorEntry)) {
-      errors.push({
+      pushExampleError({
         code: 'RTGL-BE-CONTRACT-031',
+        caseName,
         message: `Example '${caseName}' uses undeclared error code '${errorCode}'.`,
-        filePath: examplesFilePath,
       });
       return;
     }
@@ -453,28 +497,41 @@ const validateExamplesAgainstContract = ({
       label: `${rpcObject.method} error ${errorCode}`,
     });
     if (errorValidator && !errorValidator(output)) {
-      errors.push({
+      pushExampleError({
         code: 'RTGL-BE-CONTRACT-033',
+        caseName,
         message: `Example '${caseName}' output does not match error '${errorCode}': ${formatAjvErrors(errorValidator.errors)}`,
-        filePath: examplesFilePath,
       });
     }
 
-    if (caseDoc.proves?.error !== undefined && caseDoc.proves.error !== errorCode) {
-      errors.push({
+    if (caseDoc.proves?.error !== errorCode) {
+      pushExampleError({
         code: 'RTGL-BE-CONTRACT-034',
-        message: `Example '${caseName}' proves.error '${caseDoc.proves.error}' does not match output code '${errorCode}'.`,
-        filePath: examplesFilePath,
+        caseName,
+        message: caseDoc.proves?.error === undefined
+          ? `Example '${caseName}' domain error output must include proves.error: ${errorCode}.`
+          : `Example '${caseName}' proves.error '${caseDoc.proves.error}' does not match output code '${errorCode}'.`,
       });
+      return;
     }
 
     provedErrorCodes.add(errorCode);
   });
 
+  if (provedSuccessCount === 0) {
+    errors.push({
+      code: 'RTGL-BE-CONTRACT-037',
+      method: rpcObject.method,
+      message: `Method '${rpcObject.method}' must have at least one example with proves.result: success.`,
+      filePath: examplesFilePath,
+    });
+  }
+
   Object.keys(errorCatalog).forEach((errorCode) => {
     if (!provedErrorCodes.has(errorCode)) {
       errors.push({
         code: 'RTGL-BE-CONTRACT-035',
+        method: rpcObject.method,
         message: `Declared error '${errorCode}' must have at least one proving example.`,
         filePath: examplesFilePath,
       });

--- a/packages/rettangoli-be/test/cli/check.output.test.js
+++ b/packages/rettangoli-be/test/cli/check.output.test.js
@@ -179,6 +179,11 @@ describe('be check cli output', () => {
     expect(parsed.ok).toBe(true);
     expect(parsed.method).toBe('health.ping');
     expect(parsed.methodCount).toBe(1);
+    expect(parsed.nextAction).toEqual({
+      kind: 'verify',
+      message: 'Phase passed. Run full backend verification before stopping.',
+      argv: ['rtgl', 'be', 'verify', '--method', 'health.ping', '--json'],
+    });
   });
 
   it('keeps duplicate middleware errors when scoped method references that middleware', () => {
@@ -276,6 +281,14 @@ describe('be check cli output', () => {
       'suite: healthPingMethod',
       'exportName: healthPingMethod',
       '---',
+      'case: ok',
+      'proves:',
+      '  result: success',
+      'in:',
+      '  - payload: {}',
+      'out:',
+      '  ok: true',
+      '---',
       'case: invariant-failure',
       'in:',
       '  - payload: {}',
@@ -297,6 +310,268 @@ describe('be check cli output', () => {
     expect(logSpy.mock.calls.map((entry) => entry[0]).join('\n')).toContain(
       '[Check] RPC contracts passed for 1 method(s).',
     );
+  });
+
+  it('requires a success proof example', () => {
+    const rootDir = mkdtempSync(path.join(tmpdir(), 'rtgl-be-check-success-proof-'));
+    createdDirs.push(rootDir);
+    writeMethodFiles({ rootDir, includeSpec: true });
+
+    const examplesPath = path.join(rootDir, 'src', 'modules', 'health', 'ping', 'ping.examples.yaml');
+    writeFileSync(examplesPath, [
+      "file: './ping.handlers.js'",
+      'group: ping',
+      '---',
+      'suite: healthPingMethod',
+      'exportName: healthPingMethod',
+      '---',
+      'case: ok',
+      'in:',
+      '  - payload: {}',
+      'out:',
+      '  ok: true',
+      '',
+    ].join('\n'));
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    check({
+      cwd: rootDir,
+      dirs: ['./src/modules'],
+      middlewareDir: './src/middleware',
+      format: 'json',
+    });
+
+    expect(process.exitCode).toBe(1);
+    const parsed = JSON.parse(logSpy.mock.calls[0][0]);
+    expect(parsed.errors.map((error) => error.code)).toContain('RTGL-BE-CONTRACT-029');
+    expect(parsed.errors.map((error) => error.code)).toContain('RTGL-BE-CONTRACT-037');
+    expect(parsed.diagnostics[0].method).toBe('health.ping');
+    expect(parsed.diagnostics[0].ruleId).toBe('RTGL-BE-CONTRACT-029');
+    expect(parsed.diagnostics[0].rerun.argv).toEqual(['rtgl', 'be', 'check', '--format', 'json']);
+  });
+
+  it('requires explicit error proof for declared domain errors', () => {
+    const rootDir = mkdtempSync(path.join(tmpdir(), 'rtgl-be-check-error-proof-'));
+    createdDirs.push(rootDir);
+    writeMethodFiles({ rootDir, includeSpec: true });
+
+    const contractPath = path.join(rootDir, 'src', 'modules', 'health', 'ping', 'ping.contract.yaml');
+    writeFileSync(contractPath, [
+      'schemaVersion: rettangoli.contract/v1',
+      'method: health.ping',
+      'description: ping',
+      'middleware:',
+      '  before: []',
+      '  after: []',
+      'params:',
+      '  type: object',
+      '  additionalProperties: false',
+      '  properties: {}',
+      '  required: []',
+      'result:',
+      '  type: object',
+      '  additionalProperties: false',
+      '  properties:',
+      '    ok:',
+      '      type: boolean',
+      '  required: [ok]',
+      'errors:',
+      '  AUTH_REQUIRED:',
+      '    description: Authentication is required.',
+      '',
+    ].join('\n'));
+
+    const examplesPath = path.join(rootDir, 'src', 'modules', 'health', 'ping', 'ping.examples.yaml');
+    writeFileSync(examplesPath, [
+      "file: './ping.handlers.js'",
+      'group: ping',
+      '---',
+      'suite: healthPingMethod',
+      'exportName: healthPingMethod',
+      '---',
+      'case: ok',
+      'proves:',
+      '  result: success',
+      'in:',
+      '  - payload: {}',
+      'out:',
+      '  ok: true',
+      '---',
+      'case: requires-auth',
+      'in:',
+      '  - payload: {}',
+      'out:',
+      '  _error: true',
+      '  code: AUTH_REQUIRED',
+      '',
+    ].join('\n'));
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    check({
+      cwd: rootDir,
+      dirs: ['./src/modules'],
+      middlewareDir: './src/middleware',
+      format: 'json',
+    });
+
+    expect(process.exitCode).toBe(1);
+    const parsed = JSON.parse(logSpy.mock.calls[0][0]);
+    expect(parsed.errors.map((error) => error.code)).toContain('RTGL-BE-CONTRACT-034');
+    expect(parsed.errors.map((error) => error.code)).toContain('RTGL-BE-CONTRACT-035');
+  });
+
+  it('rejects examples that claim result and error proof at the same time', () => {
+    const rootDir = mkdtempSync(path.join(tmpdir(), 'rtgl-be-check-conflicting-proof-'));
+    createdDirs.push(rootDir);
+    writeMethodFiles({ rootDir, includeSpec: true });
+
+    const contractPath = path.join(rootDir, 'src', 'modules', 'health', 'ping', 'ping.contract.yaml');
+    writeFileSync(contractPath, [
+      'schemaVersion: rettangoli.contract/v1',
+      'method: health.ping',
+      'description: ping',
+      'middleware:',
+      '  before: []',
+      '  after: []',
+      'params:',
+      '  type: object',
+      '  additionalProperties: false',
+      '  properties: {}',
+      '  required: []',
+      'result:',
+      '  type: object',
+      '  additionalProperties: false',
+      '  properties:',
+      '    ok:',
+      '      type: boolean',
+      '  required: [ok]',
+      'errors:',
+      '  AUTH_REQUIRED:',
+      '    description: Authentication is required.',
+      '',
+    ].join('\n'));
+
+    const examplesPath = path.join(rootDir, 'src', 'modules', 'health', 'ping', 'ping.examples.yaml');
+    writeFileSync(examplesPath, [
+      "file: './ping.handlers.js'",
+      'group: ping',
+      '---',
+      'suite: healthPingMethod',
+      'exportName: healthPingMethod',
+      '---',
+      'case: ok',
+      'proves:',
+      '  result: success',
+      'in:',
+      '  - payload: {}',
+      'out:',
+      '  ok: true',
+      '---',
+      'case: conflicted-auth',
+      'proves:',
+      '  result: success',
+      '  error: AUTH_REQUIRED',
+      'in:',
+      '  - payload: {}',
+      'out:',
+      '  _error: true',
+      '  code: AUTH_REQUIRED',
+      '',
+    ].join('\n'));
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    check({
+      cwd: rootDir,
+      dirs: ['./src/modules'],
+      middlewareDir: './src/middleware',
+      format: 'json',
+    });
+
+    expect(process.exitCode).toBe(1);
+    const parsed = JSON.parse(logSpy.mock.calls[0][0]);
+    expect(parsed.errors.map((error) => error.code)).toContain('RTGL-BE-CONTRACT-040');
+    expect(parsed.diagnostics.find((diagnostic) => diagnostic.ruleId === 'RTGL-BE-CONTRACT-040')).toEqual(
+      expect.objectContaining({
+        method: 'health.ping',
+        case: 'conflicted-auth',
+      }),
+    );
+  });
+
+  it('validates executable input shape before treating examples as proof', () => {
+    const rootDir = mkdtempSync(path.join(tmpdir(), 'rtgl-be-check-input-shape-'));
+    createdDirs.push(rootDir);
+    writeMethodFiles({ rootDir, includeSpec: true });
+
+    const examplesPath = path.join(rootDir, 'src', 'modules', 'health', 'ping', 'ping.examples.yaml');
+    writeFileSync(examplesPath, [
+      "file: './ping.handlers.js'",
+      'group: ping',
+      '---',
+      'suite: healthPingMethod',
+      'exportName: healthPingMethod',
+      '---',
+      'case: bad-call-shape',
+      'proves:',
+      '  result: success',
+      'in:',
+      '  - 123',
+      'out:',
+      '  ok: true',
+      '',
+    ].join('\n'));
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    check({
+      cwd: rootDir,
+      dirs: ['./src/modules'],
+      middlewareDir: './src/middleware',
+      format: 'json',
+    });
+
+    expect(process.exitCode).toBe(1);
+    const parsed = JSON.parse(logSpy.mock.calls[0][0]);
+    expect(parsed.errors.map((error) => error.code)).toContain('RTGL-BE-CONTRACT-039');
+    expect(parsed.errors.map((error) => error.code)).toContain('RTGL-BE-CONTRACT-037');
+    expect(parsed.diagnostics[0]).toEqual(expect.objectContaining({
+      ruleId: 'RTGL-BE-CONTRACT-039',
+      method: 'health.ping',
+      case: 'bad-call-shape',
+    }));
+  });
+
+  it('requires at least one case document in examples', () => {
+    const rootDir = mkdtempSync(path.join(tmpdir(), 'rtgl-be-check-empty-examples-'));
+    createdDirs.push(rootDir);
+    writeMethodFiles({ rootDir, includeSpec: true });
+
+    const examplesPath = path.join(rootDir, 'src', 'modules', 'health', 'ping', 'ping.examples.yaml');
+    writeFileSync(examplesPath, [
+      "file: './ping.handlers.js'",
+      'group: ping',
+      '---',
+      'suite: healthPingMethod',
+      'exportName: healthPingMethod',
+      '',
+    ].join('\n'));
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    check({
+      cwd: rootDir,
+      dirs: ['./src/modules'],
+      middlewareDir: './src/middleware',
+      format: 'json',
+    });
+
+    expect(process.exitCode).toBe(1);
+    const parsed = JSON.parse(logSpy.mock.calls[0][0]);
+    expect(parsed.errors.map((error) => error.code)).toEqual(['RTGL-BE-CONTRACT-038']);
+    expect(parsed.diagnostics[0].fix).toContain('case document');
   });
 
   it('validates the provided example payload value', () => {

--- a/packages/rettangoli-be/test/cli/manifest.output.test.js
+++ b/packages/rettangoli-be/test/cli/manifest.output.test.js
@@ -103,15 +103,43 @@ describe('be manifest cli output', () => {
       version: '0.1.0',
     });
     expect(Object.keys(manifest.methods)).toEqual(['user.getProfile']);
+    expect(manifest.methods['user.getProfile'].domain).toBe('user');
+    expect(manifest.methods['user.getProfile'].setupDependencyPath).toBe('setup.deps.user');
     expect(manifest.methods['user.getProfile'].source).toEqual({
       contract: 'src/modules/user/getProfile/getProfile.contract.yaml',
       examples: 'src/modules/user/getProfile/getProfile.examples.yaml',
       handler: 'src/modules/user/getProfile/getProfile.handlers.js',
     });
-    expect(manifest.methods['user.getProfile'].examples).toEqual({
-      success: 1,
+    expect(manifest.methods['user.getProfile'].examples.success).toBe(1);
+    expect(manifest.methods['user.getProfile'].examples.errors).toEqual({
+      AUTH_REQUIRED: 1,
+    });
+    expect(manifest.methods['user.getProfile'].examples.cases).toEqual([
+      {
+        case: 'returns-profile',
+        proves: {
+          kind: 'result',
+          target: 'success',
+        },
+      },
+      {
+        case: 'requires-auth',
+        proves: {
+          kind: 'error',
+          target: 'AUTH_REQUIRED',
+        },
+      },
+    ]);
+    expect(manifest.methods['user.getProfile'].examples.coverage).toEqual({
+      ok: true,
+      success: {
+        proved: true,
+        count: 1,
+      },
       errors: {
-        AUTH_REQUIRED: 1,
+        declared: ['AUTH_REQUIRED'],
+        proved: ['AUTH_REQUIRED'],
+        missing: [],
       },
     });
     expect(manifest.methods['user.getProfile'].hashes.contract).toMatch(/^sha256:/);

--- a/packages/rettangoli-be/test/cli/test.command.test.js
+++ b/packages/rettangoli-be/test/cli/test.command.test.js
@@ -79,6 +79,51 @@ const writeBrokenMethod = (rootDir) => {
   ].join('\n'));
 };
 
+const writeProfileMethod = (rootDir) => {
+  const methodDir = path.join(rootDir, 'src', 'modules', 'user', 'profile');
+  mkdirSync(methodDir, { recursive: true });
+
+  writeFileSync(path.join(methodDir, 'profile.handlers.js'), 'export const userProfileMethod = async () => ({ ok: true });\n');
+  writeFileSync(path.join(methodDir, 'profile.contract.yaml'), [
+    'schemaVersion: rettangoli.contract/v1',
+    'method: user.profile',
+    'description: profile',
+    'middleware:',
+    '  before: []',
+    '  after: []',
+    'params:',
+    '  type: object',
+    '  additionalProperties: false',
+    '  properties: {}',
+    '  required: []',
+    'result:',
+    '  type: object',
+    '  additionalProperties: false',
+    '  properties:',
+    '    ok:',
+    '      type: boolean',
+    '  required: [ok]',
+    'errors: {}',
+    '',
+  ].join('\n'));
+  writeFileSync(path.join(methodDir, 'profile.examples.yaml'), [
+    "file: './profile.handlers.js'",
+    'group: profile',
+    '---',
+    'suite: userProfileMethod',
+    'exportName: userProfileMethod',
+    '---',
+    'case: ok',
+    'proves:',
+    '  result: success',
+    'in:',
+    '  - payload: {}',
+    'out:',
+    '  ok: true',
+    '',
+  ].join('\n'));
+};
+
 describe('be test command', () => {
   const createdDirs = [];
 
@@ -110,6 +155,11 @@ describe('be test command', () => {
 
     expect(result.ok).toBe(true);
     expect(result.files).toEqual(['src/modules/health/ping/ping.examples.yaml']);
+    expect(result.nextAction).toEqual({
+      kind: 'verify',
+      message: 'Phase passed. Run full backend verification before stopping.',
+      argv: ['rtgl', 'be', 'verify', '--method', 'health.ping', '--json'],
+    });
     expect(runCommand).toHaveBeenCalledWith(
       'npm',
       [
@@ -156,6 +206,62 @@ describe('be test command', () => {
     expect(result.command.args[0]).toBe('vitest');
   });
 
+  it('preserves CLI overrides in agent rerun commands', () => {
+    const rootDir = mkdtempSync(path.join(tmpdir(), 'rtgl-be-test-overrides-'));
+    createdDirs.push(rootDir);
+    writeMethod(rootDir);
+
+    const runCommand = vi.fn(() => ({
+      status: 0,
+      stdout: 'ok',
+      stderr: '',
+    }));
+
+    const result = runBackendTests({
+      cwd: rootDir,
+      method: 'health.ping',
+      middlewareDir: './src/custom-middleware',
+      config: './vitest.custom.js',
+      executable: 'custom-runner',
+      packageManager: 'pnpm',
+      format: 'json',
+      runCommand,
+    });
+
+    expect(result.commands.find((command) => command.id === 'test').argv).toEqual([
+      'rtgl',
+      'be',
+      'test',
+      '--method',
+      'health.ping',
+      '--middleware-dir',
+      './src/custom-middleware',
+      '--config',
+      './vitest.custom.js',
+      '--runner',
+      'custom-runner',
+      '--package-manager',
+      'pnpm',
+      '--json',
+    ]);
+    expect(result.nextAction.argv).toEqual([
+      'rtgl',
+      'be',
+      'verify',
+      '--method',
+      'health.ping',
+      '--middleware-dir',
+      './src/custom-middleware',
+      '--test-config',
+      './vitest.custom.js',
+      '--runner',
+      'custom-runner',
+      '--package-manager',
+      'pnpm',
+      '--json',
+    ]);
+  });
+
   it('ignores unrelated contract errors when a method is selected', () => {
     const rootDir = mkdtempSync(path.join(tmpdir(), 'rtgl-be-test-scoped-'));
     createdDirs.push(rootDir);
@@ -180,6 +286,35 @@ describe('be test command', () => {
     expect(runCommand).toHaveBeenCalledOnce();
   });
 
+  it('reports all candidate files for project-scoped test failures', () => {
+    const rootDir = mkdtempSync(path.join(tmpdir(), 'rtgl-be-test-project-fail-'));
+    createdDirs.push(rootDir);
+    writeMethod(rootDir);
+    writeProfileMethod(rootDir);
+
+    const runCommand = vi.fn(() => ({
+      status: 1,
+      stdout: 'later file failed',
+      stderr: '',
+    }));
+
+    const result = runBackendTests({
+      cwd: rootDir,
+      format: 'json',
+      env: {},
+      runCommand,
+    });
+
+    const files = [
+      'src/modules/health/ping/ping.examples.yaml',
+      'src/modules/user/profile/profile.examples.yaml',
+    ];
+    expect(result.ok).toBe(false);
+    expect(result.diagnostics[0].filePath).toBeUndefined();
+    expect(result.diagnostics[0].files).toEqual(files);
+    expect(result.nextAction.files).toEqual(files);
+  });
+
   it('does not run Vitest when no backend examples are found', () => {
     const rootDir = mkdtempSync(path.join(tmpdir(), 'rtgl-be-test-empty-'));
     createdDirs.push(rootDir);
@@ -201,6 +336,13 @@ describe('be test command', () => {
     expect(result.phase).toBe('examples');
     expect(result.files).toEqual([]);
     expect(result.error.code).toBe('RTGL-BE-TEST-001');
+    expect(result.commands.find((command) => command.id === 'test').argv).toEqual([
+      'rtgl',
+      'be',
+      'test',
+      '--json',
+    ]);
+    expect(result.nextAction.argv).toEqual(['rtgl', 'be', 'test', '--json']);
     expect(runCommand).not.toHaveBeenCalled();
   });
 });

--- a/packages/rettangoli-be/test/cli/verify.output.test.js
+++ b/packages/rettangoli-be/test/cli/verify.output.test.js
@@ -114,6 +114,30 @@ describe('be verify output', () => {
 
     expect(result.schemaVersion).toBe('rettangoli.verify/v1');
     expect(result.ok).toBe(true);
+    expect(result.scope).toEqual({
+      type: 'project',
+      methods: ['health.ping'],
+      provesProject: true,
+    });
+    expect(result.failedPhase).toBeUndefined();
+    expect(result.steps).toEqual([
+      { id: 'check', ok: true },
+      { id: 'build', ok: true, skipped: false },
+      { id: 'manifest', ok: true, skipped: false },
+      { id: 'test', ok: true, skipped: false },
+    ]);
+    expect(result.commands.find((command) => command.id === 'verify').argv).toEqual([
+      'rtgl',
+      'be',
+      'verify',
+      '--json',
+    ]);
+    expect(result.files.owned).toEqual([
+      'src/modules/health/ping/ping.contract.yaml',
+      'src/modules/health/ping/ping.examples.yaml',
+      'src/modules/health/ping/ping.handlers.js',
+    ]);
+    expect(result.nextAction.kind).toBe('done');
     expect(result.check.ok).toBe(true);
     expect(result.build.scope).toBe('project');
     expect(result.manifest.hash).toMatch(/^sha256:/);
@@ -137,10 +161,24 @@ describe('be verify output', () => {
     const result = runBackendVerify({
       cwd: rootDir,
       method: 'health.ping',
+      env: {},
       runCommand,
     });
 
     expect(result.ok).toBe(true);
+    expect(result.scope).toEqual({
+      type: 'method',
+      methods: ['health.ping'],
+      provesProject: false,
+    });
+    expect(result.commands.find((command) => command.id === 'verify').argv).toEqual([
+      'rtgl',
+      'be',
+      'verify',
+      '--method',
+      'health.ping',
+      '--json',
+    ]);
     expect(result.build).toEqual({
       ok: true,
       scope: 'method',
@@ -150,5 +188,184 @@ describe('be verify output', () => {
     });
     expect(result.manifest.methods).toEqual(['health.ping']);
     expect(result.test.files).toEqual(['src/modules/health/ping/ping.examples.yaml']);
+  });
+
+  it('preserves CLI overrides in verify rerun commands', () => {
+    const rootDir = mkdtempSync(path.join(tmpdir(), 'rtgl-be-verify-overrides-'));
+    createdDirs.push(rootDir);
+    writeProject(rootDir);
+
+    const runCommand = vi.fn(() => ({
+      status: 0,
+      stdout: '',
+      stderr: '',
+    }));
+
+    const result = runBackendVerify({
+      cwd: rootDir,
+      method: 'health.ping',
+      middlewareDir: './src/custom-middleware',
+      setup: './src/custom-setup.js',
+      outdir: './custom-generated',
+      testConfig: './vitest.custom.js',
+      executable: 'custom-runner',
+      packageManager: 'pnpm',
+      env: {},
+      runCommand,
+    });
+
+    expect(result.commands.find((command) => command.id === 'check').argv).toEqual([
+      'rtgl',
+      'be',
+      'check',
+      '--method',
+      'health.ping',
+      '--middleware-dir',
+      './src/custom-middleware',
+      '--format',
+      'json',
+    ]);
+    expect(result.commands.find((command) => command.id === 'test').argv).toEqual([
+      'rtgl',
+      'be',
+      'test',
+      '--method',
+      'health.ping',
+      '--middleware-dir',
+      './src/custom-middleware',
+      '--config',
+      './vitest.custom.js',
+      '--runner',
+      'custom-runner',
+      '--package-manager',
+      'pnpm',
+      '--json',
+    ]);
+    expect(result.commands.find((command) => command.id === 'verify').argv).toEqual([
+      'rtgl',
+      'be',
+      'verify',
+      '--method',
+      'health.ping',
+      '--middleware-dir',
+      './src/custom-middleware',
+      '--setup-path',
+      './src/custom-setup.js',
+      '--outdir',
+      './custom-generated',
+      '--test-config',
+      './vitest.custom.js',
+      '--runner',
+      'custom-runner',
+      '--package-manager',
+      'pnpm',
+      '--json',
+    ]);
+  });
+
+  it('returns agent-ready check failure details', () => {
+    const rootDir = mkdtempSync(path.join(tmpdir(), 'rtgl-be-verify-check-fail-'));
+    createdDirs.push(rootDir);
+    writeProject(rootDir);
+
+    writeFileSync(path.join(rootDir, 'src', 'modules', 'health', 'ping', 'ping.examples.yaml'), [
+      "file: './ping.handlers.js'",
+      'group: ping',
+      '---',
+      'suite: healthPingMethod',
+      'exportName: healthPingMethod',
+      '---',
+      'case: ok',
+      'in:',
+      '  - payload: {}',
+      'out:',
+      '  ok: true',
+      '',
+    ].join('\n'));
+
+    const runCommand = vi.fn(() => ({
+      status: 0,
+      stdout: '',
+      stderr: '',
+    }));
+
+    const result = runBackendVerify({
+      cwd: rootDir,
+      method: 'health.ping',
+      env: {},
+      runCommand,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.failedPhase).toBe('check');
+    expect(result.build).toBeUndefined();
+    expect(result.test).toBeUndefined();
+    expect(result.diagnostics.map((diagnostic) => diagnostic.ruleId)).toContain('RTGL-BE-CONTRACT-029');
+    expect(result.diagnostics[0].filePath).toBe('src/modules/health/ping/ping.examples.yaml');
+    expect(result.nextAction.argv).toEqual([
+      'rtgl',
+      'be',
+      'check',
+      '--method',
+      'health.ping',
+      '--format',
+      'json',
+    ]);
+    expect(runCommand).not.toHaveBeenCalled();
+  });
+
+  it('reports no examples without running Vitest', () => {
+    const rootDir = mkdtempSync(path.join(tmpdir(), 'rtgl-be-verify-empty-'));
+    createdDirs.push(rootDir);
+    mkdirSync(path.join(rootDir, 'src', 'modules'), { recursive: true });
+    writeFileSync(path.join(rootDir, 'vitest.config.js'), 'export default {};\n');
+    writeFileSync(path.join(rootDir, 'src', 'setup.js'), 'export const setup = { deps: {} };\n');
+
+    const runCommand = vi.fn(() => ({
+      status: 0,
+      stdout: '',
+      stderr: '',
+    }));
+
+    const result = runBackendVerify({
+      cwd: rootDir,
+      runCommand,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.failedPhase).toBe('examples');
+    expect(result.test.phase).toBe('examples');
+    expect(result.diagnostics[0].ruleId).toBe('RTGL-BE-TEST-001');
+    expect(result.nextAction.argv).toEqual(['rtgl', 'be', 'test', '--json']);
+    expect(runCommand).not.toHaveBeenCalled();
+  });
+
+  it('includes bounded test output when executable examples fail', () => {
+    const rootDir = mkdtempSync(path.join(tmpdir(), 'rtgl-be-verify-test-fail-'));
+    createdDirs.push(rootDir);
+    writeProject(rootDir);
+
+    const runCommand = vi.fn(() => ({
+      status: 1,
+      stdout: 'stdout failure details',
+      stderr: 'stderr failure details',
+    }));
+
+    const result = runBackendVerify({
+      cwd: rootDir,
+      method: 'health.ping',
+      env: {},
+      runCommand,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.failedPhase).toBe('test');
+    expect(result.test.exitCode).toBe(1);
+    expect(result.test.command.argv[0]).toBe('npm');
+    expect(result.diagnostics[0].ruleId).toBe('RTGL-BE-TEST-002');
+    expect(result.diagnostics[0].outputTail).toEqual({
+      stdout: 'stdout failure details',
+      stderr: 'stderr failure details',
+    });
   });
 });

--- a/packages/rettangoli-cli/cli.js
+++ b/packages/rettangoli-cli/cli.js
@@ -376,13 +376,6 @@ beCommand
 
     const bePaths = resolveBeRuntimePaths(config);
 
-    const missingDirs = bePaths.dirs.filter(
-      (dir) => !existsSync(resolve(process.cwd(), dir)),
-    );
-    if (missingDirs.length > 0) {
-      throw new Error(`Directories do not exist: ${missingDirs.join(", ")}`);
-    }
-
     options.dirs = bePaths.dirs;
     options.middlewareDir = options.middlewareDir || bePaths.middlewareDir;
 
@@ -393,6 +386,7 @@ beCommand
   .command("manifest")
   .description("Print deterministic backend API manifest")
   .option("--json", "Output JSON")
+  .option("--method <method>", "Print manifest for one backend method id")
   .option("-m, --middleware-dir <path>", "Custom middleware directory path")
   .option("-o, --output <path>", "Write manifest JSON to a file")
   .action((options) => {


### PR DESCRIPTION
## Summary

- make executable examples explicit proof contracts: success/error proofs are required, mutually exclusive, and malformed input shapes fail check
- add agent-ready JSON metadata for backend check/test/verify: scope, diagnostics, commands, rerun/next action, failed phase, owned/write files, bounded test output tails
- expand backend manifest with proof cases, coverage facts, method domain/action, and setup dependency path
- add method-scoped `rtgl be manifest --method` and keep backend check errors structured for missing method dirs
- sort backend file discovery for deterministic generated output

## Review process

- used three read-only subagents for design review: contract semantics, long-running agent ergonomics, and implementation risks
- used a follow-up implementation-review subagent on the actual diff
- fixed reviewer findings around conflicting proof tags, malformed `in`, project-wide method ids, and direct test JSON commands

## Verification

- `bunx vitest run test/cli/check.output.test.js test/cli/manifest.output.test.js test/cli/test.command.test.js test/cli/verify.output.test.js --reporter=verbose --config vitest.config.js`
- `bun run test`
- manual example app checks:
  - `node ../../../rettangoli-cli/cli.js be manifest --method user.getProfile --json`
  - `node ../../../rettangoli-cli/cli.js be check --method user.getProfile --format json`
  - `node ../../../rettangoli-cli/cli.js be test --method user.getProfile --json`
