### PR TITLE
Improve backend agent verification workflows

### DIFF
--- a/packages/rettangoli-be/README.md
+++ b/packages/rettangoli-be/README.md
@@ -25,7 +25,10 @@ Backend framework for Rettangoli JSON-RPC applications.
 
 - `build`
 - `check`
+- `db`
 - `manifest`
+- `resume`
+- `scaffold`
 - `test`
 - `verify`
 - `start`
@@ -61,11 +64,15 @@ be:
 With `rtgl`:
 
 ```bash
+rtgl be scaffold user.getProfile --json
 rtgl be check
+rtgl be db check --json
 rtgl be build
+rtgl be build --dry-run --json
 rtgl be manifest
 rtgl be test --method user.getProfile
 rtgl be verify --json
+rtgl be resume <taskId> --json
 rtgl be watch
 ```
 
@@ -79,9 +86,50 @@ This keeps wiring in the framework so users do not maintain index/registry files
 `rtgl be manifest` prints deterministic JSON for contracts, examples, handlers,
 hashes, schemas, error catalogs, proof cases, and example coverage.
 
-`rtgl be verify --json` runs the closed loop: check, build, manifest hash, and
-executable examples. JSON output includes scope, failed phase, affected files,
-rerun argv, diagnostics, and the next action for agent iteration.
+`rtgl be verify --json` runs the closed loop: check, dry-run build plan,
+manifest hash, SQLite migration check for project scope, and executable handler
+examples. JSON output includes scope, failed phase, affected files, rerun argv,
+diagnostics, and the next action for agent iteration.
+
+`rtgl be test` executes handler examples. It proves handler contract behavior;
+middleware/runtime behavior should be covered by generated-app or HTTP tests.
+
+## Minimal Project Bootstrap
+
+A runnable backend app needs app-local test tooling:
+
+```json
+{
+  "type": "module",
+  "scripts": {
+    "be:check": "rtgl be check",
+    "be:verify": "rtgl be verify --json"
+  },
+  "dependencies": {
+    "@rettangoli/be": "^1.0.3"
+  },
+  "devDependencies": {
+    "puty": "^0.1.2",
+    "vitest": "^4.0.15"
+  }
+}
+```
+
+Use the package `vitest.config.js` shape from `examples/basic-app` so
+`*.examples.yaml` files execute through Puty.
+
+Minimum setup:
+
+```js
+export const setup = {
+  deps: {
+    user: {},
+  },
+};
+```
+
+Scaffolded methods include a `setupRequirement` telling agents which
+`setup.deps.<domain>` object must exist before importing the generated app.
 
 ## Handler outcome contract
 

--- a/packages/rettangoli-be/src/cli/agentLoop.js
+++ b/packages/rettangoli-be/src/cli/agentLoop.js
@@ -33,48 +33,81 @@ const appendOption = (args, flag, value, defaultValue) => {
   }
 };
 
+const appendRepeatedOption = (args, flag, values = [], defaultValues = []) => {
+  const normalizedValues = Array.isArray(values) ? values : [values].filter(Boolean);
+  const normalizedDefaults = Array.isArray(defaultValues) ? defaultValues : [defaultValues].filter(Boolean);
+
+  if (
+    normalizedValues.length === normalizedDefaults.length
+    && normalizedValues.every((value, index) => value === normalizedDefaults[index])
+  ) {
+    return;
+  }
+
+  normalizedValues.forEach((value) => {
+    appendOption(args, flag, value);
+  });
+};
+
 export const createBackendCommands = ({
+  commandPrefix = ['rtgl', 'be'],
+  dirs = ['./src/modules'],
   method,
   middlewareDir,
   setup,
   outdir,
+  migrationsDir,
   config,
   testConfig,
   executable,
   packageManager,
 } = {}) => {
   const methodArgs = method ? ['--method', method] : [];
+  const dirArgs = [];
+  appendRepeatedOption(dirArgs, '--dir', dirs, ['./src/modules']);
   const middlewareArgs = [];
   appendOption(middlewareArgs, '--middleware-dir', middlewareDir, './src/middleware');
 
-  const testArgs = [...methodArgs, ...middlewareArgs];
+  const testArgs = [...dirArgs, ...methodArgs, ...middlewareArgs];
   appendOption(testArgs, '--config', config ?? testConfig, './vitest.config.js');
   appendOption(testArgs, '--runner', executable);
   appendOption(testArgs, '--package-manager', packageManager);
 
-  const verifyArgs = [...methodArgs, ...middlewareArgs];
+  const manifestArgs = [...dirArgs, ...methodArgs, ...middlewareArgs];
+  appendOption(manifestArgs, '--outdir', outdir, './.rtgl-be/generated');
+  appendOption(manifestArgs, '--migrations-dir', migrationsDir, './migrations');
+
+  const verifyArgs = [...dirArgs, ...methodArgs, ...middlewareArgs];
   appendOption(verifyArgs, '--setup-path', setup, './src/setup.js');
   appendOption(verifyArgs, '--outdir', outdir, './.rtgl-be/generated');
+  appendOption(verifyArgs, '--migrations-dir', migrationsDir, './migrations');
   appendOption(verifyArgs, '--test-config', testConfig ?? config, './vitest.config.js');
   appendOption(verifyArgs, '--runner', executable);
   appendOption(verifyArgs, '--package-manager', packageManager);
 
+  const dbArgs = [];
+  appendOption(dbArgs, '--migrations-dir', migrationsDir, './migrations');
+
   return [
     {
       id: 'check',
-      argv: ['rtgl', 'be', 'check', ...methodArgs, ...middlewareArgs, '--format', 'json'],
+      argv: [...commandPrefix, 'check', ...dirArgs, ...methodArgs, ...middlewareArgs, '--format', 'json'],
     },
     {
       id: 'manifest',
-      argv: ['rtgl', 'be', 'manifest', ...methodArgs, ...middlewareArgs, '--json'],
+      argv: [...commandPrefix, 'manifest', ...manifestArgs, '--json'],
     },
     {
       id: 'test',
-      argv: ['rtgl', 'be', 'test', ...testArgs, '--json'],
+      argv: [...commandPrefix, 'test', ...testArgs, '--json'],
+    },
+    {
+      id: 'db',
+      argv: [...commandPrefix, 'db', 'check', ...dbArgs, '--json'],
     },
     {
       id: 'verify',
-      argv: ['rtgl', 'be', 'verify', ...verifyArgs, '--json'],
+      argv: [...commandPrefix, 'verify', ...verifyArgs, '--json'],
     },
   ];
 };
@@ -85,7 +118,11 @@ export const findCommand = (commands, id) => {
 
 const createFixHint = (ruleId) => {
   const hints = {
+    'RTGL-BE-CONTRACT-003': 'Create exactly one .handlers.js file named after the action folder.',
+    'RTGL-BE-CONTRACT-004': 'Create exactly one .contract.yaml file named after the action folder.',
     'RTGL-BE-CONTRACT-041': 'Rename or remove the unsupported method package file.',
+    'RTGL-BE-CONTRACT-013': 'Remove the middleware reference or create a matching middleware module.',
+    'RTGL-BE-CONTRACT-019': 'Change the contract method id to match the method folder path.',
     'RTGL-BE-CONTRACT-042': 'Set params.type to object.',
     'RTGL-BE-CONTRACT-043': 'Set result.type to object.',
     'RTGL-BE-CONTRACT-044': 'Remove JSON-RPC protocol fields from the result schema.',
@@ -105,6 +142,9 @@ const createFixHint = (ruleId) => {
     'RTGL-BE-CONTRACT-038': 'Add at least one case document to the examples file.',
     'RTGL-BE-CONTRACT-039': "Set 'in' to an array with exactly one object argument.",
     'RTGL-BE-CONTRACT-040': 'Use either proves.result or proves.error, not both.',
+    'RTGL-BE-DB-001': 'Rename duplicate migration files so every migration id is unique.',
+    'RTGL-BE-DB-002': 'Review the destructive migration statement and make the migration policy explicit.',
+    'RTGL-BE-DB-003': 'Fix the SQL in the failing migration file and rerun db check.',
     'RTGL-BE-TEST-001': 'Add a .examples.yaml file with at least one proving case.',
     'RTGL-BE-TEST-002': 'Fix the failing executable example, handler, or test dependency.',
   };
@@ -175,6 +215,14 @@ export const createNextAction = ({
       };
     }
 
+    if (verifyCommand?.argv?.includes('--method')) {
+      return {
+        kind: 'done',
+        message: 'Method verification passed. This does not prove project-wide database migrations; run project verify before stopping.',
+        argv: verifyCommand?.argv,
+      };
+    }
+
     return {
       kind: 'done',
       message: 'Verification passed.',
@@ -199,7 +247,9 @@ export const createNextAction = ({
     ? 'examples-or-handler'
     : failedPhase === 'build'
       ? 'backend-build'
-      : 'contract-package';
+      : failedPhase === 'db'
+        ? 'database-migrations'
+        : 'contract-package';
 
   return {
     kind: 'fix',

--- a/packages/rettangoli-be/src/cli/check.js
+++ b/packages/rettangoli-be/src/cli/check.js
@@ -16,6 +16,7 @@ export const runBackendCheck = (options = {}) => {
     ? analysis.contracts.map((contract) => contract.method)
     : analysis.allContracts.map((contract) => contract.method);
   const commands = createBackendCommands({
+    dirs: options.dirs,
     method: options.method,
     middlewareDir: options.middlewareDir,
   });

--- a/packages/rettangoli-be/src/cli/contracts.js
+++ b/packages/rettangoli-be/src/cli/contracts.js
@@ -13,6 +13,18 @@ import {
   validateRpcDirs,
 } from '../core/contracts/rpcFiles.js';
 
+export const normalizeContractDirs = (dirs = ['./src/modules']) => {
+  if (Array.isArray(dirs)) {
+    return dirs;
+  }
+
+  if (typeof dirs === 'string' && dirs) {
+    return [dirs];
+  }
+
+  return [];
+};
+
 export {
   analyzeRpcDirs,
   collectMethodContractEntriesFromDirs,
@@ -32,8 +44,10 @@ export const resolveContractDirs = ({
   dirs = ['./src/modules'],
   middlewareDir = './src/middleware',
 }) => {
+  const normalizedDirs = normalizeContractDirs(dirs);
+
   return {
-    methodDirs: dirs.map((dir) => path.resolve(cwd, dir)),
+    methodDirs: normalizedDirs.map((dir) => path.resolve(cwd, dir)),
     middlewareDirs: [path.resolve(cwd, middlewareDir)],
   };
 };

--- a/packages/rettangoli-be/src/cli/db.js
+++ b/packages/rettangoli-be/src/cli/db.js
@@ -82,36 +82,58 @@ const quoteSqliteDotPath = (filePath) => `"${filePath.replaceAll('"', '""')}"`;
 const replayMigrations = ({ migrations, sqliteExecutable, timeoutMs = SQLITE_REPLAY_TIMEOUT_MS }) => {
   const tempDir = mkdtempSync(path.join(tmpdir(), 'rtgl-be-db-'));
   const dbPath = path.join(tempDir, 'check.sqlite');
-  const replayPath = path.join(tempDir, 'replay.sql');
+  const stdoutParts = [];
+  const stderrParts = [];
 
   try {
-    const replaySql = `${[
-      'PRAGMA foreign_keys = ON;',
-      ...migrations.map((migration) => [
+    for (const migration of migrations) {
+      const replayPath = path.join(tempDir, `${migration.id}.sql`);
+      const replaySql = `${[
+        'PRAGMA foreign_keys = ON;',
         `-- ${migration.id}`,
         migration.content,
-      ].join('\n')),
-    ].join('\n')}\n`;
-    writeFileSync(replayPath, replaySql);
+      ].join('\n')}\n`;
+      writeFileSync(replayPath, replaySql);
 
-    const input = `.read ${quoteSqliteDotPath(replayPath)}\n.quit\n`;
-    const result = spawnSync(sqliteExecutable, ['-batch', dbPath], {
-      input,
-      encoding: 'utf8',
-      timeout: timeoutMs,
-    });
-    const stderr = [
-      result.error?.message,
-      result.stderr,
-    ].filter(Boolean).join('\n');
+      const input = `.read ${quoteSqliteDotPath(replayPath)}\n.quit\n`;
+      const result = spawnSync(sqliteExecutable, ['-batch', dbPath], {
+        input,
+        encoding: 'utf8',
+        timeout: timeoutMs,
+      });
+      const stderr = [
+        result.error?.message,
+        result.stderr,
+      ].filter(Boolean).join('\n');
+
+      if (result.stdout) {
+        stdoutParts.push(result.stdout);
+      }
+      if (stderr) {
+        stderrParts.push(stderr);
+      }
+
+      if (result.status !== 0) {
+        return {
+          ok: false,
+          exitCode: result.status,
+          signal: result.signal,
+          timedOut: result.error?.code === 'ETIMEDOUT',
+          stdout: stdoutParts.join('\n'),
+          stderr,
+          migrationId: migration.id,
+          migrationPath: migration.path,
+        };
+      }
+    }
 
     return {
-      ok: result.status === 0,
-      exitCode: result.status,
-      signal: result.signal,
-      timedOut: result.error?.code === 'ETIMEDOUT',
-      stdout: result.stdout,
-      stderr,
+      ok: true,
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      stdout: stdoutParts.join('\n'),
+      stderr: stderrParts.join('\n'),
     };
   } finally {
     rmSync(tempDir, { recursive: true, force: true });
@@ -124,6 +146,7 @@ export const runBackendDbCheck = (options = {}) => {
     migrationsDir = './migrations',
     sqliteExecutable = 'sqlite3',
     replayTimeoutMs = SQLITE_REPLAY_TIMEOUT_MS,
+    failOnWarnings = false,
     runReplay = replayMigrations,
   } = options;
   const migrations = findMigrations({ cwd, migrationsDir });
@@ -156,28 +179,42 @@ export const runBackendDbCheck = (options = {}) => {
   let replay = {
     ok: migrations.length === 0,
     skipped: migrations.length === 0,
+    reason: migrations.length === 0 ? 'no migrations' : undefined,
   };
 
-  if (migrations.length > 0 && !diagnostics.some((diagnostic) => diagnostic.severity === 'error')) {
+  const hasBlockingDiagnostics = diagnostics.some((diagnostic) => diagnostic.severity === 'error');
+  if (migrations.length > 0 && hasBlockingDiagnostics) {
+    replay = {
+      ok: false,
+      skipped: true,
+      reason: 'blocked by migration diagnostics',
+    };
+  } else if (migrations.length > 0) {
     replay = runReplay({ migrations, sqliteExecutable, timeoutMs: replayTimeoutMs });
     if (!replay.ok) {
       const detail = String(replay.stderr || replay.stdout || '').trim()
         || `sqlite3 exited with ${replay.exitCode ?? replay.signal ?? 'unknown status'}.`;
       diagnostics.push(createDiagnostic({
         ruleId: 'RTGL-BE-DB-003',
-        filePath: migrations[0]?.path,
-        migrationId: migrations[0]?.id,
+        filePath: replay.migrationPath ?? migrations[0]?.path,
+        migrationId: replay.migrationId ?? migrations[0]?.id,
         message: `SQLite migration replay failed: ${detail}`,
       }));
     }
   }
 
+  const errorCount = diagnostics.filter((diagnostic) => diagnostic.severity === 'error').length;
+  const warningCount = diagnostics.filter((diagnostic) => diagnostic.severity === 'warning').length;
+
   return createCliResult({
     command: 'db check',
     artifactSchemaVersion: 'rettangoli.dbCheck/v1',
-    ok: !diagnostics.some((diagnostic) => diagnostic.severity === 'error'),
+    ok: errorCount === 0 && (!failOnWarnings || warningCount === 0),
     migrationsDir,
     migrationCount: migrations.length,
+    errorCount,
+    warningCount,
+    failOnWarnings,
     migrations: migrations.map(stripMigrationContent),
     replay: {
       ok: replay.ok,
@@ -185,6 +222,7 @@ export const runBackendDbCheck = (options = {}) => {
       exitCode: replay.exitCode,
       signal: replay.signal,
       timedOut: replay.timedOut === true,
+      reason: replay.reason,
     },
     diagnostics,
   });

--- a/packages/rettangoli-be/src/cli/manifest.js
+++ b/packages/rettangoli-be/src/cli/manifest.js
@@ -318,8 +318,11 @@ const manifestRettangoliBackend = (options = {}) => {
 
   if (!check.ok) {
     const commands = createBackendCommands({
+      dirs: options.dirs,
       method: options.method,
       middlewareDir: options.middlewareDir,
+      outdir: options.outdir,
+      migrationsDir: options.migrationsDir,
     });
     const result = createCliResult({
       command: 'manifest',

--- a/packages/rettangoli-be/src/cli/scaffold.js
+++ b/packages/rettangoli-be/src/cli/scaffold.js
@@ -2,6 +2,7 @@ import path from 'node:path';
 import { createHash } from 'node:crypto';
 import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import { stringifyStableJson } from './json.js';
+import { normalizeContractDirs } from './contracts.js';
 
 const hashContent = (content) => {
   const hash = createHash('sha256');
@@ -99,7 +100,7 @@ const createExamplesContent = ({ domain, action, exportName }) => [
 ].join('\n');
 
 const createHandlerContent = ({ exportName }) => [
-  `export const ${exportName} = async () => ({`,
+  `export const ${exportName} = () => ({`,
   '  ok: true,',
   '});',
   '',
@@ -120,6 +121,17 @@ const stripContent = (target) => {
   return publicTarget;
 };
 
+const createVerifyArgv = ({ method, dirs }) => {
+  const argv = ['rtgl', 'be', 'verify'];
+  if (!(dirs.length === 1 && dirs[0] === './src/modules')) {
+    dirs.forEach((dir) => {
+      argv.push('--dir', dir);
+    });
+  }
+  argv.push('--method', method, '--json');
+  return argv;
+};
+
 export const createMethodScaffoldPlan = ({
   cwd = process.cwd(),
   method,
@@ -127,7 +139,12 @@ export const createMethodScaffoldPlan = ({
   dirs = './src/modules',
 } = {}) => {
   const parsed = parseMethodId(methodId);
-  const modulesDir = path.resolve(cwd, dirs);
+  const methodDirs = normalizeContractDirs(dirs);
+  if (methodDirs.length !== 1) {
+    throw new Error('Method scaffold requires exactly one method directory.');
+  }
+
+  const modulesDir = path.resolve(cwd, methodDirs[0]);
   const methodDir = path.join(modulesDir, parsed.domain, parsed.action);
   const exportName = `${toCamel(parsed.domain)}${toPascal(parsed.action)}Method`;
   const targets = [
@@ -162,8 +179,13 @@ export const createMethodScaffoldPlan = ({
     exportName,
     conflicts,
     targets: targets.map(stripContent),
+    setupRequirement: {
+      path: 'src/setup.js',
+      dependencyPath: `setup.deps.${parsed.domain}`,
+      message: `Ensure setup.deps.${parsed.domain} exists before importing the generated app.`,
+    },
     verify: {
-      argv: ['rtgl', 'be', 'verify', '--method', parsed.method, '--json'],
+      argv: createVerifyArgv({ method: parsed.method, dirs: methodDirs }),
     },
     _private: {
       targets,

--- a/packages/rettangoli-be/src/cli/test.js
+++ b/packages/rettangoli-be/src/cli/test.js
@@ -19,6 +19,18 @@ const toOutputTail = (value, maxLength = 4000) => {
   return text.length > maxLength ? text.slice(-maxLength) : text;
 };
 
+const toProcessOutputText = (value) => {
+  if (value === undefined || value === null) {
+    return '';
+  }
+
+  if (Buffer.isBuffer(value)) {
+    return value.toString('utf8');
+  }
+
+  return String(value);
+};
+
 const createPackageRunner = ({ executable, packageManager, env = process.env } = {}) => {
   if (executable) {
     return {
@@ -76,6 +88,7 @@ export const runBackendTests = (options = {}) => {
     : analysis.allContracts.map((contract) => contract.method);
   const scope = createScope({ method, methods });
   const commands = createBackendCommands({
+    dirs,
     method,
     middlewareDir,
     config,
@@ -170,13 +183,18 @@ export const runBackendTests = (options = {}) => {
   });
   const exitCode = typeof result.status === 'number' ? result.status : 1;
   const ok = exitCode === 0;
-  const stdout = result.stdout ?? '';
-  const stderr = result.stderr ?? '';
+  const stdout = toProcessOutputText(result.stdout ?? result.output?.[1]);
+  const stderr = [
+    toProcessOutputText(result.stderr ?? result.output?.[2]),
+    result.error?.message,
+  ].filter(Boolean).join('\n');
   const failureDiagnostic = ok ? undefined : normalizeDiagnostic({
     cwd,
     error: {
       code: 'RTGL-BE-TEST-002',
-      message: `Backend examples failed with exit code ${exitCode}.`,
+      message: result.error?.message
+        ? `Backend examples failed with exit code ${exitCode}: ${result.error.message}`
+        : `Backend examples failed with exit code ${exitCode}.`,
       filePath: files.length === 1 ? files[0] : undefined,
     },
     phase: 'test',

--- a/packages/rettangoli-be/src/cli/verify.js
+++ b/packages/rettangoli-be/src/cli/verify.js
@@ -95,10 +95,12 @@ export const runBackendVerify = (options = {}) => {
     method,
   };
   const commands = createBackendCommands({
+    dirs,
     method,
     middlewareDir,
     setup,
     outdir,
+    migrationsDir,
     testConfig,
     executable,
     packageManager,
@@ -178,6 +180,7 @@ export const runBackendVerify = (options = {}) => {
         ok: true,
         scope: 'project',
         generated: false,
+        dryRun: true,
         plan: {
           schemaVersion: output.schemaVersion,
           outdir: output.outdir,
@@ -264,9 +267,13 @@ export const runBackendVerify = (options = {}) => {
     ...(test.diagnostics ?? []),
   ];
   const ok = check.ok && buildResult.ok && manifestResult.ok && db.ok && test.ok;
-  const ownedFiles = manifestValue
-    ? collectSourceFilesFromManifest(manifestValue)
-    : [...new Set(diagnostics.map((diagnostic) => diagnostic.filePath).filter(Boolean))].sort();
+  const diagnosticFiles = diagnostics
+    .map((diagnostic) => diagnostic.filePath)
+    .filter(Boolean);
+  const ownedFiles = [
+    ...(manifestValue ? collectSourceFilesFromManifest(manifestValue) : []),
+    ...diagnosticFiles,
+  ].filter(Boolean);
   const writeFiles = method
     ? []
     : (buildResult.plan?.targets ?? [])
@@ -283,7 +290,7 @@ export const runBackendVerify = (options = {}) => {
     steps,
     commands,
     files: {
-      owned: ownedFiles,
+      owned: [...new Set(ownedFiles)].sort(),
       write: writeFiles,
     },
     diagnostics,

--- a/packages/rettangoli-be/src/core/contracts/rpcFiles.js
+++ b/packages/rettangoli-be/src/core/contracts/rpcFiles.js
@@ -40,8 +40,33 @@ const formatAjvErrors = (errors = []) => {
     .join('; ');
 };
 
-const parseMethodFileMeta = (filePath = '') => {
+const pathContains = (parentPath, childPath) => {
+  const relative = path.relative(parentPath, childPath);
+  return relative === '' || (!!relative && !relative.startsWith('..') && !path.isAbsolute(relative));
+};
+
+const parseMethodFileLayout = (filePath = '', methodDirs = []) => {
   const normalized = path.normalize(filePath);
+  const absoluteFilePath = path.resolve(filePath);
+  const owningMethodDir = methodDirs
+    .map((methodDir) => path.resolve(methodDir))
+    .find((methodDir) => pathContains(methodDir, absoluteFilePath));
+
+  if (owningMethodDir) {
+    const parts = path.relative(owningMethodDir, absoluteFilePath).split(path.sep);
+    if (parts.length !== 3) {
+      return { ok: false, reason: 'invalid-layout' };
+    }
+
+    const [domain, action, fileName] = parts;
+    return {
+      ok: true,
+      domain,
+      action,
+      fileName,
+    };
+  }
+
   const parts = normalized.split(path.sep);
   const modulesIndex = parts.lastIndexOf('modules');
 
@@ -52,10 +77,31 @@ const parseMethodFileMeta = (filePath = '') => {
   const domain = parts[modulesIndex + 1];
   const action = parts[modulesIndex + 2];
   const fileName = parts[modulesIndex + 3];
+
+  return {
+    ok: true,
+    domain,
+    action,
+    fileName,
+  };
+};
+
+const parseMethodFileMeta = (filePath = '', methodDirs = []) => {
+  const layout = parseMethodFileLayout(filePath, methodDirs);
+
+  if (!layout.ok) {
+    return layout;
+  }
+
+  const { domain, action, fileName } = layout;
   const suffix = findSupportedMethodSuffix(fileName);
 
   if (!suffix) {
-    return { ok: false, reason: 'unsupported-suffix' };
+    return {
+      ...layout,
+      reason: 'unsupported-suffix',
+      ok: false,
+    };
   }
 
   const fileType = METHOD_FILE_KIND_BY_SUFFIX[suffix];
@@ -77,30 +123,26 @@ export const isSupportedMethodFile = (filePath = '') => {
   return SUPPORTED_METHOD_FILE_SUFFIXES.some((suffix) => filePath.endsWith(suffix));
 };
 
-export const collectMethodContractEntriesFromFiles = (allFiles = []) => {
+export const collectMethodContractEntriesFromFiles = (allFiles = [], { methodDirs = [] } = {}) => {
   const entries = [];
   const collectionErrors = [];
 
   allFiles
     .filter((filePath) => isPotentialMethodFile(filePath) && !isSupportedMethodFile(filePath))
     .forEach((filePath) => {
-      const normalized = path.normalize(filePath);
-      const parts = normalized.split(path.sep);
-      const modulesIndex = parts.lastIndexOf('modules');
-
-      if (modulesIndex === -1 || parts.length !== modulesIndex + 4) {
+      const layout = parseMethodFileLayout(filePath, methodDirs);
+      if (!layout.ok) {
         return;
       }
 
-      const action = parts[modulesIndex + 2];
-      const fileName = parts[modulesIndex + 3];
+      const { domain, action, fileName } = layout;
       if (!fileName.startsWith(`${action}.`)) {
         return;
       }
 
       collectionErrors.push({
         code: 'RTGL-BE-CONTRACT-041',
-        method: `${parts[modulesIndex + 1]}.${action}`,
+        method: `${domain}.${action}`,
         message: `Unsupported method package file '${fileName}'. Expected ${SUPPORTED_METHOD_FILE_SUFFIXES.join(', ')}.`,
         filePath,
       });
@@ -109,12 +151,12 @@ export const collectMethodContractEntriesFromFiles = (allFiles = []) => {
   allFiles
     .filter((filePath) => isSupportedMethodFile(filePath))
     .forEach((filePath) => {
-      const parsed = parseMethodFileMeta(filePath);
+      const parsed = parseMethodFileMeta(filePath, methodDirs);
 
       if (!parsed.ok) {
         collectionErrors.push({
           code: 'RTGL-BE-CONTRACT-001',
-          message: `Invalid method file layout under modules/: ${filePath}`,
+          message: `Invalid method file layout under configured method dirs: ${filePath}`,
           filePath,
         });
         return;
@@ -167,7 +209,7 @@ export const collectMethodContractEntriesFromDirs = (dirs = []) => {
   const existingDirs = dirs.filter((dirPath) => existsSync(dirPath));
   const missingDirs = dirs.filter((dirPath) => !existsSync(dirPath));
   const allFiles = getAllFiles(existingDirs);
-  const result = collectMethodContractEntriesFromFiles(allFiles);
+  const result = collectMethodContractEntriesFromFiles(allFiles, { methodDirs: existingDirs });
 
   missingDirs.forEach((missingDir) => {
     result.collectionErrors.push({

--- a/packages/rettangoli-be/test/cli/check.output.test.js
+++ b/packages/rettangoli-be/test/cli/check.output.test.js
@@ -2,10 +2,10 @@ import path from 'node:path';
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import check from '../../src/cli/check.js';
+import check, { runBackendCheck } from '../../src/cli/check.js';
 
-const writeMethodFiles = ({ rootDir, includeSpec = true }) => {
-  const methodDir = path.join(rootDir, 'src', 'modules', 'health', 'ping');
+const writeMethodFiles = ({ rootDir, includeSpec = true, modulesDir = 'src/modules' }) => {
+  const methodDir = path.join(rootDir, modulesDir, 'health', 'ping');
   mkdirSync(methodDir, { recursive: true });
 
   writeFileSync(path.join(methodDir, 'ping.handlers.js'), 'export const healthPingMethod = async () => ({ ok: true });\n');
@@ -758,5 +758,39 @@ describe('be check cli output', () => {
     expect(process.exitCode).toBe(1);
     const parsed = parseStdoutJson(stdoutSpy);
     expect(parsed.errors.map((error) => error.code)).toContain('RTGL-BE-CONTRACT-041');
+  });
+
+  it('discovers methods relative to configured method dirs without requiring a modules path segment', () => {
+    const rootDir = mkdtempSync(path.join(tmpdir(), 'rtgl-be-check-custom-dir-'));
+    createdDirs.push(rootDir);
+    writeMethodFiles({
+      rootDir,
+      includeSpec: true,
+      modulesDir: 'backend/methods',
+    });
+
+    const result = runBackendCheck({
+      cwd: rootDir,
+      dirs: ['./backend/methods'],
+      method: 'health.ping',
+      format: 'json',
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.scope).toEqual({
+      type: 'method',
+      methods: ['health.ping'],
+      provesProject: false,
+    });
+    expect(result.nextAction.argv).toEqual([
+      'rtgl',
+      'be',
+      'verify',
+      '--dir',
+      './backend/methods',
+      '--method',
+      'health.ping',
+      '--json',
+    ]);
   });
 });

--- a/packages/rettangoli-be/test/cli/db.output.test.js
+++ b/packages/rettangoli-be/test/cli/db.output.test.js
@@ -58,6 +58,11 @@ describe('be db check command', () => {
       ruleId: 'RTGL-BE-DB-001',
       migrationId: '001_init',
     }));
+    expect(result.replay).toEqual(expect.objectContaining({
+      ok: false,
+      skipped: true,
+      reason: 'blocked by migration diagnostics',
+    }));
   });
 
   it('reports incomplete SQL replay failures without timing out', () => {
@@ -81,5 +86,45 @@ describe('be db check command', () => {
       migrationId: '001_bad',
     }));
     expect(result.diagnostics[0].message).toMatch(/incomplete input/i);
+  });
+
+  it('points replay failures at the failing migration file', () => {
+    const rootDir = mkdtempSync(path.join(tmpdir(), 'rtgl-be-db-bad-second-'));
+    createdDirs.push(rootDir);
+    mkdirSync(path.join(rootDir, 'migrations'), { recursive: true });
+    writeFileSync(path.join(rootDir, 'migrations', '001_ok.sql'), 'CREATE TABLE users (id TEXT PRIMARY KEY);\n');
+    writeFileSync(path.join(rootDir, 'migrations', '002_bad.sql'), 'CREATE TABLE broken (\n');
+
+    const result = runBackendDbCheck({ cwd: rootDir });
+
+    expect(result.ok).toBe(false);
+    expect(result.diagnostics[0]).toEqual(expect.objectContaining({
+      ruleId: 'RTGL-BE-DB-003',
+      filePath: 'migrations/002_bad.sql',
+      migrationId: '002_bad',
+    }));
+  });
+
+  it('reports destructive migration warnings and can fail on warnings', () => {
+    const rootDir = mkdtempSync(path.join(tmpdir(), 'rtgl-be-db-warning-'));
+    createdDirs.push(rootDir);
+    mkdirSync(path.join(rootDir, 'migrations'), { recursive: true });
+    writeFileSync(path.join(rootDir, 'migrations', '001_drop.sql'), [
+      'CREATE TABLE old_users (id TEXT PRIMARY KEY);',
+      'DROP TABLE old_users;',
+      '',
+    ].join('\n'));
+
+    const defaultResult = runBackendDbCheck({ cwd: rootDir });
+    const strictResult = runBackendDbCheck({
+      cwd: rootDir,
+      failOnWarnings: true,
+    });
+
+    expect(defaultResult.ok).toBe(true);
+    expect(defaultResult.warningCount).toBe(1);
+    expect(defaultResult.errorCount).toBe(0);
+    expect(strictResult.ok).toBe(false);
+    expect(strictResult.failOnWarnings).toBe(true);
   });
 });

--- a/packages/rettangoli-be/test/cli/public-cli.output.test.js
+++ b/packages/rettangoli-be/test/cli/public-cli.output.test.js
@@ -1,0 +1,22 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const cliPath = path.resolve(process.cwd(), '../rettangoli-cli/cli.js');
+
+describe('public rtgl be cli surface', () => {
+  it('exposes backend scaffold, db, resume, and build plan options', () => {
+    const source = readFileSync(cliPath, 'utf8');
+
+    expect(source).toContain('scaffold: scaffoldBe');
+    expect(source).toContain('db: dbBe');
+    expect(source).toContain('resume: resumeBe');
+    expect(source).toContain('.command("scaffold [methodId]")');
+    expect(source).toContain('beCommand.command("db")');
+    expect(source).toContain('.command("resume <taskId>")');
+    expect(source).toContain('.option("--dry-run"');
+    expect(source).toContain('.option("--check"');
+    expect(source).toContain('.option("--migrations-dir <path>"');
+    expect(source).toContain('.option("--fail-on-warnings"');
+  });
+});

--- a/packages/rettangoli-be/test/cli/scaffold.output.test.js
+++ b/packages/rettangoli-be/test/cli/scaffold.output.test.js
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { afterEach, describe, expect, it } from 'vitest';
 import {
@@ -36,11 +36,19 @@ describe('be scaffold command', () => {
       'src/modules/user/getProfile/getProfile.handlers.js',
     ]);
     expect(plan.targets[0].hash).toMatch(/^sha256:/);
+    expect(plan.setupRequirement).toEqual({
+      path: 'src/setup.js',
+      dependencyPath: 'setup.deps.user',
+      message: 'Ensure setup.deps.user exists before importing the generated app.',
+    });
     expect(existsSync(path.join(rootDir, 'src', 'modules', 'user', 'getProfile'))).toBe(false);
 
     applyMethodScaffoldPlan(plan);
 
     expect(existsSync(path.join(rootDir, 'src', 'modules', 'user', 'getProfile', 'getProfile.contract.yaml'))).toBe(true);
+    expect(readFileSync(path.join(rootDir, 'src', 'modules', 'user', 'getProfile', 'getProfile.handlers.js'), 'utf8')).toContain(
+      'export const userGetProfileMethod = () =>',
+    );
     const check = runBackendCheck({
       cwd: rootDir,
       method: 'user.getProfile',
@@ -79,5 +87,34 @@ describe('be scaffold command', () => {
       cwd: rootDir,
       methodId: 'user.get/Profile',
     })).toThrow(/invalid/i);
+  });
+
+  it('accepts one configured dirs entry and preserves it in verify argv', () => {
+    const rootDir = mkdtempSync(path.join(tmpdir(), 'rtgl-be-scaffold-custom-dir-'));
+    createdDirs.push(rootDir);
+
+    const plan = createMethodScaffoldPlan({
+      cwd: rootDir,
+      methodId: 'billing.createInvoice',
+      dirs: ['./backend/methods'],
+    });
+
+    expect(plan.methodFolder).toBe('backend/methods/billing/createInvoice');
+    expect(plan.verify.argv).toEqual([
+      'rtgl',
+      'be',
+      'verify',
+      '--dir',
+      './backend/methods',
+      '--method',
+      'billing.createInvoice',
+      '--json',
+    ]);
+
+    expect(() => createMethodScaffoldPlan({
+      cwd: rootDir,
+      methodId: 'billing.createInvoice',
+      dirs: ['./backend/methods', './other'],
+    })).toThrow(/exactly one method directory/);
   });
 });

--- a/packages/rettangoli-be/test/cli/test.command.test.js
+++ b/packages/rettangoli-be/test/cli/test.command.test.js
@@ -319,6 +319,28 @@ describe('be test command', () => {
     expect(result.nextAction.files).toEqual(files);
   });
 
+  it('includes runner spawn errors in test diagnostics', () => {
+    const rootDir = mkdtempSync(path.join(tmpdir(), 'rtgl-be-test-spawn-error-'));
+    createdDirs.push(rootDir);
+    writeMethod(rootDir);
+
+    const result = runBackendTests({
+      cwd: rootDir,
+      format: 'json',
+      executable: 'custom-runner',
+      runCommand: vi.fn(() => ({
+        status: null,
+        stdout: '',
+        stderr: '',
+        error: new Error('spawn custom-runner ENOENT'),
+      })),
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.diagnostics[0].message).toContain('spawn custom-runner ENOENT');
+    expect(result.diagnostics[0].outputTail.stderr).toContain('spawn custom-runner ENOENT');
+  });
+
   it('does not run Vitest when no backend examples are found', () => {
     const rootDir = mkdtempSync(path.join(tmpdir(), 'rtgl-be-test-empty-'));
     createdDirs.push(rootDir);

--- a/packages/rettangoli-be/test/cli/verify.output.test.js
+++ b/packages/rettangoli-be/test/cli/verify.output.test.js
@@ -9,7 +9,7 @@ import {
 } from '../../src/cli/agentWorkflow.js';
 import { createBackendManifest } from '../../src/cli/manifest.js';
 
-const writeProject = (rootDir) => {
+const writeProject = (rootDir, { modulesDir = 'src/modules' } = {}) => {
   const srcDir = path.join(rootDir, 'src');
   mkdirSync(srcDir, { recursive: true });
   writeFileSync(path.join(srcDir, 'setup.js'), [
@@ -20,7 +20,7 @@ const writeProject = (rootDir) => {
   ].join('\n'));
   writeFileSync(path.join(rootDir, 'vitest.config.js'), 'export default {};\n');
 
-  const methodDir = path.join(srcDir, 'modules', 'health', 'ping');
+  const methodDir = path.join(rootDir, modulesDir, 'health', 'ping');
   mkdirSync(methodDir, { recursive: true });
   writeFileSync(path.join(methodDir, 'ping.handlers.js'), 'export const healthPingMethod = async () => ({ ok: true });\n');
   writeFileSync(path.join(methodDir, 'ping.contract.yaml'), [
@@ -217,7 +217,7 @@ describe('be verify output', () => {
   it('preserves CLI overrides in verify rerun commands', () => {
     const rootDir = mkdtempSync(path.join(tmpdir(), 'rtgl-be-verify-overrides-'));
     createdDirs.push(rootDir);
-    writeProject(rootDir);
+    writeProject(rootDir, { modulesDir: 'backend/methods' });
 
     const runCommand = vi.fn(() => ({
       status: 0,
@@ -228,9 +228,11 @@ describe('be verify output', () => {
     const result = runBackendVerify({
       cwd: rootDir,
       method: 'health.ping',
+      dirs: ['./backend/methods'],
       middlewareDir: './src/custom-middleware',
       setup: './src/custom-setup.js',
       outdir: './custom-generated',
+      migrationsDir: './database/sql',
       testConfig: './vitest.custom.js',
       executable: 'custom-runner',
       packageManager: 'pnpm',
@@ -242,6 +244,8 @@ describe('be verify output', () => {
       'rtgl',
       'be',
       'check',
+      '--dir',
+      './backend/methods',
       '--method',
       'health.ping',
       '--middleware-dir',
@@ -253,6 +257,8 @@ describe('be verify output', () => {
       'rtgl',
       'be',
       'test',
+      '--dir',
+      './backend/methods',
       '--method',
       'health.ping',
       '--middleware-dir',
@@ -269,6 +275,8 @@ describe('be verify output', () => {
       'rtgl',
       'be',
       'verify',
+      '--dir',
+      './backend/methods',
       '--method',
       'health.ping',
       '--middleware-dir',
@@ -277,6 +285,8 @@ describe('be verify output', () => {
       './src/custom-setup.js',
       '--outdir',
       './custom-generated',
+      '--migrations-dir',
+      './database/sql',
       '--test-config',
       './vitest.custom.js',
       '--runner',
@@ -285,6 +295,40 @@ describe('be verify output', () => {
       'pnpm',
       '--json',
     ]);
+  });
+
+  it('points db verify failures at migration files and db rerun commands', () => {
+    const rootDir = mkdtempSync(path.join(tmpdir(), 'rtgl-be-verify-db-fail-'));
+    createdDirs.push(rootDir);
+    writeProject(rootDir);
+    mkdirSync(path.join(rootDir, 'migrations'), { recursive: true });
+    writeFileSync(path.join(rootDir, 'migrations', '001_ok.sql'), 'CREATE TABLE users (id TEXT PRIMARY KEY);\n');
+    writeFileSync(path.join(rootDir, 'migrations', '002_bad.sql'), 'CREATE TABLE broken (\n');
+
+    const runCommand = vi.fn(() => ({
+      status: 0,
+      stdout: '',
+      stderr: '',
+    }));
+
+    const result = runBackendVerify({
+      cwd: rootDir,
+      runCommand,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.failedPhase).toBe('db');
+    expect(result.diagnostics[0]).toEqual(expect.objectContaining({
+      ruleId: 'RTGL-BE-DB-003',
+      filePath: 'migrations/002_bad.sql',
+    }));
+    expect(result.files.owned).toContain('migrations/002_bad.sql');
+    expect(result.nextAction).toEqual(expect.objectContaining({
+      kind: 'fix',
+      phase: 'db',
+      target: 'database-migrations',
+      argv: ['rtgl', 'be', 'db', 'check', '--json'],
+    }));
   });
 
   it('returns agent-ready check failure details', () => {

--- a/packages/rettangoli-cli/cli.js
+++ b/packages/rettangoli-cli/cli.js
@@ -22,7 +22,10 @@ const beCli = existsSync(localBeCliUrl)
 const {
   build: buildBe,
   check: checkBe,
+  db: dbBe,
   manifest: manifestBe,
+  resume: resumeBe,
+  scaffold: scaffoldBe,
   start: startBe,
   test: testBe,
   verify: verifyBe,
@@ -96,6 +99,7 @@ function resolveBeRuntimePaths(config) {
     middlewareDir: be.middlewareDir || "./src/middleware",
     setup: be.setup || "./src/setup.js",
     outdir: be.outdir || "./.rtgl-be/generated",
+    migrationsDir: be.migrationsDir || "./migrations",
     domainErrors: be.domainErrors || {},
   };
 }
@@ -333,9 +337,13 @@ const beCommand = program.command("be").description("Backend framework");
 beCommand
   .command("build")
   .description("Build backend method registry and app entry")
+  .option("--dir <path>", "Backend method directory to scan (repeatable)", collectValues, [])
   .option("-s, --setup-path <path>", "Custom setup file path")
   .option("-m, --middleware-dir <path>", "Custom middleware directory path")
   .option("-o, --outdir <path>", "Generated output directory")
+  .option("--dry-run", "Print the deterministic build plan without writing files")
+  .option("--check", "Check whether generated files are fresh")
+  .option("--json", "Output JSON")
   .action((options) => {
     const config = readConfig();
 
@@ -345,18 +353,20 @@ beCommand
 
     const bePaths = resolveBeRuntimePaths(config);
 
-    const missingDirs = bePaths.dirs.filter(
+    const selectedDirs = options.dir.length > 0 ? options.dir : bePaths.dirs;
+    const missingDirs = selectedDirs.filter(
       (dir) => !existsSync(resolve(process.cwd(), dir)),
     );
     if (missingDirs.length > 0) {
       throw new Error(`Directories do not exist: ${missingDirs.join(", ")}`);
     }
 
-    options.dirs = bePaths.dirs;
+    options.dirs = selectedDirs;
     options.middlewareDir = options.middlewareDir || bePaths.middlewareDir;
     options.setup = options.setupPath || bePaths.setup;
     options.outdir = options.outdir || bePaths.outdir;
     options.domainErrors = bePaths.domainErrors;
+    if (options.json) options.format = "json";
 
     buildBe(options);
   });
@@ -365,6 +375,8 @@ beCommand
   .command("check")
   .description("Validate backend RPC contracts")
   .option("--format <format>", "Output format: text or json", "text")
+  .option("--json", "Output JSON")
+  .option("--dir <path>", "Backend method directory to scan (repeatable)", collectValues, [])
   .option("--method <method>", "Validate one backend method id")
   .option("-m, --middleware-dir <path>", "Custom middleware directory path")
   .action((options) => {
@@ -376,8 +388,9 @@ beCommand
 
     const bePaths = resolveBeRuntimePaths(config);
 
-    options.dirs = bePaths.dirs;
+    options.dirs = options.dir.length > 0 ? options.dir : bePaths.dirs;
     options.middlewareDir = options.middlewareDir || bePaths.middlewareDir;
+    if (options.json) options.format = "json";
 
     checkBe(options);
   });
@@ -386,8 +399,11 @@ beCommand
   .command("manifest")
   .description("Print deterministic backend API manifest")
   .option("--json", "Output JSON")
+  .option("--dir <path>", "Backend method directory to scan (repeatable)", collectValues, [])
   .option("--method <method>", "Print manifest for one backend method id")
   .option("-m, --middleware-dir <path>", "Custom middleware directory path")
+  .option("--outdir <path>", "Generated output directory used for target facts")
+  .option("--migrations-dir <path>", "SQLite migrations directory")
   .option("-o, --output <path>", "Write manifest JSON to a file")
   .action((options) => {
     const config = readConfig();
@@ -398,8 +414,10 @@ beCommand
 
     const bePaths = resolveBeRuntimePaths(config);
 
-    options.dirs = bePaths.dirs;
+    options.dirs = options.dir.length > 0 ? options.dir : bePaths.dirs;
     options.middlewareDir = options.middlewareDir || bePaths.middlewareDir;
+    options.outdir = options.outdir || bePaths.outdir;
+    options.migrationsDir = options.migrationsDir || bePaths.migrationsDir;
 
     requireBeCommand(manifestBe, "manifest")(options);
   });
@@ -409,9 +427,11 @@ beCommand
   .description("Run backend executable examples")
   .option("--format <format>", "Output format: text or json", "text")
   .option("--json", "Output JSON")
+  .option("--dir <path>", "Backend method directory to scan (repeatable)", collectValues, [])
   .option("--method <method>", "Run examples for one backend method id")
   .option("-m, --middleware-dir <path>", "Custom middleware directory path")
   .option("--config <path>", "Vitest config path", "./vitest.config.js")
+  .option("--test-config <path>", "Alias for --config")
   .option("--package-manager <name>", "Package manager for running Vitest: npm, pnpm, yarn, bun")
   .option("--runner <command>", "Executable used to run Vitest")
   .action((options) => {
@@ -423,8 +443,9 @@ beCommand
 
     const bePaths = resolveBeRuntimePaths(config);
 
-    options.dirs = bePaths.dirs;
+    options.dirs = options.dir.length > 0 ? options.dir : bePaths.dirs;
     options.middlewareDir = options.middlewareDir || bePaths.middlewareDir;
+    options.config = options.testConfig || options.config;
     options.executable = options.runner;
     if (options.json) options.format = "json";
 
@@ -436,10 +457,15 @@ beCommand
   .description("Run backend check, build, manifest, and examples")
   .option("--format <format>", "Output format: text or json", "text")
   .option("--json", "Output JSON")
+  .option("--dir <path>", "Backend method directory to scan (repeatable)", collectValues, [])
   .option("--method <method>", "Verify one backend method id")
   .option("-s, --setup-path <path>", "Custom setup file path")
   .option("-m, --middleware-dir <path>", "Custom middleware directory path")
   .option("-o, --outdir <path>", "Generated output directory")
+  .option("--migrations-dir <path>", "SQLite migrations directory")
+  .option("--evidence <taskId>", "Write verification evidence under .rtgl-be/evidence")
+  .option("--task-id <taskId>", "Task id for verification evidence")
+  .option("--config <path>", "Alias for --test-config")
   .option("--test-config <path>", "Vitest config path", "./vitest.config.js")
   .option("--package-manager <name>", "Package manager for running Vitest: npm, pnpm, yarn, bun")
   .option("--runner <command>", "Executable used to run Vitest")
@@ -452,14 +478,63 @@ beCommand
 
     const bePaths = resolveBeRuntimePaths(config);
 
-    options.dirs = bePaths.dirs;
+    options.dirs = options.dir.length > 0 ? options.dir : bePaths.dirs;
     options.middlewareDir = options.middlewareDir || bePaths.middlewareDir;
     options.setup = options.setupPath || bePaths.setup;
     options.outdir = options.outdir || bePaths.outdir;
+    options.migrationsDir = options.migrationsDir || bePaths.migrationsDir;
+    options.testConfig = options.config || options.testConfig;
     options.executable = options.runner;
     if (options.json) options.format = "json";
 
     requireBeCommand(verifyBe, "verify")(options);
+  });
+
+beCommand
+  .command("scaffold [methodId]")
+  .description("Scaffold a backend method package")
+  .option("--method <method>", "Backend method id, e.g. user.getProfile")
+  .option("--dir <path>", "Backend method directory to create under")
+  .option("--dry-run", "Print the scaffold plan without writing files")
+  .option("--check", "Alias for --dry-run")
+  .option("--json", "Output JSON")
+  .action((methodId, options) => {
+    const config = readConfig();
+    const bePaths = resolveBeRuntimePaths(config);
+
+    options.methodId = options.method || methodId;
+    options.dirs = options.dir || bePaths.dirs[0] || "./src/modules";
+    if (options.json) options.format = "json";
+    requireBeCommand(scaffoldBe, "scaffold")(options);
+  });
+
+const beDbCommand = beCommand.command("db").description("SQLite backend database checks");
+
+beDbCommand
+  .command("check")
+  .description("Validate and replay SQLite migrations")
+  .option("--json", "Output JSON")
+  .option("--migrations-dir <path>", "SQLite migrations directory")
+  .option("--fail-on-warnings", "Return non-zero when warnings are present")
+  .action((options) => {
+    const config = readConfig();
+    const bePaths = resolveBeRuntimePaths(config);
+
+    options.migrationsDir = options.migrationsDir || bePaths.migrationsDir;
+    options.failOnWarnings = !!options.failOnWarnings;
+    if (options.json) options.format = "json";
+
+    requireBeCommand(dbBe, "db")(options);
+  });
+
+beCommand
+  .command("resume <taskId>")
+  .description("Resume a backend verification task anchor")
+  .option("--json", "Output JSON")
+  .action((taskId, options) => {
+    options.taskId = taskId;
+    if (options.json) options.format = "json";
+    requireBeCommand(resumeBe, "resume")(options);
   });
 
 beCommand


### PR DESCRIPTION
Summary:
- improve agent rerun commands, scoped dirs, scaffold output, and public rtgl be CLI coverage
- make DB migration checks point at exact failing migrations and support warning-fail mode
- improve test diagnostics and verify affected-file output for agent loops
- document backend bootstrap and handler-example scope

Tests:
- npm exec -- vitest run test/cli/check.output.test.js test/cli/test.command.test.js test/cli/verify.output.test.js test/cli/db.output.test.js test/cli/scaffold.output.test.js test/cli/public-cli.output.test.js --reporter=verbose --config vitest.config.js
- npm test
- git diff --check
- node ../rettangoli-cli/cli.js be --help
- node ../rettangoli-cli/cli.js be build --help