### PR TITLE
Improve backend agent workflow and contract ergonomics

### DIFF
--- a/packages/rettangoli-be/src/cli/agentLoop.js
+++ b/packages/rettangoli-be/src/cli/agentLoop.js
@@ -63,6 +63,10 @@ export const createBackendCommands = ({
   setup,
   outdir,
   migrationsDir,
+  configPath,
+  globalMiddleware = [],
+  globalMiddlewareBefore = [],
+  globalMiddlewareAfter = [],
   config,
   testConfig,
   executable,
@@ -103,31 +107,61 @@ export const createBackendCommands = ({
   const appArgs = [...dirArgs, ...methodArgs, ...middlewareArgs];
   appendOption(appArgs, '--setup-path', setup, './src/setup.js');
 
+  const context = {};
+  if (typeof configPath === 'string' && configPath && configPath !== 'rettangoli.config.yaml') {
+    context.configPath = configPath;
+  }
+
+  const runtime = {};
+  if (Array.isArray(globalMiddleware) && globalMiddleware.length > 0) {
+    runtime.globalMiddleware = globalMiddleware;
+  }
+  if (Array.isArray(globalMiddlewareBefore) && globalMiddlewareBefore.length > 0) {
+    runtime.globalMiddlewareBefore = globalMiddlewareBefore;
+  }
+  if (Array.isArray(globalMiddlewareAfter) && globalMiddlewareAfter.length > 0) {
+    runtime.globalMiddlewareAfter = globalMiddlewareAfter;
+  }
+  if (Object.keys(runtime).length > 0) {
+    context.runtime = runtime;
+  }
+
+  const withContext = (command) => {
+    if (Object.keys(context).length === 0) {
+      return command;
+    }
+
+    return {
+      ...command,
+      context,
+    };
+  };
+
   return [
-    {
+    withContext({
       id: 'check',
       argv: [...commandPrefix, 'check', ...dirArgs, ...methodArgs, ...middlewareArgs, '--format', 'json'],
-    },
-    {
+    }),
+    withContext({
       id: 'manifest',
       argv: [...commandPrefix, 'manifest', ...manifestArgs, '--json'],
-    },
-    {
+    }),
+    withContext({
       id: 'test',
       argv: [...commandPrefix, 'test', ...testArgs, '--json'],
-    },
-    {
+    }),
+    withContext({
       id: 'db',
       argv: [...commandPrefix, 'db', 'check', ...dbArgs, '--json'],
-    },
-    {
+    }),
+    withContext({
       id: 'app',
       argv: [...commandPrefix, 'app', 'check', ...appArgs, '--json'],
-    },
-    {
+    }),
+    withContext({
       id: 'verify',
       argv: [...commandPrefix, 'verify', ...verifyArgs, '--json'],
-    },
+    }),
   ];
 };
 
@@ -179,6 +213,7 @@ const createFixHint = (ruleId) => {
     'RTGL-BE-DB-001': 'Rename duplicate migration files so every migration id is unique.',
     'RTGL-BE-DB-002': 'Review the destructive migration statement and make the migration policy explicit.',
     'RTGL-BE-DB-003': 'Fix the SQL in the failing migration file and rerun db check.',
+    'RTGL-BE-RUNNER-001': 'Fix the local test runner environment or configure --package-manager/--runner.',
     'RTGL-BE-APP-001': 'Create the configured setup file or pass --setup-path.',
     'RTGL-BE-APP-002': 'Fix the setup file import error.',
     'RTGL-BE-APP-003': 'Export setup or default from the setup file.',
@@ -213,7 +248,7 @@ export const normalizeDiagnostic = ({
     schemaVersion: DIAGNOSTIC_SCHEMA_VERSION,
     ruleId,
     code: ruleId,
-    severity: 'error',
+    severity: error?.severity ?? 'error',
     phase,
     method: error?.method ?? method,
     filePath,
@@ -251,37 +286,54 @@ export const createNextAction = ({
   final = false,
 } = {}) => {
   const verifyCommand = findCommand(commands, 'verify');
-
-  if (ok) {
-    if (!final) {
-      return {
-        kind: 'verify',
-        message: 'Phase passed. Run full backend verification before stopping.',
-        argv: verifyCommand?.argv,
-      };
-    }
-
-    if (verifyCommand?.argv?.includes('--method')) {
-      return {
-        kind: 'verify',
-        message: 'Method verification passed. Run project verification before stopping.',
-        argv: removeOptionWithValue(verifyCommand.argv, '--method'),
-      };
+  const attachCommandContext = (action, command) => {
+    if (!command?.context) {
+      return action;
     }
 
     return {
+      ...action,
+      context: command.context,
+    };
+  };
+
+  if (ok) {
+    if (!final) {
+      return attachCommandContext({
+        kind: 'verify',
+        message: 'Phase passed. Run full backend verification before stopping.',
+        argv: verifyCommand?.argv,
+      }, verifyCommand);
+    }
+
+    if (verifyCommand?.argv?.includes('--method')) {
+      return attachCommandContext({
+        kind: 'verify',
+        message: 'Method verification passed. Run project verification before stopping.',
+        argv: removeOptionWithValue(verifyCommand.argv, '--method'),
+      }, verifyCommand);
+    }
+
+    return attachCommandContext({
       kind: 'done',
       message: 'Verification passed.',
       argv: verifyCommand?.argv,
-    };
+    }, verifyCommand);
   }
 
   const phaseCommandId = failedPhase === 'contracts'
     ? 'check'
     : failedPhase === 'examples'
       ? 'test'
+      : failedPhase === 'runner'
+        ? 'test'
       : failedPhase;
-  const command = findCommand(commands, phaseCommandId) ?? verifyCommand;
+  const diagnosticCommands = diagnostics
+    .map((diagnostic) => diagnostic.rerun)
+    .filter(Boolean);
+  const diagnosticCommandIds = [...new Set(diagnosticCommands.map((commandEntry) => commandEntry.id))];
+  const diagnosticCommand = diagnosticCommandIds.length === 1 ? diagnosticCommands[0] : undefined;
+  const command = diagnosticCommand ?? findCommand(commands, phaseCommandId) ?? verifyCommand;
   const ruleIds = [...new Set(diagnostics.map((diagnostic) => diagnostic.ruleId).filter(Boolean))].sort();
   const targets = [...new Set(
     diagnostics.flatMap((diagnostic) => [
@@ -289,8 +341,12 @@ export const createNextAction = ({
       ...asArray(diagnostic.files),
     ].filter(Boolean)),
   )].sort();
-  const target = failedPhase === 'test'
+  const target = command?.id === 'app'
+    ? 'runtime-app'
+    : failedPhase === 'test'
     ? 'examples-or-handler'
+    : failedPhase === 'runner'
+      ? 'test-runner'
     : failedPhase === 'build'
       ? 'backend-build'
       : failedPhase === 'db'
@@ -299,14 +355,14 @@ export const createNextAction = ({
           ? 'runtime-app'
           : 'contract-package';
 
-  return {
+  return attachCommandContext({
     kind: 'fix',
     phase: failedPhase,
     target,
     ruleIds,
     files: targets,
     argv: command?.argv,
-  };
+  }, command);
 };
 
 export const collectSourceFilesFromManifest = (manifest) => {

--- a/packages/rettangoli-be/src/cli/app.js
+++ b/packages/rettangoli-be/src/cli/app.js
@@ -8,13 +8,14 @@ import {
   createScope,
   findCommand,
   normalizeDiagnostic,
-  normalizeDiagnostics,
   toPosixRelativePath,
 } from './agentLoop.js';
 import { createApp } from '../runtime/createApp.js';
 import { resolveSingleFunctionExport } from '../runtime/resolveExports.js';
 import { createCliResult } from './results.js';
 import { stringifyStableJson } from './json.js';
+import { resolveBackendProjectOptions } from './projectOptions.js';
+import { resolveSetupExport, resolveSetupValue } from '../runtime/setup.js';
 
 const isPlainObject = (value) => !!value && typeof value === 'object' && !Array.isArray(value);
 
@@ -32,18 +33,6 @@ const createAppDiagnostic = ({ cwd, error, method, command }) => normalizeDiagno
   command,
 });
 
-const resolveSetupExport = (setupModule) => {
-  if (Object.prototype.hasOwnProperty.call(setupModule, 'setup')) {
-    return setupModule.setup;
-  }
-
-  if (Object.prototype.hasOwnProperty.call(setupModule, 'default')) {
-    return setupModule.default;
-  }
-
-  return undefined;
-};
-
 const collectReferencedMiddlewareNames = (contracts = []) => {
   return new Set(contracts.flatMap((contract) => [
     ...(Array.isArray(contract.rpc?.middleware?.before) ? contract.rpc.middleware.before : []),
@@ -51,11 +40,29 @@ const collectReferencedMiddlewareNames = (contracts = []) => {
   ]));
 };
 
-const collectGlobalMiddlewareNames = ({ globalMiddlewareBefore = [], globalMiddlewareAfter = [] } = {}) => {
+const collectGlobalMiddlewareNames = ({
+  globalMiddleware = [],
+  globalMiddlewareBefore = [],
+  globalMiddlewareAfter = [],
+} = {}) => {
   return new Set([
+    ...(Array.isArray(globalMiddleware) ? globalMiddleware : []),
     ...(Array.isArray(globalMiddlewareBefore) ? globalMiddlewareBefore : []),
     ...(Array.isArray(globalMiddlewareAfter) ? globalMiddlewareAfter : []),
   ]);
+};
+
+const parseDuplicateMiddlewareName = (error) => {
+  if (error?.code !== 'RTGL-BE-CONTRACT-021') {
+    return undefined;
+  }
+
+  return String(error.message || '').match(/Duplicate middleware name '([^']+)'/)?.[1];
+};
+
+const isGlobalMiddlewareContractError = ({ error, globalMiddlewareNames }) => {
+  const duplicateMiddlewareName = parseDuplicateMiddlewareName(error);
+  return !!duplicateMiddlewareName && globalMiddlewareNames.has(duplicateMiddlewareName);
 };
 
 const validateHandlerExport = ({ cwd, contract, moduleObject, diagnostics, command }) => {
@@ -133,12 +140,15 @@ const createInstantiationDiagnostic = ({ cwd, error, method, command, setupPath,
 };
 
 export const runBackendAppCheck = async (options = {}) => {
+  options = resolveBackendProjectOptions(options);
   const {
     cwd = process.cwd(),
     dirs = ['./src/modules'],
     middlewareDir = './src/middleware',
     setup = './src/setup.js',
+    configPath,
     method,
+    globalMiddleware = [],
     globalMiddlewareBefore = [],
     globalMiddlewareAfter = [],
   } = options;
@@ -147,9 +157,14 @@ export const runBackendAppCheck = async (options = {}) => {
     method,
     middlewareDir,
     setup,
+    configPath,
+    globalMiddleware,
+    globalMiddlewareBefore,
+    globalMiddlewareAfter,
   });
   const command = findCommand(commands, 'app');
   const globalMiddlewareNames = collectGlobalMiddlewareNames({
+    globalMiddleware,
     globalMiddlewareBefore,
     globalMiddlewareAfter,
   });
@@ -166,13 +181,16 @@ export const runBackendAppCheck = async (options = {}) => {
   const scope = createScope({ method, methods });
 
   if (!analysis.ok) {
-    const diagnostics = normalizeDiagnostics({
+    const checkCommand = findCommand(commands, 'check');
+    const diagnostics = analysis.errors.map((error) => normalizeDiagnostic({
       cwd,
-      errors: analysis.errors,
+      error,
       phase: 'contracts',
       method,
-      command: findCommand(commands, 'check'),
-    });
+      command: isGlobalMiddlewareContractError({ error, globalMiddlewareNames })
+        ? command
+        : checkCommand,
+    }));
 
     return createCliResult({
       command: 'app check',
@@ -210,7 +228,13 @@ export const runBackendAppCheck = async (options = {}) => {
   } else {
     try {
       const setupModule = await importModuleFromPath(setupPath);
-      setupValue = resolveSetupExport(setupModule);
+      const setupExport = resolveSetupExport(setupModule);
+      setupValue = setupExport === undefined
+        ? undefined
+        : await resolveSetupValue(setupExport, {
+          cwd,
+          mode: 'check',
+        });
     } catch (error) {
       diagnostics.push(createAppDiagnostic({
         cwd,
@@ -232,7 +256,7 @@ export const runBackendAppCheck = async (options = {}) => {
       command,
       error: {
         code: 'RTGL-BE-APP-003',
-        message: 'Setup file must export setup or default.',
+        message: 'Setup file must export setup, createSetup, or default.',
         filePath: setupPath,
       },
     }));
@@ -243,7 +267,7 @@ export const runBackendAppCheck = async (options = {}) => {
       command,
       error: {
         code: 'RTGL-BE-APP-004',
-        message: 'Setup export must be an object.',
+        message: 'Setup export must be an object or a factory returning an object.',
         filePath: setupPath,
       },
     }));
@@ -350,6 +374,7 @@ export const runBackendAppCheck = async (options = {}) => {
         methodContracts,
         methodHandlers,
         middlewareModules,
+        globalMiddleware,
         globalMiddlewareBefore,
         globalMiddlewareAfter,
       });

--- a/packages/rettangoli-be/src/cli/build.js
+++ b/packages/rettangoli-be/src/cli/build.js
@@ -7,6 +7,7 @@ import {
 } from '../core/contracts/rpcFiles.js';
 import { resolveContractDirs } from './contracts.js';
 import { stringifyStableJson } from './json.js';
+import { resolveBackendProjectOptions } from './projectOptions.js';
 
 const toPosixRelativeImport = (fromFilePath, toFilePath) => {
   const relativePath = path.relative(path.dirname(fromFilePath), toFilePath).replaceAll(path.sep, '/');
@@ -77,22 +78,31 @@ const createGeneratedRegistryContent = ({
 const createGeneratedAppEntryContent = ({
   outputFile,
   setupPath,
+  globalMiddleware = [],
+  globalMiddlewareBefore = [],
+  globalMiddlewareAfter = [],
 }) => {
   const lines = [
     `import { createApp } from '@rettangoli/be';`,
     `import registry from './registry.js';`,
     `import * as setupModule from '${toPosixRelativeImport(outputFile, setupPath)}';`,
     '',
-    'const setup = setupModule.setup ?? setupModule.default;',
-    'if (!setup) {',
-    "  throw new Error('Generated app: setup export not found. Export setup or default from setup.js');",
+    'const setupExport = setupModule.setup ?? setupModule.createSetup ?? setupModule.default;',
+    'if (!setupExport) {',
+    "  throw new Error('Generated app: setup export not found. Export setup, createSetup, or default from setup.js');",
     '}',
+    "const setup = typeof setupExport === 'function'",
+    "  ? await setupExport({ cwd: process.cwd(), env: process.env, mode: 'generated' })",
+    '  : setupExport;',
     '',
     'export const app = createApp({',
     '  setup,',
     '  methodContracts: registry.methodContracts,',
     '  methodHandlers: registry.methodHandlers,',
     '  middlewareModules: registry.middlewareModules,',
+    `  globalMiddleware: ${JSON.stringify(globalMiddleware)},`,
+    `  globalMiddlewareBefore: ${JSON.stringify(globalMiddlewareBefore)},`,
+    `  globalMiddlewareAfter: ${JSON.stringify(globalMiddlewareAfter)},`,
     '});',
     '',
     'export default app;',
@@ -128,15 +138,21 @@ const stripBuildPlanPrivate = (plan) => {
 };
 
 export const createBackendBuildPlan = (options = {}) => {
+  options = resolveBackendProjectOptions(options);
   const {
     cwd = process.cwd(),
     dirs = ['./src/modules'],
     middlewareDir = './src/middleware',
     setup = './src/setup.js',
     outdir = './.rtgl-be/generated',
+    globalMiddleware = [],
+    globalMiddlewareBefore = [],
+    globalMiddlewareAfter = [],
+    configPath,
   } = options;
 
   const resolvedOutdir = path.resolve(cwd, outdir);
+  const resolvedConfigPath = path.resolve(cwd, configPath ?? 'rettangoli.config.yaml');
   const { methodDirs, middlewareDirs } = resolveContractDirs({
     cwd,
     dirs,
@@ -160,6 +176,7 @@ export const createBackendBuildPlan = (options = {}) => {
     ]),
     ...analysis.middlewareEntries.map((entry) => entry.filePath),
     path.resolve(cwd, setup),
+    ...(existsSync(resolvedConfigPath) ? [resolvedConfigPath] : []),
   ].map((filePath) => toPosixRelativePath(cwd, filePath)).sort();
   const registryContent = createGeneratedRegistryContent({
     outputFile: registryPath,
@@ -169,6 +186,9 @@ export const createBackendBuildPlan = (options = {}) => {
   const appEntryContent = createGeneratedAppEntryContent({
     outputFile: appEntryPath,
     setupPath: path.resolve(cwd, setup),
+    globalMiddleware,
+    globalMiddlewareBefore,
+    globalMiddlewareAfter,
   });
   const privateTargets = [
     createTarget({

--- a/packages/rettangoli-be/src/cli/check.js
+++ b/packages/rettangoli-be/src/cli/check.js
@@ -9,8 +9,10 @@ import {
 } from './agentLoop.js';
 import { stringifyStableJson } from './json.js';
 import { createCliResult } from './results.js';
+import { resolveBackendProjectOptions } from './projectOptions.js';
 
 export const runBackendCheck = (options = {}) => {
+  options = resolveBackendProjectOptions(options);
   const analysis = analyzeBackendContracts(options);
   const methods = options.method
     ? analysis.contracts.map((contract) => contract.method)
@@ -19,6 +21,7 @@ export const runBackendCheck = (options = {}) => {
     dirs: options.dirs,
     method: options.method,
     middlewareDir: options.middlewareDir,
+    configPath: options.configPath,
   });
   const diagnostics = normalizeDiagnostics({
     cwd: options.cwd ?? process.cwd(),

--- a/packages/rettangoli-be/src/cli/db.js
+++ b/packages/rettangoli-be/src/cli/db.js
@@ -6,6 +6,13 @@ import { spawnSync } from 'node:child_process';
 import { getAllFiles } from '../commonBuild.js';
 import { stringifyStableJson } from './json.js';
 import { createCliResult } from './results.js';
+import {
+  createBackendCommands,
+  createNextAction,
+  findCommand,
+  normalizeDiagnostic,
+} from './agentLoop.js';
+import { resolveBackendProjectOptions } from './projectOptions.js';
 
 const toPosixRelativePath = (cwd, filePath) => {
   return path.relative(cwd, filePath).replaceAll(path.sep, '/');
@@ -79,7 +86,12 @@ export const collectBackendMigrationFacts = ({
 
 const quoteSqliteDotPath = (filePath) => `"${filePath.replaceAll('"', '""')}"`;
 
-const replayMigrations = ({ migrations, sqliteExecutable, timeoutMs = SQLITE_REPLAY_TIMEOUT_MS }) => {
+const replayMigrations = ({
+  migrations,
+  sqliteExecutable,
+  timeoutMs = SQLITE_REPLAY_TIMEOUT_MS,
+  runCommand = spawnSync,
+}) => {
   const tempDir = mkdtempSync(path.join(tmpdir(), 'rtgl-be-db-'));
   const dbPath = path.join(tempDir, 'check.sqlite');
   const stdoutParts = [];
@@ -96,13 +108,17 @@ const replayMigrations = ({ migrations, sqliteExecutable, timeoutMs = SQLITE_REP
       writeFileSync(replayPath, replaySql);
 
       const input = `.read ${quoteSqliteDotPath(replayPath)}\n.quit\n`;
-      const result = spawnSync(sqliteExecutable, ['-batch', dbPath], {
+      const result = runCommand(sqliteExecutable, ['-batch', dbPath], {
         input,
         encoding: 'utf8',
         timeout: timeoutMs,
       });
+      const hasProcessError = !!result.error;
+      const processError = hasProcessError && (result.status === 0 || typeof result.status !== 'number')
+        ? result.error.message
+        : undefined;
       const stderr = [
-        result.error?.message,
+        processError,
         result.stderr,
       ].filter(Boolean).join('\n');
 
@@ -113,10 +129,13 @@ const replayMigrations = ({ migrations, sqliteExecutable, timeoutMs = SQLITE_REP
         stderrParts.push(stderr);
       }
 
-      if (result.status !== 0) {
+      if (hasProcessError || result.status !== 0) {
+        const exitCode = hasProcessError && (result.status === 0 || typeof result.status !== 'number')
+          ? 1
+          : result.status;
         return {
           ok: false,
-          exitCode: result.status,
+          exitCode,
           signal: result.signal,
           timedOut: result.error?.code === 'ETIMEDOUT',
           stdout: stdoutParts.join('\n'),
@@ -141,6 +160,7 @@ const replayMigrations = ({ migrations, sqliteExecutable, timeoutMs = SQLITE_REP
 };
 
 export const runBackendDbCheck = (options = {}) => {
+  options = resolveBackendProjectOptions(options);
   const {
     cwd = process.cwd(),
     migrationsDir = './migrations',
@@ -148,14 +168,21 @@ export const runBackendDbCheck = (options = {}) => {
     replayTimeoutMs = SQLITE_REPLAY_TIMEOUT_MS,
     failOnWarnings = false,
     runReplay = replayMigrations,
+    replayCommand = spawnSync,
   } = options;
+  const commands = createBackendCommands({
+    configPath: options.configPath,
+    migrationsDir,
+    failOnWarnings,
+  });
+  const dbCommand = findCommand(commands, 'db');
   const migrations = findMigrations({ cwd, migrationsDir });
-  const diagnostics = [];
+  const rawDiagnostics = [];
   const seenIds = new Map();
 
   migrations.forEach((migration) => {
     if (seenIds.has(migration.id)) {
-      diagnostics.push(createDiagnostic({
+      rawDiagnostics.push(createDiagnostic({
         ruleId: 'RTGL-BE-DB-001',
         filePath: migration.path,
         migrationId: migration.id,
@@ -166,7 +193,7 @@ export const runBackendDbCheck = (options = {}) => {
     }
 
     if (migration.destructive) {
-      diagnostics.push(createDiagnostic({
+      rawDiagnostics.push(createDiagnostic({
         ruleId: 'RTGL-BE-DB-002',
         severity: 'warning',
         filePath: migration.path,
@@ -182,7 +209,7 @@ export const runBackendDbCheck = (options = {}) => {
     reason: migrations.length === 0 ? 'no migrations' : undefined,
   };
 
-  const hasBlockingDiagnostics = diagnostics.some((diagnostic) => diagnostic.severity === 'error');
+  const hasBlockingDiagnostics = rawDiagnostics.some((diagnostic) => diagnostic.severity === 'error');
   if (migrations.length > 0 && hasBlockingDiagnostics) {
     replay = {
       ok: false,
@@ -190,11 +217,16 @@ export const runBackendDbCheck = (options = {}) => {
       reason: 'blocked by migration diagnostics',
     };
   } else if (migrations.length > 0) {
-    replay = runReplay({ migrations, sqliteExecutable, timeoutMs: replayTimeoutMs });
+    replay = runReplay({
+      migrations,
+      sqliteExecutable,
+      timeoutMs: replayTimeoutMs,
+      runCommand: replayCommand,
+    });
     if (!replay.ok) {
       const detail = String(replay.stderr || replay.stdout || '').trim()
         || `sqlite3 exited with ${replay.exitCode ?? replay.signal ?? 'unknown status'}.`;
-      diagnostics.push(createDiagnostic({
+      rawDiagnostics.push(createDiagnostic({
         ruleId: 'RTGL-BE-DB-003',
         filePath: replay.migrationPath ?? migrations[0]?.path,
         migrationId: replay.migrationId ?? migrations[0]?.id,
@@ -203,13 +235,24 @@ export const runBackendDbCheck = (options = {}) => {
     }
   }
 
+  const diagnostics = rawDiagnostics.map((diagnostic) => normalizeDiagnostic({
+    cwd,
+    error: diagnostic,
+    phase: 'db',
+    command: dbCommand,
+    extra: {
+      migrationId: diagnostic.migrationId,
+    },
+  }));
   const errorCount = diagnostics.filter((diagnostic) => diagnostic.severity === 'error').length;
   const warningCount = diagnostics.filter((diagnostic) => diagnostic.severity === 'warning').length;
+  const ok = errorCount === 0 && (!failOnWarnings || warningCount === 0);
 
   return createCliResult({
     command: 'db check',
     artifactSchemaVersion: 'rettangoli.dbCheck/v1',
-    ok: errorCount === 0 && (!failOnWarnings || warningCount === 0),
+    ok,
+    commands,
     migrationsDir,
     migrationCount: migrations.length,
     errorCount,
@@ -225,6 +268,12 @@ export const runBackendDbCheck = (options = {}) => {
       reason: replay.reason,
     },
     diagnostics,
+    nextAction: createNextAction({
+      ok,
+      failedPhase: ok ? undefined : 'db',
+      diagnostics,
+      commands,
+    }),
   });
 };
 

--- a/packages/rettangoli-be/src/cli/manifest.js
+++ b/packages/rettangoli-be/src/cli/manifest.js
@@ -11,6 +11,7 @@ import {
 import { stringifyStableJson } from './json.js';
 import { createCliResult } from './results.js';
 import { collectBackendMigrationFacts } from './db.js';
+import { resolveBackendProjectOptions } from './projectOptions.js';
 
 export { stringifyStableJson } from './json.js';
 
@@ -187,14 +188,16 @@ const createProtocolPolicy = () => ({
   },
 });
 
-export const createBackendManifest = ({
-  cwd = process.cwd(),
-  dirs = ['./src/modules'],
-  middlewareDir = './src/middleware',
-  method,
-  migrationsDir = './migrations',
-  outdir = './.rtgl-be/generated',
-} = {}) => {
+export const createBackendManifest = (inputOptions = {}) => {
+  const options = resolveBackendProjectOptions(inputOptions);
+  const {
+    cwd,
+    dirs,
+    middlewareDir,
+    method,
+    migrationsDir,
+    outdir,
+  } = options;
   const analysis = analyzeBackendContracts({
     cwd,
     dirs,

--- a/packages/rettangoli-be/src/cli/projectOptions.js
+++ b/packages/rettangoli-be/src/cli/projectOptions.js
@@ -1,0 +1,37 @@
+import { loadBeProjectConfig } from '../runtime/loadBeProjectConfig.js';
+
+const normalizeDirs = (value) => {
+  if (Array.isArray(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string' && value) {
+    return [value];
+  }
+
+  return [];
+};
+
+export const resolveBackendProjectOptions = (options = {}) => {
+  const cwd = options.cwd ?? process.cwd();
+  const configPath = options.configPath ?? 'rettangoli.config.yaml';
+  const projectConfig = options.projectConfig ?? loadBeProjectConfig({
+    cwd,
+    configPath,
+    env: options.env ?? process.env,
+  });
+
+  return {
+    ...options,
+    cwd,
+    configPath,
+    projectConfig,
+    dirs: normalizeDirs(options.dirs ?? options.dir ?? projectConfig.dirs),
+    middlewareDir: options.middlewareDir ?? projectConfig.middlewareDir,
+    setup: options.setup ?? options.setupPath ?? projectConfig.setup,
+    outdir: options.outdir ?? projectConfig.outdir,
+    migrationsDir: options.migrationsDir ?? projectConfig.migrationsDir,
+    globalMiddlewareBefore: options.globalMiddlewareBefore ?? projectConfig.globalMiddleware.before,
+    globalMiddlewareAfter: options.globalMiddlewareAfter ?? projectConfig.globalMiddleware.after,
+  };
+};

--- a/packages/rettangoli-be/src/cli/scaffold.js
+++ b/packages/rettangoli-be/src/cli/scaffold.js
@@ -15,13 +15,6 @@ const toPosixRelativePath = (cwd, filePath) => {
   return path.relative(cwd, filePath).replaceAll(path.sep, '/');
 };
 
-const toKebab = (value) => {
-  return String(value)
-    .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
-    .replace(/[_\s.]+/g, '-')
-    .toLowerCase();
-};
-
 const toPascal = (value) => {
   return String(value)
     .split(/[-_.\s]+/)
@@ -59,39 +52,26 @@ const parseMethodId = (methodId) => {
 };
 
 const createContractContent = ({ domain, action, method }) => [
-  'schemaVersion: rettangoli.contract/v1',
-  `method: ${method}`,
-  `description: ${toKebab(domain)} ${toKebab(action)}`,
-  'middleware:',
-  '  before: []',
-  '  after: []',
+  `id: ${method}`,
   'params:',
-  '  type: object',
-  '  additionalProperties: false',
-  '  properties: {}',
-  '  required: []',
+  '  schema:',
+  '    type: object',
+  '    additionalProperties: false',
+  '    properties: {}',
+  '    required: []',
   'result:',
-  '  type: object',
-  '  additionalProperties: false',
-  '  properties:',
-  '    ok:',
-  '      type: boolean',
-  '  required: [ok]',
-  'errors: {}',
+  '  schema:',
+  '    type: object',
+  '    additionalProperties: false',
+  '    properties:',
+  '      ok:',
+  '        type: boolean',
+  '    required: [ok]',
   '',
 ].join('\n');
 
-const createExamplesContent = ({ domain, action, exportName }) => [
-  'schemaVersion: rettangoli.examples/v1',
-  `file: './${action}.handlers.js'`,
-  `group: ${toKebab(domain)}-${toKebab(action)}`,
-  '---',
-  `suite: ${exportName}`,
-  `exportName: ${exportName}`,
-  '---',
+const createExamplesContent = () => [
   'case: ok',
-  'proves:',
-  '  result: success',
   'request:',
   '  id: ok',
   '  params: {}',
@@ -160,7 +140,7 @@ export const createMethodScaffoldPlan = ({
       cwd,
       filePath: path.join(methodDir, `${parsed.action}.examples.yaml`),
       kind: 'examples',
-      content: createExamplesContent({ ...parsed, exportName }),
+      content: createExamplesContent(),
     }),
     createScaffoldTarget({
       cwd,

--- a/packages/rettangoli-be/src/cli/test.js
+++ b/packages/rettangoli-be/src/cli/test.js
@@ -13,6 +13,7 @@ import {
 } from './agentLoop.js';
 import { stringifyStableJson } from './json.js';
 import { createCliResult } from './results.js';
+import { resolveBackendProjectOptions } from './projectOptions.js';
 
 const toOutputTail = (value, maxLength = 4000) => {
   const text = String(value ?? '');
@@ -32,6 +33,17 @@ const toProcessOutputText = (value) => {
 };
 
 const inferAppFailureFromOutput = ({ cwd, output, method, setup }) => {
+  const runtimeContractMatch = output.match(/\b(RTGL-BE-CONTRACT-\d{3})\s+(.+?)\s+\[([^\]]+)\]/);
+  if (runtimeContractMatch) {
+    const [, code, message, filePath] = runtimeContractMatch;
+    return {
+      code,
+      method,
+      message: `Runtime contract validation failed: ${message}`,
+      filePath,
+    };
+  }
+
   const setupPath = path.resolve(cwd, setup);
   const missingDomainMatch = output.match(/createApp: missing setup\.deps\.([A-Za-z0-9_]+) object required by method '([^']+)'/);
   if (missingDomainMatch) {
@@ -63,6 +75,25 @@ const inferAppFailureFromOutput = ({ cwd, output, method, setup }) => {
   }
 
   return undefined;
+};
+
+const createRunnerFailure = ({ result, runner, args }) => {
+  if (!result.error) {
+    return undefined;
+  }
+
+  return {
+    code: 'RTGL-BE-RUNNER-001',
+    message: `Backend example runner failed: ${result.error.message}`,
+    runner: {
+      executable: runner.executable,
+      args,
+      argv: [runner.executable, ...args],
+      status: result.status,
+      signal: result.signal,
+      errorCode: result.error.code,
+    },
+  };
 };
 
 const createPackageRunner = ({ executable, packageManager, env = process.env } = {}) => {
@@ -97,12 +128,14 @@ const createPackageRunner = ({ executable, packageManager, env = process.env } =
 };
 
 export const runBackendTests = (options = {}) => {
+  options = resolveBackendProjectOptions(options);
   const {
     cwd = process.cwd(),
     dirs = ['./src/modules'],
     middlewareDir = './src/middleware',
     method,
     setup = './src/setup.js',
+    configPath,
     globalMiddleware = [],
     globalMiddlewareBefore = [],
     globalMiddlewareAfter = [],
@@ -130,6 +163,10 @@ export const runBackendTests = (options = {}) => {
     method,
     middlewareDir,
     setup,
+    configPath,
+    globalMiddleware,
+    globalMiddlewareBefore,
+    globalMiddlewareAfter,
     config,
     executable,
     packageManager,
@@ -213,9 +250,9 @@ export const runBackendTests = (options = {}) => {
   }
 
   const vitestArgs = ['vitest', 'run', ...files, '--reporter', reporter];
-  const configPath = path.resolve(cwd, config);
+  const resolvedTestConfigPath = path.resolve(cwd, config);
 
-  if (config && !existsSync(configPath)) {
+  if (config && !existsSync(resolvedTestConfigPath)) {
     const diagnostic = normalizeDiagnostic({
       cwd,
       error: {
@@ -278,9 +315,17 @@ export const runBackendTests = (options = {}) => {
     env: childEnv,
     encoding: 'utf8',
     stdio: captureOutput ? 'pipe' : 'inherit',
-  });
-  const exitCode = result.error ? 1 : typeof result.status === 'number' ? result.status : 1;
-  const ok = !result.error && exitCode === 0;
+  }) ?? {
+    status: 1,
+    stdout: '',
+    stderr: '',
+    error: new Error('Backend example runner did not return a process result.'),
+  };
+  const runnerFailure = createRunnerFailure({ result, runner, args });
+  const exitCode = runnerFailure
+    ? (typeof result.status === 'number' && result.status !== 0 ? result.status : 1)
+    : (typeof result.status === 'number' ? result.status : 1);
+  const ok = !runnerFailure && exitCode === 0;
   const stdout = toProcessOutputText(result.stdout ?? result.output?.[1]);
   const stderr = [
     toProcessOutputText(result.stderr ?? result.output?.[2]),
@@ -293,23 +338,25 @@ export const runBackendTests = (options = {}) => {
     method,
     setup,
   });
-  const failurePhase = appFailure ? 'app' : 'test';
-  const failureCommand = appFailure ? findCommand(commands, 'app') : testCommand;
+  const failureError = runnerFailure ?? appFailure ?? {
+    code: 'RTGL-BE-TEST-002',
+    message: result.error?.message
+      ? `Backend examples failed with exit code ${exitCode}: ${result.error.message}`
+      : `Backend examples failed with exit code ${exitCode}.`,
+    filePath: files.length === 1 ? files[0] : undefined,
+  };
+  const failurePhase = runnerFailure ? 'runner' : appFailure ? 'app' : 'test';
+  const failureCommand = runnerFailure ? testCommand : appFailure ? findCommand(commands, 'app') : testCommand;
   const failureDiagnostic = ok ? undefined : normalizeDiagnostic({
     cwd,
-    error: appFailure ?? {
-      code: 'RTGL-BE-TEST-002',
-      message: result.error?.message
-        ? `Backend examples failed with exit code ${exitCode}: ${result.error.message}`
-        : `Backend examples failed with exit code ${exitCode}.`,
-      filePath: files.length === 1 ? files[0] : undefined,
-    },
+    error: failureError,
     phase: failurePhase,
     method,
     command: failureCommand,
     extra: {
-      files: relatedFiles,
-      executedFiles: files,
+      files: runnerFailure ? [] : relatedFiles,
+      executedFiles: runnerFailure ? [] : files,
+      runner: runnerFailure?.runner,
       outputTail: {
         stdout: toOutputTail(stdout),
         stderr: toOutputTail(stderr),

--- a/packages/rettangoli-be/src/cli/verify.js
+++ b/packages/rettangoli-be/src/cli/verify.js
@@ -21,6 +21,7 @@ import {
   normalizeDiagnostic,
   toPosixRelativePath,
 } from './agentLoop.js';
+import { resolveBackendProjectOptions } from './projectOptions.js';
 
 const hashJson = (value) => {
   const hash = createHash('sha256');
@@ -113,10 +114,10 @@ const createDiscoveryRoots = ({ dirs, middlewareDir, migrationsDir }) => {
   ].filter(Boolean))].sort();
 };
 
-const createProjectInputFiles = ({ cwd, setup, testConfig }) => {
+const createProjectInputFiles = ({ cwd, setup, testConfig, configPath }) => {
   return [...new Set([
     'package.json',
-    'rettangoli.config.yaml',
+    configPath,
     setup,
     testConfig,
   ].filter(Boolean)
@@ -134,6 +135,7 @@ const existingGeneratedInputFiles = ({ cwd, outdir }) => {
 };
 
 export const runBackendVerify = async (options = {}) => {
+  options = resolveBackendProjectOptions(options);
   const {
     cwd = process.cwd(),
     dirs = ['./src/modules'],
@@ -141,6 +143,8 @@ export const runBackendVerify = async (options = {}) => {
     method,
     setup = './src/setup.js',
     outdir = './.rtgl-be/generated',
+    configPath = 'rettangoli.config.yaml',
+    projectConfig,
     testConfig = './vitest.config.js',
     runCommand,
     executable,
@@ -151,6 +155,7 @@ export const runBackendVerify = async (options = {}) => {
     migrationsDir = './migrations',
     failOnWarnings = false,
     runDbReplay,
+    globalMiddleware = [],
     globalMiddlewareBefore = [],
     globalMiddlewareAfter = [],
   } = options;
@@ -160,6 +165,8 @@ export const runBackendVerify = async (options = {}) => {
     dirs,
     middlewareDir,
     method,
+    configPath,
+    projectConfig,
   };
   const commands = createBackendCommands({
     dirs,
@@ -168,6 +175,10 @@ export const runBackendVerify = async (options = {}) => {
     setup,
     outdir,
     migrationsDir,
+    configPath,
+    globalMiddleware,
+    globalMiddlewareBefore,
+    globalMiddlewareAfter,
     testConfig,
     executable,
     packageManager,
@@ -180,7 +191,12 @@ export const runBackendVerify = async (options = {}) => {
     : check.scope.methods;
   const discoveryRoots = createDiscoveryRoots({ dirs, middlewareDir, migrationsDir });
   const projectInputFiles = [
-    ...createProjectInputFiles({ cwd, setup, testConfig }),
+    ...createProjectInputFiles({
+      cwd,
+      setup,
+      testConfig,
+      configPath,
+    }),
     ...existingGeneratedInputFiles({ cwd, outdir }),
   ];
 
@@ -251,6 +267,11 @@ export const runBackendVerify = async (options = {}) => {
         middlewareDir,
         setup,
         outdir,
+        configPath,
+        projectConfig,
+        globalMiddleware,
+        globalMiddlewareBefore,
+        globalMiddlewareAfter,
         dryRun: true,
         silent: true,
       });
@@ -283,6 +304,8 @@ export const runBackendVerify = async (options = {}) => {
       method,
       outdir,
       migrationsDir,
+      configPath,
+      projectConfig,
     });
     const scopeHash = hashJson(manifestValue);
     manifestResult = {
@@ -301,6 +324,7 @@ export const runBackendVerify = async (options = {}) => {
     : await runBackendAppCheck({
         ...sharedOptions,
         setup,
+        globalMiddleware,
         globalMiddlewareBefore,
         globalMiddlewareAfter,
       });
@@ -310,6 +334,8 @@ export const runBackendVerify = async (options = {}) => {
     : runBackendDbCheck({
       cwd,
       migrationsDir,
+      configPath,
+      projectConfig,
       failOnWarnings,
       runReplay: runDbReplay,
     });
@@ -317,6 +343,9 @@ export const runBackendVerify = async (options = {}) => {
   const test = runBackendTests({
     ...sharedOptions,
     setup,
+    configPath,
+    projectConfig,
+    globalMiddleware,
     globalMiddlewareBefore,
     globalMiddlewareAfter,
     config: testConfig,

--- a/packages/rettangoli-be/src/core/contracts/rpcFiles.js
+++ b/packages/rettangoli-be/src/core/contracts/rpcFiles.js
@@ -28,11 +28,20 @@ const isPlainObject = (value) => {
   return !!value && typeof value === 'object' && !Array.isArray(value);
 };
 
+const hasOwn = (object, key) => {
+  return isPlainObject(object) && Object.prototype.hasOwnProperty.call(object, key);
+};
+
 const createAjv = () => new Ajv({
   allErrors: true,
   strict: false,
   allowUnionTypes: true,
 });
+
+const CONTRACT_SCHEMA_VERSION = 'rettangoli.contract/v1';
+const EXAMPLES_SCHEMA_VERSION = 'rettangoli.examples/v1';
+const JSON_RPC_DOMAIN_ERROR_CODE = -32000;
+const JSON_RPC_VERSION = '2.0';
 
 const formatAjvErrors = (errors = []) => {
   return errors
@@ -116,6 +125,99 @@ const parseMethodFileMeta = (filePath = '', methodDirs = []) => {
     baseName,
     folderKey: `${domain}/${action}`,
     inferredMethod: `${domain}.${action}`,
+  };
+};
+
+const resolveSchemaContainer = (value) => {
+  if (isPlainObject(value) && isPlainObject(value.schema)) {
+    return value.schema;
+  }
+
+  return value;
+};
+
+const createEmptyParamsSchema = () => ({
+  type: 'object',
+  additionalProperties: false,
+  properties: {},
+  required: [],
+});
+
+const normalizeMiddlewareConfig = (rpcObject) => {
+  if (!hasOwn(rpcObject, 'middleware')) {
+    return {
+      before: [],
+      after: [],
+    };
+  }
+
+  if (!isPlainObject(rpcObject.middleware)) {
+    return rpcObject.middleware;
+  }
+
+  return {
+    ...rpcObject.middleware,
+    before: hasOwn(rpcObject.middleware, 'before') ? rpcObject.middleware.before : [],
+    after: hasOwn(rpcObject.middleware, 'after') ? rpcObject.middleware.after : [],
+  };
+};
+
+const normalizeRpcObject = ({ rpcObject, inferredMethod }) => {
+  if (!isPlainObject(rpcObject)) {
+    return rpcObject;
+  }
+
+  const normalized = {
+    ...rpcObject,
+    schemaVersion: hasOwn(rpcObject, 'schemaVersion') ? rpcObject.schemaVersion : CONTRACT_SCHEMA_VERSION,
+    method: rpcObject.method ?? rpcObject.id ?? inferredMethod,
+    middleware: normalizeMiddlewareConfig(rpcObject),
+    params: resolveSchemaContainer(rpcObject.params) ?? createEmptyParamsSchema(),
+    errors: hasOwn(rpcObject, 'errors') ? rpcObject.errors : {},
+  };
+
+  if (hasOwn(rpcObject, 'result')) {
+    normalized.result = resolveSchemaContainer(rpcObject.result);
+  }
+
+  return normalized;
+};
+
+const isExampleCaseDocument = (document) => {
+  return isPlainObject(document) && hasOwn(document, 'case');
+};
+
+const isExamplesConfigDocument = (document) => {
+  return isPlainObject(document)
+    && !isExampleCaseDocument(document)
+    && (
+      hasOwn(document, 'schemaVersion')
+      || hasOwn(document, 'file')
+      || hasOwn(document, 'group')
+      || hasOwn(document, 'runtime')
+      || hasOwn(document, 'mode')
+    );
+};
+
+const isExamplesSuiteDocument = (document) => {
+  return isPlainObject(document)
+    && !isExampleCaseDocument(document)
+    && (
+      hasOwn(document, 'suite')
+      || hasOwn(document, 'exportName')
+    );
+};
+
+const resolveExamplesDocuments = (documents = []) => {
+  const configDocument = isExamplesConfigDocument(documents[0]) ? documents[0] : {};
+  const suiteIndex = configDocument === documents[0] ? 1 : 0;
+  const suiteDocument = isExamplesSuiteDocument(documents[suiteIndex]) ? documents[suiteIndex] : {};
+  const caseDocuments = documents.filter(isExampleCaseDocument);
+
+  return {
+    configDocument,
+    suiteDocument,
+    caseDocuments,
   };
 };
 
@@ -267,7 +369,10 @@ export const buildRpcContractIndex = (entries = []) => {
     if (entry.fileType === 'rpc') {
       target.rpcObjects.push({
         filePath: entry.filePath,
-        rpcObject: entry.rpcObject,
+        rpcObject: normalizeRpcObject({
+          rpcObject: entry.rpcObject,
+          inferredMethod: entry.inferredMethod,
+        }),
       });
     }
 
@@ -283,20 +388,8 @@ export const buildRpcContractIndex = (entries = []) => {
 };
 
 const validateRpcRequiredKeys = (rpcObject, filePath, errors) => {
-  const requiredKeys = ['schemaVersion', 'method', 'description', 'middleware'];
-
-  requiredKeys.forEach((key) => {
-    if (!Object.prototype.hasOwnProperty.call(rpcObject, key)) {
-      errors.push({
-        code: 'RTGL-BE-CONTRACT-009',
-        message: `Missing required key '${key}' in RPC contract.`,
-        filePath,
-      });
-    }
-  });
-
-  ['params', 'result', 'errors'].forEach((key) => {
-    if (!Object.prototype.hasOwnProperty.call(rpcObject, key)) {
+  ['result'].forEach((key) => {
+    if (!hasOwn(rpcObject, key)) {
       errors.push({
         code: 'RTGL-BE-CONTRACT-009',
         message: `Missing required key '${key}' in RPC contract.`,
@@ -306,9 +399,9 @@ const validateRpcRequiredKeys = (rpcObject, filePath, errors) => {
   });
 };
 
-const resolveParamsSchema = (rpcObject) => rpcObject.params;
+const resolveParamsSchema = (rpcObject) => rpcObject.params ?? createEmptyParamsSchema();
 const resolveResultSchema = (rpcObject) => rpcObject.result;
-const resolveErrorCatalog = (rpcObject) => rpcObject.errors;
+const resolveErrorCatalog = (rpcObject) => rpcObject.errors ?? {};
 
 const validateMiddlewareConfig = ({ rpcObject, filePath, middlewareNames, errors }) => {
   const middleware = rpcObject.middleware;
@@ -437,9 +530,10 @@ const validateExamplesHeader = ({
   }
 
   const examplesFilePath = methodEntry.examplesDocuments[0].filePath;
-  const documents = methodEntry.examplesDocuments[0].documents;
-  const configDocument = documents[0];
-  const suiteDocument = documents[1];
+  const {
+    configDocument,
+    suiteDocument,
+  } = resolveExamplesDocuments(methodEntry.examplesDocuments[0].documents);
   const method = rpcObject.method;
   const expectedHandlerFile = `./${methodEntry.action}.handlers.js`;
 
@@ -454,17 +548,17 @@ const validateExamplesHeader = ({
     return;
   }
 
-  if (configDocument.schemaVersion !== 'rettangoli.examples/v1') {
+  if (hasOwn(configDocument, 'schemaVersion') && configDocument.schemaVersion !== EXAMPLES_SCHEMA_VERSION) {
     errors.push({
       code: 'RTGL-BE-CONTRACT-046',
       method,
-      message: 'Examples schemaVersion must be rettangoli.examples/v1.',
+      message: `Examples schemaVersion must be ${EXAMPLES_SCHEMA_VERSION}.`,
       filePath: examplesFilePath,
       jsonPointer: '/documents/0/schemaVersion',
     });
   }
 
-  if (configDocument.file !== expectedHandlerFile) {
+  if (hasOwn(configDocument, 'file') && configDocument.file !== expectedHandlerFile) {
     errors.push({
       code: 'RTGL-BE-CONTRACT-047',
       method,
@@ -474,7 +568,7 @@ const validateExamplesHeader = ({
     });
   }
 
-  if (typeof configDocument.group !== 'string' || !configDocument.group.trim()) {
+  if (hasOwn(configDocument, 'group') && (typeof configDocument.group !== 'string' || !configDocument.group.trim())) {
     errors.push({
       code: 'RTGL-BE-CONTRACT-046',
       method,
@@ -505,7 +599,7 @@ const validateExamplesHeader = ({
     return;
   }
 
-  if (typeof suiteDocument.suite !== 'string' || !suiteDocument.suite.trim()) {
+  if (hasOwn(suiteDocument, 'suite') && (typeof suiteDocument.suite !== 'string' || !suiteDocument.suite.trim())) {
     errors.push({
       code: 'RTGL-BE-CONTRACT-049',
       method,
@@ -515,7 +609,7 @@ const validateExamplesHeader = ({
     });
   }
 
-  if (typeof suiteDocument.exportName !== 'string' || !suiteDocument.exportName.trim()) {
+  if (hasOwn(suiteDocument, 'exportName') && (typeof suiteDocument.exportName !== 'string' || !suiteDocument.exportName.trim())) {
     errors.push({
       code: 'RTGL-BE-CONTRACT-049',
       method,
@@ -560,13 +654,6 @@ const createErrorSchemaFromCatalogEntry = ({ code, entry }) => {
   };
 };
 
-const JSON_RPC_DOMAIN_ERROR_CODE = -32000;
-const JSON_RPC_VERSION = '2.0';
-
-const hasOwn = (object, key) => {
-  return isPlainObject(object) && Object.prototype.hasOwnProperty.call(object, key);
-};
-
 const validateExamplesAgainstContract = ({
   methodEntry,
   rpcObject,
@@ -578,8 +665,7 @@ const validateExamplesAgainstContract = ({
   }
 
   const examplesFilePath = methodEntry.examplesDocuments[0].filePath;
-  const documents = methodEntry.examplesDocuments[0].documents;
-  const caseDocuments = documents.filter((doc) => isPlainObject(doc) && Object.prototype.hasOwnProperty.call(doc, 'case'));
+  const { caseDocuments } = resolveExamplesDocuments(methodEntry.examplesDocuments[0].documents);
   const ajv = createAjv();
 
   if (caseDocuments.length === 0) {
@@ -632,6 +718,10 @@ const validateExamplesAgainstContract = ({
     const caseName = typeof caseDoc.case === 'string' ? caseDoc.case : '<unnamed>';
     const input = Array.isArray(caseDoc.in) && isPlainObject(caseDoc.in[0]) ? caseDoc.in[0] : {};
     const request = caseDoc.request ?? input.request;
+    const requestMeta = isPlainObject(request) && hasOwn(request, 'meta') ? request.meta : undefined;
+    const throwsCode = typeof caseDoc.throws === 'string' && caseDoc.throws.trim()
+      ? caseDoc.throws
+      : undefined;
 
     if (caseDoc.proves?.result !== undefined && caseDoc.proves?.error !== undefined) {
       pushExampleError({
@@ -642,11 +732,59 @@ const validateExamplesAgainstContract = ({
       return;
     }
 
+    if (throwsCode && caseDoc.proves?.result !== undefined) {
+      pushExampleError({
+        code: 'RTGL-BE-CONTRACT-040',
+        caseName,
+        message: `RPC example '${caseName}' must not include both throws and proves.result.`,
+      });
+      return;
+    }
+
     if (!isPlainObject(request)) {
       pushExampleError({
         code: 'RTGL-BE-CONTRACT-050',
         caseName,
         message: `RPC example '${caseName}' must include a request object.`,
+      });
+      return;
+    }
+
+    if (hasOwn(caseDoc, 'meta') && requestMeta !== undefined) {
+      pushExampleError({
+        code: 'RTGL-BE-CONTRACT-050',
+        caseName,
+        message: `RPC example '${caseName}' must not include both top-level meta and request.meta.`,
+      });
+      return;
+    }
+
+    const meta = hasOwn(caseDoc, 'meta') ? caseDoc.meta : requestMeta ?? input.meta;
+    if (meta !== undefined && !isPlainObject(meta)) {
+      pushExampleError({
+        code: 'RTGL-BE-CONTRACT-050',
+        caseName,
+        message: `RPC example '${caseName}' meta must be an object when provided.`,
+      });
+      return;
+    }
+
+    const context = hasOwn(caseDoc, 'context') ? caseDoc.context : input.context;
+    if (context !== undefined && !isPlainObject(context)) {
+      pushExampleError({
+        code: 'RTGL-BE-CONTRACT-050',
+        caseName,
+        message: `RPC example '${caseName}' context must be an object when provided.`,
+      });
+      return;
+    }
+
+    const cookies = hasOwn(caseDoc, 'cookies') ? caseDoc.cookies : input.cookies;
+    if (cookies !== undefined && !isPlainObject(cookies)) {
+      pushExampleError({
+        code: 'RTGL-BE-CONTRACT-050',
+        caseName,
+        message: `RPC example '${caseName}' cookies must be an object when provided.`,
       });
       return;
     }
@@ -691,6 +829,30 @@ const validateExamplesAgainstContract = ({
 
     const output = caseDoc.out;
     if (!isPlainObject(output)) {
+      if (throwsCode) {
+        const errorEntry = errorCatalog[throwsCode];
+        if (!isPlainObject(errorEntry)) {
+          pushExampleError({
+            code: 'RTGL-BE-CONTRACT-031',
+            caseName,
+            message: `RPC example '${caseName}' uses undeclared error code '${throwsCode}'.`,
+          });
+          return;
+        }
+
+        if (caseDoc.proves?.error !== undefined && caseDoc.proves.error !== throwsCode) {
+          pushExampleError({
+            code: 'RTGL-BE-CONTRACT-034',
+            caseName,
+            message: `RPC example '${caseName}' proves.error '${caseDoc.proves.error}' does not match throws '${throwsCode}'.`,
+          });
+          return;
+        }
+
+        provedErrorCodes.add(throwsCode);
+        return;
+      }
+
       pushExampleError({
         code: 'RTGL-BE-CONTRACT-052',
         caseName,
@@ -759,17 +921,16 @@ const validateExamplesAgainstContract = ({
         });
       }
 
-      if (caseDoc.proves?.result !== 'success') {
+      if (caseDoc.proves?.result !== undefined && caseDoc.proves.result !== 'success') {
         pushExampleError({
           code: 'RTGL-BE-CONTRACT-029',
           caseName,
-          message: caseDoc.proves?.result === undefined
-            ? `RPC example '${caseName}' success output must include proves.result: success.`
-            : `RPC example '${caseName}' proves.result must be 'success'.`,
+          message: `RPC example '${caseName}' proves.result must be 'success'.`,
         });
-      } else {
-        provedSuccessCount += 1;
+        return;
       }
+
+      provedSuccessCount += 1;
       return;
     }
 
@@ -838,6 +999,15 @@ const validateExamplesAgainstContract = ({
       return;
     }
 
+    if (throwsCode !== undefined && throwsCode !== errorCode) {
+      pushExampleError({
+        code: 'RTGL-BE-CONTRACT-034',
+        caseName,
+        message: `RPC example '${caseName}' throws '${throwsCode}' does not match output code '${errorCode}'.`,
+      });
+      return;
+    }
+
     const errorValidator = compileSchemaForCheck({
       ajv,
       schema: createErrorSchemaFromCatalogEntry({ code: errorCode, entry: errorEntry }),
@@ -861,13 +1031,11 @@ const validateExamplesAgainstContract = ({
       });
     }
 
-    if (caseDoc.proves?.error !== errorCode) {
+    if (caseDoc.proves?.error !== undefined && caseDoc.proves.error !== errorCode) {
       pushExampleError({
         code: 'RTGL-BE-CONTRACT-034',
         caseName,
-        message: caseDoc.proves?.error === undefined
-          ? `RPC example '${caseName}' domain error output must include proves.error: ${errorCode}.`
-          : `RPC example '${caseName}' proves.error '${caseDoc.proves.error}' does not match output code '${errorCode}'.`,
+        message: `RPC example '${caseName}' proves.error '${caseDoc.proves.error}' does not match output code '${errorCode}'.`,
       });
       return;
     }
@@ -964,15 +1132,15 @@ export const validateRpcContractIndex = ({
 
     validateRpcRequiredKeys(rpcObject, filePath, errors);
 
-    if (rpcObject.schemaVersion !== 'rettangoli.contract/v1') {
+    if (rpcObject.schemaVersion !== CONTRACT_SCHEMA_VERSION) {
       errors.push({
         code: 'RTGL-BE-CONTRACT-023',
-        message: 'RPC schemaVersion must be rettangoli.contract/v1.',
+        message: `RPC schemaVersion must be ${CONTRACT_SCHEMA_VERSION}.`,
         filePath,
       });
     }
 
-    if (typeof rpcObject.description !== 'string' || !rpcObject.description.trim()) {
+    if (hasOwn(rpcObject, 'description') && (typeof rpcObject.description !== 'string' || !rpcObject.description.trim())) {
       errors.push({
         code: 'RTGL-BE-CONTRACT-008',
         message: 'RPC description must be a non-empty string.',
@@ -987,6 +1155,19 @@ export const validateRpcContractIndex = ({
         filePath,
       });
     } else {
+      if (
+        hasOwn(rpcObject, 'id')
+        && typeof rpcObject.id === 'string'
+        && rpcObject.id.trim()
+        && rpcObject.id !== rpcObject.method
+      ) {
+        errors.push({
+          code: 'RTGL-BE-CONTRACT-018',
+          message: `RPC id '${rpcObject.id}' must match method '${rpcObject.method}'.`,
+          filePath,
+        });
+      }
+
       if (rpcObject.method !== methodEntry.inferredMethod) {
         errors.push({
           code: 'RTGL-BE-CONTRACT-019',

--- a/packages/rettangoli-be/src/runtime/createApp.js
+++ b/packages/rettangoli-be/src/runtime/createApp.js
@@ -12,6 +12,10 @@ import { resolveSingleFunctionExport } from './resolveExports.js';
 
 const isPlainObject = (value) => !!value && typeof value === 'object' && !Array.isArray(value);
 
+const hasOwn = (object, key) => {
+  return isPlainObject(object) && Object.prototype.hasOwnProperty.call(object, key);
+};
+
 const normalizeSetup = (setup) => {
   if (!isPlainObject(setup)) {
     throw new Error('createApp: setup object is required');
@@ -115,13 +119,52 @@ const createErrorSchemaFromCatalog = (errors = {}) => {
   };
 };
 
+const resolveSchemaContainer = (value) => {
+  if (isPlainObject(value) && isPlainObject(value.schema)) {
+    return value.schema;
+  }
+
+  return value;
+};
+
+const createEmptyParamsSchema = () => ({
+  type: 'object',
+  additionalProperties: false,
+  properties: {},
+  required: [],
+});
+
+const normalizeRpcMiddleware = (middleware) => {
+  if (middleware === undefined) {
+    return {
+      before: [],
+      after: [],
+    };
+  }
+
+  if (!isPlainObject(middleware)) {
+    return middleware;
+  }
+
+  return {
+    ...middleware,
+    before: hasOwn(middleware, 'before') ? middleware.before : [],
+    after: hasOwn(middleware, 'after') ? middleware.after : [],
+  };
+};
+
 const normalizeRpcContract = (rpcContract) => {
-  const paramsSchema = rpcContract.params;
-  const resultSchema = rpcContract.result;
-  const errorSchema = createErrorSchemaFromCatalog(rpcContract.errors ?? {});
+  const paramsSchema = resolveSchemaContainer(rpcContract.params) ?? createEmptyParamsSchema();
+  const resultSchema = resolveSchemaContainer(rpcContract.result);
+  const errors = rpcContract.errors ?? {};
+  const errorSchema = createErrorSchemaFromCatalog(errors);
 
   return {
     ...rpcContract,
+    params: paramsSchema,
+    result: resultSchema,
+    errors,
+    middleware: normalizeRpcMiddleware(rpcContract.middleware),
     paramsSchema,
     resultSchema,
     errorSchema,

--- a/packages/rettangoli-be/src/runtime/createAppFromProject.js
+++ b/packages/rettangoli-be/src/runtime/createAppFromProject.js
@@ -6,21 +6,22 @@ import {
   formatContractFailureReport,
 } from '../core/contracts/rpcFiles.js';
 import { createApp } from './createApp.js';
+import { resolveSetupExport, resolveSetupValue } from './setup.js';
 
 const importModuleFromPath = async (filePath) => {
   const fileUrl = pathToFileURL(filePath).href;
   return import(fileUrl);
 };
 
-const loadSetup = async (setupPath) => {
+const loadSetup = async (setupPath, { cwd } = {}) => {
   const setupModule = await importModuleFromPath(setupPath);
+  const setupExport = resolveSetupExport(setupModule);
 
-  if (setupModule.setup) {
-    return setupModule.setup;
-  }
-
-  if (setupModule.default) {
-    return setupModule.default;
+  if (setupExport !== undefined) {
+    return resolveSetupValue(setupExport, {
+      cwd,
+      mode: 'runtime',
+    });
   }
 
   throw new Error(`createAppFromProject: setup export not found in ${setupPath}`);
@@ -101,6 +102,7 @@ export const createAppFromProject = async ({
   middlewareDeps = {},
   createRequestId,
   includeInternalErrorDetails = false,
+  setup,
 } = {}) => {
   const resolvedMethodDirs = methodDirs.map((dir) => path.resolve(cwd, dir));
   const resolvedMiddlewareDirs = middlewareDirs.map((dir) => path.resolve(cwd, dir));
@@ -153,7 +155,7 @@ export const createAppFromProject = async ({
     }));
   }
 
-  const setup = await loadSetup(resolvedSetupPath);
+  const resolvedSetup = setup ?? await loadSetup(resolvedSetupPath, { cwd });
 
   const methodContracts = {};
   const methodHandlers = {};
@@ -173,7 +175,7 @@ export const createAppFromProject = async ({
   }
 
   return createApp({
-    setup,
+    setup: resolvedSetup,
     methodContracts,
     methodHandlers,
     middlewareModules,

--- a/packages/rettangoli-be/src/runtime/createServerFromProject.js
+++ b/packages/rettangoli-be/src/runtime/createServerFromProject.js
@@ -6,6 +6,7 @@ import { createReadyExtension } from '../extensions/createReadyExtension.js';
 import { createVersionExtension } from '../extensions/createVersionExtension.js';
 import { createAppFromProject } from './createAppFromProject.js';
 import { loadBeProjectConfig } from './loadBeProjectConfig.js';
+import { resolveSetupExport, resolveSetupValue } from './setup.js';
 import { createHttpHandler } from '../transport/http/createHttpHandler.js';
 import { parseCookieHeader, serializeResponseCookies } from '../transport/http/cookies.js';
 
@@ -16,15 +17,15 @@ const importModuleFromPath = async (filePath) => {
   return import(fileUrl);
 };
 
-const loadSetup = async (setupPath) => {
+const loadSetup = async (setupPath, { cwd } = {}) => {
   const setupModule = await importModuleFromPath(setupPath);
+  const setupExport = resolveSetupExport(setupModule);
 
-  if (setupModule.setup) {
-    return setupModule.setup;
-  }
-
-  if (setupModule.default) {
-    return setupModule.default;
+  if (setupExport !== undefined) {
+    return resolveSetupValue(setupExport, {
+      cwd,
+      mode: 'server',
+    });
   }
 
   throw new Error(`createServerFromProject: setup export not found in ${setupPath}`);
@@ -196,17 +197,18 @@ export const createServerFromProject = async ({
   configPath = 'rettangoli.config.yaml',
 } = {}) => {
   const beConfig = loadBeProjectConfig({ cwd, configPath });
+  const setupPath = path.resolve(cwd, beConfig.setup);
+  const setup = await loadSetup(setupPath, { cwd });
   const app = await createAppFromProject({
     cwd,
     methodDirs: beConfig.dirs,
     middlewareDirs: [beConfig.middlewareDir],
     setupPath: beConfig.setup,
+    setup,
     globalMiddlewareBefore: beConfig.globalMiddleware.before,
     globalMiddlewareAfter: beConfig.globalMiddleware.after,
   });
 
-  const setupPath = path.resolve(cwd, beConfig.setup);
-  const setup = await loadSetup(setupPath);
   if (!isPlainObject(setup) || !isPlainObject(setup.deps)) {
     throw new Error('createServerFromProject: setup.deps is required');
   }

--- a/packages/rettangoli-be/src/runtime/setup.js
+++ b/packages/rettangoli-be/src/runtime/setup.js
@@ -1,0 +1,31 @@
+const hasOwn = (object, key) => {
+  return !!object && Object.prototype.hasOwnProperty.call(object, key);
+};
+
+export const resolveSetupExport = (setupModule) => {
+  if (hasOwn(setupModule, 'setup')) {
+    return setupModule.setup;
+  }
+
+  if (hasOwn(setupModule, 'createSetup')) {
+    return setupModule.createSetup;
+  }
+
+  if (hasOwn(setupModule, 'default')) {
+    return setupModule.default;
+  }
+
+  return undefined;
+};
+
+export const resolveSetupValue = async (setupExport, {
+  cwd = process.cwd(),
+  env = process.env,
+  mode = 'runtime',
+} = {}) => {
+  if (typeof setupExport === 'function') {
+    return setupExport({ cwd, env, mode });
+  }
+
+  return setupExport;
+};

--- a/packages/rettangoli-be/src/testing/examples.js
+++ b/packages/rettangoli-be/src/testing/examples.js
@@ -3,10 +3,12 @@ import { readFileSync } from 'node:fs';
 import { load as loadYaml, loadAll as loadAllYaml } from 'js-yaml';
 import { describe, expect, it } from 'vitest';
 import { createAppFromProject } from '../runtime/createAppFromProject.js';
+import { loadBeProjectConfig } from '../runtime/loadBeProjectConfig.js';
 import { stringifyStableJson } from '../cli/json.js';
 
 const isPlainObject = (value) => !!value && typeof value === 'object' && !Array.isArray(value);
 const JSON_RPC_VERSION = '2.0';
+const JSON_RPC_DOMAIN_ERROR_CODE = -32000;
 
 const hasOwn = (object, key) => {
   return isPlainObject(object) && Object.prototype.hasOwnProperty.call(object, key);
@@ -17,6 +19,44 @@ const readExampleDocuments = (yamlDir, yamlFile) => {
   const content = readFileSync(path.join(yamlDir, yamlFile), 'utf8');
   loadAllYaml(content, (doc) => documents.push(doc ?? {}));
   return documents;
+};
+
+const isExampleCaseDocument = (document) => {
+  return isPlainObject(document) && hasOwn(document, 'case');
+};
+
+const isExamplesConfigDocument = (document) => {
+  return isPlainObject(document)
+    && !isExampleCaseDocument(document)
+    && (
+      hasOwn(document, 'schemaVersion')
+      || hasOwn(document, 'file')
+      || hasOwn(document, 'group')
+      || hasOwn(document, 'runtime')
+      || hasOwn(document, 'mode')
+    );
+};
+
+const isExamplesSuiteDocument = (document) => {
+  return isPlainObject(document)
+    && !isExampleCaseDocument(document)
+    && (
+      hasOwn(document, 'suite')
+      || hasOwn(document, 'exportName')
+    );
+};
+
+const resolveExamplesDocuments = (documents = []) => {
+  const configDocument = isExamplesConfigDocument(documents[0]) ? documents[0] : {};
+  const suiteIndex = configDocument === documents[0] ? 1 : 0;
+  const suiteDocument = isExamplesSuiteDocument(documents[suiteIndex]) ? documents[suiteIndex] : {};
+  const caseDocuments = documents.filter(isExampleCaseDocument);
+
+  return {
+    configDocument,
+    suiteDocument,
+    caseDocuments,
+  };
 };
 
 const parseExampleDocumentsFromSource = (source) => {
@@ -30,19 +70,20 @@ const resolveExampleMethod = ({ yamlDir, configDocument, runtimeOptions }) => {
     return runtimeOptions.method;
   }
 
-  if (typeof configDocument.file !== 'string' || !configDocument.file.endsWith('.handlers.js')) {
-    return undefined;
-  }
+  const handlerFile = typeof configDocument.file === 'string' && configDocument.file.endsWith('.handlers.js')
+    ? configDocument.file
+    : `./${path.basename(yamlDir)}.handlers.js`;
 
   const contractPath = path.resolve(
     yamlDir,
-    configDocument.file.replace(/\.handlers\.js$/, '.contract.yaml'),
+    handlerFile.replace(/\.handlers\.js$/, '.contract.yaml'),
   );
 
   try {
     const contractDocument = loadYaml(readFileSync(contractPath, 'utf8')) ?? {};
-    return typeof contractDocument.method === 'string' && contractDocument.method
-      ? contractDocument.method
+    const method = contractDocument.method ?? contractDocument.id;
+    return typeof method === 'string' && method
+      ? method
       : undefined;
   } catch {
     return undefined;
@@ -81,16 +122,64 @@ const normalizeExpectedResponse = ({ response, request }) => {
 
 const createRpcDispatchInput = ({ caseDoc, method }) => {
   const input = Array.isArray(caseDoc.in) && isPlainObject(caseDoc.in[0]) ? caseDoc.in[0] : {};
+  const rawRequest = caseDoc.request ?? input.request;
+  const requestMeta = isPlainObject(rawRequest) && hasOwn(rawRequest, 'meta')
+    ? rawRequest.meta
+    : undefined;
+  const requestCookies = isPlainObject(rawRequest) && hasOwn(rawRequest, 'cookies')
+    ? rawRequest.cookies
+    : undefined;
+  const requestContext = isPlainObject(rawRequest) && hasOwn(rawRequest, 'context')
+    ? rawRequest.context
+    : undefined;
+  if (hasOwn(caseDoc, 'meta') && requestMeta !== undefined) {
+    throw new Error(`Rettangoli example '${caseDoc.case}' must not include both top-level meta and request.meta.`);
+  }
+  const requestWithoutRuntime = isPlainObject(rawRequest)
+    ? Object.fromEntries(
+      Object.entries(rawRequest)
+        .filter(([key]) => !['meta', 'cookies', 'context'].includes(key)),
+    )
+    : rawRequest;
   const request = normalizeExampleRequest({
-    request: caseDoc.request ?? input.request,
+    request: requestWithoutRuntime,
     method,
   });
   return {
     request,
-    meta: caseDoc.meta ?? input.meta,
-    cookies: caseDoc.cookies ?? input.cookies,
-    context: caseDoc.context ?? input.context,
+    meta: caseDoc.meta ?? requestMeta ?? input.meta,
+    cookies: caseDoc.cookies ?? requestCookies ?? input.cookies,
+    context: caseDoc.context ?? requestContext ?? input.context,
   };
+};
+
+const assertThrowsMatches = ({ caseDoc, request, actualResponse }) => {
+  const expectedCode = caseDoc.throws;
+  try {
+    expect(actualResponse?.jsonrpc).toBe(JSON_RPC_VERSION);
+    expect(actualResponse?.id).toBe(hasOwn(request, 'id') ? request.id : null);
+    expect(actualResponse?.error?.code).toBe(JSON_RPC_DOMAIN_ERROR_CODE);
+    expect(actualResponse?.error?.message).toBe('Domain error');
+    expect(actualResponse?.error?.data?.code).toBe(expectedCode);
+  } catch (error) {
+    error.message = createResponseMismatchMessage({
+      caseDoc,
+      expectedResponse: {
+        jsonrpc: JSON_RPC_VERSION,
+        id: hasOwn(request, 'id') ? request.id : null,
+        error: {
+          code: JSON_RPC_DOMAIN_ERROR_CODE,
+          message: 'Domain error',
+          data: {
+            code: expectedCode,
+          },
+        },
+      },
+      actualResponse,
+      assertionMessage: error.message,
+    });
+    throw error;
+  }
 };
 
 export const createResponseMismatchMessage = ({ caseDoc, expectedResponse, actualResponse, assertionMessage }) => [
@@ -134,7 +223,8 @@ const parseRuntimeEnvOptions = () => {
 const isRettangoliExamplesSource = (source) => {
   try {
     const documents = parseExampleDocumentsFromSource(source);
-    return documents[0]?.schemaVersion === 'rettangoli.examples/v1';
+    return documents[0]?.schemaVersion === 'rettangoli.examples/v1'
+      || documents.some(isExampleCaseDocument);
   } catch {
     return false;
   }
@@ -143,24 +233,35 @@ const isRettangoliExamplesSource = (source) => {
 const resolveRuntimeOptions = ({ configDocument, options }) => {
   const runtime = isPlainObject(configDocument.runtime) ? configDocument.runtime : {};
   const envOptions = parseRuntimeEnvOptions();
+  const cwd = runtime.cwd
+    ? path.resolve(process.cwd(), runtime.cwd)
+    : envOptions.cwd ?? options.cwd ?? process.cwd();
+  const projectConfig = loadBeProjectConfig({ cwd });
   return {
-    cwd: runtime.cwd ? path.resolve(process.cwd(), runtime.cwd) : envOptions.cwd ?? options.cwd ?? process.cwd(),
-    methodDirs: runtime.methodDirs ?? envOptions.methodDirs ?? options.methodDirs ?? ['./src/modules'],
-    middlewareDirs: runtime.middlewareDirs ?? envOptions.middlewareDirs ?? options.middlewareDirs ?? ['./src/middleware'],
-    setupPath: runtime.setupPath ?? envOptions.setupPath ?? options.setupPath ?? './src/setup.js',
+    cwd,
+    methodDirs: runtime.methodDirs ?? envOptions.methodDirs ?? options.methodDirs ?? projectConfig.dirs,
+    middlewareDirs: runtime.middlewareDirs ?? envOptions.middlewareDirs ?? options.middlewareDirs ?? [projectConfig.middlewareDir],
+    setupPath: runtime.setupPath ?? envOptions.setupPath ?? options.setupPath ?? projectConfig.setup,
     method: runtime.method ?? envOptions.method ?? options.method,
     globalMiddleware: runtime.globalMiddleware ?? envOptions.globalMiddleware ?? options.globalMiddleware ?? [],
-    globalMiddlewareBefore: runtime.globalMiddlewareBefore ?? envOptions.globalMiddlewareBefore ?? options.globalMiddlewareBefore ?? [],
-    globalMiddlewareAfter: runtime.globalMiddlewareAfter ?? envOptions.globalMiddlewareAfter ?? options.globalMiddlewareAfter ?? [],
+    globalMiddlewareBefore: runtime.globalMiddlewareBefore
+      ?? envOptions.globalMiddlewareBefore
+      ?? options.globalMiddlewareBefore
+      ?? projectConfig.globalMiddleware.before,
+    globalMiddlewareAfter: runtime.globalMiddlewareAfter
+      ?? envOptions.globalMiddlewareAfter
+      ?? options.globalMiddlewareAfter
+      ?? projectConfig.globalMiddleware.after,
   };
 };
 
 const setupRpcExamplesFromYaml = async (yamlDir, yamlFile, options = {}) => {
   const documents = readExampleDocuments(yamlDir, yamlFile);
-  const configDocument = documents[0] ?? {};
-  const suiteDocument = documents[1] ?? {};
-  const caseDocuments = documents
-    .filter((doc) => isPlainObject(doc) && Object.prototype.hasOwnProperty.call(doc, 'case'));
+  const {
+    configDocument,
+    suiteDocument,
+    caseDocuments,
+  } = resolveExamplesDocuments(documents);
   const runtimeOptions = resolveRuntimeOptions({ configDocument, options });
   const method = resolveExampleMethod({ yamlDir, configDocument, runtimeOptions });
   let appPromise;
@@ -174,6 +275,7 @@ const setupRpcExamplesFromYaml = async (yamlDir, yamlFile, options = {}) => {
       globalMiddleware: runtimeOptions.globalMiddleware,
       globalMiddlewareBefore: runtimeOptions.globalMiddlewareBefore,
       globalMiddlewareAfter: runtimeOptions.globalMiddlewareAfter,
+      includeInternalErrorDetails: true,
     });
     return appPromise;
   };
@@ -189,6 +291,15 @@ const setupRpcExamplesFromYaml = async (yamlDir, yamlFile, options = {}) => {
           request: dispatchInput.request,
         });
         const { response } = await app.dispatchWithContext(dispatchInput);
+        if (!isPlainObject(caseDoc.out) && typeof caseDoc.throws === 'string' && caseDoc.throws.trim()) {
+          assertThrowsMatches({
+            caseDoc,
+            request: dispatchInput.request,
+            actualResponse: response,
+          });
+          return;
+        }
+
         assertResponseMatches({
           caseDoc,
           expectedResponse,
@@ -201,9 +312,9 @@ const setupRpcExamplesFromYaml = async (yamlDir, yamlFile, options = {}) => {
 
 export const setupRettangoliExamplesFromYaml = async (yamlDir, yamlFile, options = {}) => {
   const documents = readExampleDocuments(yamlDir, yamlFile);
-  const configDocument = documents[0] ?? {};
+  const { configDocument } = resolveExamplesDocuments(documents);
 
-  if (configDocument?.schemaVersion !== 'rettangoli.examples/v1') {
+  if (hasOwn(configDocument, 'schemaVersion') && configDocument.schemaVersion !== 'rettangoli.examples/v1') {
     throw new Error(`Rettangoli examples must use schemaVersion rettangoli.examples/v1 in ${yamlFile}`);
   }
 

--- a/packages/rettangoli-be/test/cli/app.output.test.js
+++ b/packages/rettangoli-be/test/cli/app.output.test.js
@@ -241,6 +241,25 @@ describe('be app check command', () => {
     }));
   });
 
+  it('validates legacy global middleware', async () => {
+    const rootDir = mkdtempSync(path.join(tmpdir(), 'rtgl-be-app-check-legacy-global-middleware-'));
+    createdDirs.push(rootDir);
+    writeMethod(rootDir);
+    mkdirSync(path.join(rootDir, 'src', 'middleware'), { recursive: true });
+    writeFileSync(path.join(rootDir, 'src', 'middleware', 'globalLegacy.js'), 'export const globalLegacy = () => "not middleware";\n');
+
+    const result = await runBackendAppCheck({
+      cwd: rootDir,
+      globalMiddleware: ['globalLegacy'],
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.diagnostics[0]).toEqual(expect.objectContaining({
+      ruleId: 'RTGL-BE-APP-011',
+      filePath: 'src/middleware/globalLegacy.js',
+    }));
+  });
+
   it('validates configured global middleware in method scope', async () => {
     const rootDir = mkdtempSync(path.join(tmpdir(), 'rtgl-be-app-check-method-global-middleware-'));
     createdDirs.push(rootDir);
@@ -281,6 +300,67 @@ describe('be app check command', () => {
       ruleId: 'RTGL-BE-CONTRACT-021',
       phase: 'contracts',
       filePath: 'src/middleware/nested/globalBefore.js',
+    }));
+    expect(result.nextAction).toEqual(expect.objectContaining({
+      phase: 'contracts',
+      target: 'runtime-app',
+      argv: [
+        'rtgl',
+        'be',
+        'app',
+        'check',
+        '--method',
+        'health.ping',
+        '--json',
+      ],
+    }));
+  });
+
+  it('keeps ordinary contract failures on the check rerun surface when globals exist', async () => {
+    const rootDir = mkdtempSync(path.join(tmpdir(), 'rtgl-be-app-check-contract-with-global-'));
+    createdDirs.push(rootDir);
+    writeMethod(rootDir);
+    mkdirSync(path.join(rootDir, 'src', 'middleware'), { recursive: true });
+    writeFileSync(path.join(rootDir, 'src', 'middleware', 'globalBefore.js'), 'export const globalBefore = () => (next) => (ctx) => next(ctx);\n');
+    writeFileSync(path.join(rootDir, 'src', 'modules', 'health', 'ping', 'ping.contract.yaml'), [
+      'schemaVersion: rettangoli.contract/v1',
+      'method: health.other',
+      'description: ping',
+      'middleware:',
+      '  before: []',
+      '  after: []',
+      'params:',
+      '  type: object',
+      '  additionalProperties: false',
+      '  properties: {}',
+      '  required: []',
+      'result:',
+      '  type: object',
+      '  additionalProperties: false',
+      '  properties:',
+      '    ok:',
+      '      type: boolean',
+      '  required: [ok]',
+      'errors: {}',
+      '',
+    ].join('\n'));
+
+    const result = await runBackendAppCheck({
+      cwd: rootDir,
+      globalMiddlewareBefore: ['globalBefore'],
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.diagnostics[0].ruleId).toBe('RTGL-BE-CONTRACT-019');
+    expect(result.nextAction).toEqual(expect.objectContaining({
+      phase: 'contracts',
+      target: 'contract-package',
+      argv: ['rtgl', 'be', 'check', '--format', 'json'],
+      context: {
+        runtime: {
+          globalMiddlewareBefore: ['globalBefore'],
+        },
+      },
     }));
   });
 

--- a/packages/rettangoli-be/test/cli/build.output.test.js
+++ b/packages/rettangoli-be/test/cli/build.output.test.js
@@ -1,6 +1,7 @@
 import path from 'node:path';
 import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
+import { pathToFileURL } from 'node:url';
 import { afterEach, describe, expect, it } from 'vitest';
 import build from '../../src/cli/build.js';
 import {
@@ -92,7 +93,8 @@ describe('be build cli', () => {
     expect(existsSync(out.appEntryPath)).toBe(true);
 
     const appEntry = readFileSync(out.appEntryPath, 'utf8');
-    expect(appEntry).toContain('setupModule.setup ?? setupModule.default');
+    expect(appEntry).toContain('setupModule.setup ?? setupModule.createSetup ?? setupModule.default');
+    expect(appEntry).toContain("await setupExport({ cwd: process.cwd(), env: process.env, mode: 'generated' })");
   });
 
   it('creates a deterministic dry-run build plan without writing files', () => {
@@ -161,5 +163,104 @@ describe('be build cli', () => {
     build({ cwd: rootDir, silent: true });
     const currentFreshness = checkBackendBuildPlanFreshness(plan);
     expect(currentFreshness.ok).toBe(true);
+  });
+
+  it('generates an app entry with config global middleware parity', async () => {
+    const rootDir = mkdtempSync(path.join(process.cwd(), '.tmp-rtgl-be-build-runtime-'));
+    createdDirs.push(rootDir);
+
+    const srcDir = path.join(rootDir, 'src');
+    mkdirSync(path.join(srcDir, 'modules', 'health', 'ping'), { recursive: true });
+    mkdirSync(path.join(srcDir, 'middleware'), { recursive: true });
+    writeFileSync(path.join(rootDir, 'rettangoli.config.yaml'), [
+      'be:',
+      '  globalMiddleware:',
+      '    before: [withAuth]',
+      '',
+    ].join('\n'));
+    writeFileSync(path.join(srcDir, 'setup.js'), 'export const setup = { deps: { health: {} } };\n');
+    writeFileSync(path.join(srcDir, 'middleware', 'withAuth.js'), [
+      'export const withAuth = () => (next) => async (ctx) => {',
+      "  ctx.authUser = { userId: 'u-1' };",
+      '  return next(ctx);',
+      '};',
+      '',
+    ].join('\n'));
+    writeFileSync(path.join(srcDir, 'modules', 'health', 'ping', 'ping.handlers.js'), [
+      'export const healthPingMethod = async ({ context }) => ({',
+      '  ok: true,',
+      '  authUser: context.authUser.userId,',
+      '});',
+      '',
+    ].join('\n'));
+    writeFileSync(path.join(srcDir, 'modules', 'health', 'ping', 'ping.contract.yaml'), [
+      'schemaVersion: rettangoli.contract/v1',
+      'method: health.ping',
+      'description: ping',
+      'middleware:',
+      '  before: []',
+      '  after: []',
+      'params:',
+      '  type: object',
+      '  additionalProperties: false',
+      '  properties: {}',
+      '  required: []',
+      'result:',
+      '  type: object',
+      '  additionalProperties: false',
+      '  properties:',
+      '    ok:',
+      '      type: boolean',
+      '    authUser:',
+      '      type: string',
+      '  required: [ok, authUser]',
+      'errors: {}',
+      '',
+    ].join('\n'));
+    writeFileSync(path.join(srcDir, 'modules', 'health', 'ping', 'ping.examples.yaml'), [
+      'schemaVersion: rettangoli.examples/v1',
+      "file: './ping.handlers.js'",
+      'group: health-ping',
+      '---',
+      'suite: healthPingMethod',
+      'exportName: healthPingMethod',
+      '---',
+      'case: ok',
+      'proves:',
+      '  result: success',
+      'request:',
+      '  id: ok',
+      '  params: {}',
+      'out:',
+      '  result:',
+      '    ok: true',
+      '    authUser: u-1',
+      '',
+    ].join('\n'));
+
+    const out = build({ cwd: rootDir, silent: true });
+
+    const appEntry = readFileSync(out.appEntryPath, 'utf8');
+    expect(appEntry).toContain('globalMiddlewareBefore: ["withAuth"]');
+    expect(out.inputSourcePaths).toContain('rettangoli.config.yaml');
+
+    const appModule = await import(`${pathToFileURL(out.appEntryPath).href}?t=${Date.now()}`);
+    const { response } = await appModule.app.dispatchWithContext({
+      request: {
+        jsonrpc: '2.0',
+        id: 'auth',
+        method: 'health.ping',
+        params: {},
+      },
+    });
+
+    expect(response).toEqual({
+      jsonrpc: '2.0',
+      id: 'auth',
+      result: {
+        ok: true,
+        authUser: 'u-1',
+      },
+    });
   });
 });

--- a/packages/rettangoli-be/test/cli/check.output.test.js
+++ b/packages/rettangoli-be/test/cli/check.output.test.js
@@ -211,6 +211,111 @@ describe('be check cli output', () => {
     );
   });
 
+  it('accepts minimal contracts and headerless examples', () => {
+    const rootDir = mkdtempSync(path.join(tmpdir(), 'rtgl-be-check-minimal-'));
+    createdDirs.push(rootDir);
+    const methodDir = path.join(rootDir, 'src', 'modules', 'health', 'ping');
+    mkdirSync(methodDir, { recursive: true });
+    writeFileSync(path.join(methodDir, 'ping.handlers.js'), [
+      'export const healthPingMethod = async ({ payload }) => {',
+      '  if (payload.fail) return { _error: true, code: "UNAVAILABLE", details: { reason: "down" } };',
+      '  return { ok: true };',
+      '};',
+      '',
+    ].join('\n'));
+    writeFileSync(path.join(methodDir, 'ping.contract.yaml'), [
+      'id: health.ping',
+      'params:',
+      '  schema:',
+      '    type: object',
+      '    additionalProperties: false',
+      '    properties:',
+      '      fail:',
+      '        type: boolean',
+      '    required: []',
+      'result:',
+      '  schema:',
+      '    type: object',
+      '    additionalProperties: false',
+      '    properties:',
+      '      ok:',
+      '        type: boolean',
+      '    required: [ok]',
+      'errors:',
+      '  UNAVAILABLE:',
+      '    description: dependency is down',
+      '    details:',
+      '      type: object',
+      '      additionalProperties: false',
+      '      properties:',
+      '        reason:',
+      '          const: down',
+      '      required: [reason]',
+      '',
+    ].join('\n'));
+    writeFileSync(path.join(methodDir, 'ping.examples.yaml'), [
+      'case: ok',
+      'request:',
+      '  id: ok',
+      '  meta:',
+      '    tenantId: acme',
+      '  params: {}',
+      'out:',
+      '  result:',
+      '    ok: true',
+      '---',
+      'case: unavailable',
+      'request:',
+      '  id: unavailable',
+      '  params:',
+      '    fail: true',
+      'throws: UNAVAILABLE',
+      '',
+    ].join('\n'));
+
+    const result = runBackendCheck({
+      cwd: rootDir,
+      dirs: ['./src/modules'],
+      middlewareDir: './src/middleware',
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.methodCount).toBe(1);
+  });
+
+  it('rejects conflicting example meta aliases', () => {
+    const rootDir = mkdtempSync(path.join(tmpdir(), 'rtgl-be-check-meta-conflict-'));
+    createdDirs.push(rootDir);
+    writeMethodFiles({ rootDir, includeSpec: true });
+    const examplesPath = path.join(rootDir, 'src', 'modules', 'health', 'ping', 'ping.examples.yaml');
+    writeFileSync(examplesPath, [
+      ...exampleHeader(),
+      '---',
+      'case: ok',
+      'request:',
+      '  id: ok',
+      '  meta:',
+      '    tenantId: request',
+      '  params: {}',
+      'meta:',
+      '  tenantId: top',
+      'out:',
+      '  result:',
+      '    ok: true',
+      '',
+    ].join('\n'));
+
+    const result = runBackendCheck({
+      cwd: rootDir,
+      dirs: ['./src/modules'],
+      middlewareDir: './src/middleware',
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.errors[0].code).toBe('RTGL-BE-CONTRACT-050');
+    expect(result.errors[0].message).toContain('top-level meta and request.meta');
+  });
+
   it('checks one method in json format', () => {
     const rootDir = mkdtempSync(path.join(tmpdir(), 'rtgl-be-check-method-'));
     createdDirs.push(rootDir);
@@ -339,7 +444,7 @@ describe('be check cli output', () => {
     expect(parsed.errors.map((error) => error.code)).toContain('RTGL-BE-CONTRACT-048');
   });
 
-  it('requires a success proof example', () => {
+  it('infers success proof from result examples', () => {
     const rootDir = mkdtempSync(path.join(tmpdir(), 'rtgl-be-check-success-proof-'));
     createdDirs.push(rootDir);
     writeMethodFiles({ rootDir, includeSpec: true });
@@ -351,25 +456,16 @@ describe('be check cli output', () => {
       '',
     ].join('\n'));
 
-    const stdoutSpy = captureStdout();
-
-    check({
+    const result = runBackendCheck({
       cwd: rootDir,
       dirs: ['./src/modules'],
       middlewareDir: './src/middleware',
-      format: 'json',
     });
 
-    expect(process.exitCode).toBe(1);
-    const parsed = parseStdoutJson(stdoutSpy);
-    expect(parsed.errors.map((error) => error.code)).toContain('RTGL-BE-CONTRACT-029');
-    expect(parsed.errors.map((error) => error.code)).toContain('RTGL-BE-CONTRACT-037');
-    expect(parsed.diagnostics[0].method).toBe('health.ping');
-    expect(parsed.diagnostics[0].ruleId).toBe('RTGL-BE-CONTRACT-029');
-    expect(parsed.diagnostics[0].rerun.argv).toEqual(['rtgl', 'be', 'check', '--format', 'json']);
+    expect(result.ok).toBe(true);
   });
 
-  it('requires explicit error proof for declared domain errors', () => {
+  it('infers error proof from domain error examples', () => {
     const rootDir = mkdtempSync(path.join(tmpdir(), 'rtgl-be-check-error-proof-'));
     createdDirs.push(rootDir);
     writeMethodFiles({ rootDir, includeSpec: true });
@@ -408,19 +504,13 @@ describe('be check cli output', () => {
       '',
     ].join('\n'));
 
-    const stdoutSpy = captureStdout();
-
-    check({
+    const result = runBackendCheck({
       cwd: rootDir,
       dirs: ['./src/modules'],
       middlewareDir: './src/middleware',
-      format: 'json',
     });
 
-    expect(process.exitCode).toBe(1);
-    const parsed = parseStdoutJson(stdoutSpy);
-    expect(parsed.errors.map((error) => error.code)).toContain('RTGL-BE-CONTRACT-034');
-    expect(parsed.errors.map((error) => error.code)).toContain('RTGL-BE-CONTRACT-035');
+    expect(result.ok).toBe(true);
   });
 
   it('rejects examples that claim result and error proof at the same time', () => {
@@ -999,6 +1089,68 @@ describe('be check cli output', () => {
       './backend/methods',
       '--method',
       'health.ping',
+      '--json',
+    ]);
+  });
+
+  it('loads configured method dirs for package-level checks', () => {
+    const rootDir = mkdtempSync(path.join(tmpdir(), 'rtgl-be-check-config-dir-'));
+    createdDirs.push(rootDir);
+    writeMethodFiles({
+      rootDir,
+      includeSpec: true,
+      modulesDir: 'backend/methods',
+    });
+    writeFileSync(path.join(rootDir, 'rettangoli.config.yaml'), [
+      'be:',
+      '  dirs: [./backend/methods]',
+      '',
+    ].join('\n'));
+
+    const result = runBackendCheck({
+      cwd: rootDir,
+      format: 'json',
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.methodCount).toBe(1);
+    expect(result.scope).toEqual({
+      type: 'project',
+      methods: ['health.ping'],
+      provesProject: true,
+    });
+    expect(result.nextAction.argv).toEqual([
+      'rtgl',
+      'be',
+      'verify',
+      '--dir',
+      './backend/methods',
+      '--json',
+    ]);
+  });
+
+  it('normalizes singular dir option for package-level checks', () => {
+    const rootDir = mkdtempSync(path.join(tmpdir(), 'rtgl-be-check-singular-dir-'));
+    createdDirs.push(rootDir);
+    writeMethodFiles({
+      rootDir,
+      includeSpec: true,
+      modulesDir: 'backend/methods',
+    });
+
+    const result = runBackendCheck({
+      cwd: rootDir,
+      dir: './backend/methods',
+      format: 'json',
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.nextAction.argv).toEqual([
+      'rtgl',
+      'be',
+      'verify',
+      '--dir',
+      './backend/methods',
       '--json',
     ]);
   });

--- a/packages/rettangoli-be/test/cli/db.output.test.js
+++ b/packages/rettangoli-be/test/cli/db.output.test.js
@@ -4,6 +4,20 @@ import { tmpdir } from 'node:os';
 import { afterEach, describe, expect, it } from 'vitest';
 import { runBackendDbCheck } from '../../src/cli/db.js';
 
+const replayOk = () => ({
+  status: 0,
+  stdout: '',
+  stderr: '',
+  signal: null,
+});
+
+const replaySqlError = (message = 'Parse error: incomplete input') => () => ({
+  status: 1,
+  stdout: '',
+  stderr: message,
+  signal: null,
+});
+
 describe('be db check command', () => {
   const createdDirs = [];
 
@@ -34,7 +48,10 @@ describe('be db check command', () => {
       '',
     ].join('\n'));
 
-    const result = runBackendDbCheck({ cwd: rootDir });
+    const result = runBackendDbCheck({
+      cwd: rootDir,
+      replayCommand: replayOk,
+    });
 
     expect(result.schemaVersion).toBe('rettangoli.cliResult/v1');
     expect(result.artifactSchemaVersion).toBe('rettangoli.dbCheck/v1');
@@ -56,7 +73,20 @@ describe('be db check command', () => {
     expect(result.ok).toBe(false);
     expect(result.diagnostics[0]).toEqual(expect.objectContaining({
       ruleId: 'RTGL-BE-DB-001',
+      file: { path: 'migrations/nested/001_init.sql' },
+      filePath: 'migrations/nested/001_init.sql',
       migrationId: '001_init',
+      fix: 'Rename duplicate migration files so every migration id is unique.',
+      rerun: expect.objectContaining({
+        id: 'db',
+        argv: ['rtgl', 'be', 'db', 'check', '--json'],
+      }),
+    }));
+    expect(result.nextAction).toEqual(expect.objectContaining({
+      phase: 'db',
+      target: 'database-migrations',
+      files: ['migrations/nested/001_init.sql'],
+      argv: ['rtgl', 'be', 'db', 'check', '--json'],
     }));
     expect(result.replay).toEqual(expect.objectContaining({
       ok: false,
@@ -75,6 +105,7 @@ describe('be db check command', () => {
     const result = runBackendDbCheck({
       cwd: rootDir,
       replayTimeoutMs: 1000,
+      replayCommand: replaySqlError('Parse error near line 3: incomplete input'),
     });
     const elapsedMs = Date.now() - startedAt;
 
@@ -86,6 +117,7 @@ describe('be db check command', () => {
       migrationId: '001_bad',
     }));
     expect(result.diagnostics[0].message).toMatch(/incomplete input/i);
+    expect(result.diagnostics[0].message).not.toContain('spawnSync sqlite3 EPERM');
   });
 
   it('points replay failures at the failing migration file', () => {
@@ -95,13 +127,61 @@ describe('be db check command', () => {
     writeFileSync(path.join(rootDir, 'migrations', '001_ok.sql'), 'CREATE TABLE users (id TEXT PRIMARY KEY);\n');
     writeFileSync(path.join(rootDir, 'migrations', '002_bad.sql'), 'CREATE TABLE broken (\n');
 
-    const result = runBackendDbCheck({ cwd: rootDir });
+    let replayCount = 0;
+    const result = runBackendDbCheck({
+      cwd: rootDir,
+      replayCommand: () => {
+        replayCount += 1;
+        return replayCount === 1
+          ? replayOk()
+          : replaySqlError('Parse error near line 3: incomplete input')();
+      },
+    });
 
     expect(result.ok).toBe(false);
     expect(result.diagnostics[0]).toEqual(expect.objectContaining({
       ruleId: 'RTGL-BE-DB-003',
       filePath: 'migrations/002_bad.sql',
       migrationId: '002_bad',
+    }));
+    expect(result.diagnostics[0].message).not.toContain('spawnSync sqlite3 EPERM');
+  });
+
+  it('fails replay when sqlite spawn reports an error with status zero', () => {
+    const rootDir = mkdtempSync(path.join(tmpdir(), 'rtgl-be-db-spawn-error-status-zero-'));
+    createdDirs.push(rootDir);
+    mkdirSync(path.join(rootDir, 'migrations'), { recursive: true });
+    writeFileSync(path.join(rootDir, 'migrations', '001_ok.sql'), 'CREATE TABLE users (id TEXT PRIMARY KEY);\n');
+
+    const result = runBackendDbCheck({
+      cwd: rootDir,
+      replayCommand: () => ({
+        status: 0,
+        stdout: '',
+        stderr: '',
+        signal: null,
+        error: Object.assign(new Error('spawnSync sqlite3 EPERM'), {
+          code: 'EPERM',
+        }),
+      }),
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.replay).toEqual(expect.objectContaining({
+      ok: false,
+      exitCode: 1,
+      timedOut: false,
+    }));
+    expect(result.diagnostics[0]).toEqual(expect.objectContaining({
+      ruleId: 'RTGL-BE-DB-003',
+      filePath: 'migrations/001_ok.sql',
+      migrationId: '001_ok',
+    }));
+    expect(result.diagnostics[0].message).toContain('spawnSync sqlite3 EPERM');
+    expect(result.nextAction).toEqual(expect.objectContaining({
+      phase: 'db',
+      target: 'database-migrations',
+      argv: ['rtgl', 'be', 'db', 'check', '--json'],
     }));
   });
 
@@ -115,16 +195,71 @@ describe('be db check command', () => {
       '',
     ].join('\n'));
 
-    const defaultResult = runBackendDbCheck({ cwd: rootDir });
+    const defaultResult = runBackendDbCheck({
+      cwd: rootDir,
+      replayCommand: replayOk,
+    });
     const strictResult = runBackendDbCheck({
       cwd: rootDir,
       failOnWarnings: true,
+      replayCommand: replayOk,
     });
 
     expect(defaultResult.ok).toBe(true);
     expect(defaultResult.warningCount).toBe(1);
     expect(defaultResult.errorCount).toBe(0);
+    expect(defaultResult.diagnostics[0]).toEqual(expect.objectContaining({
+      ruleId: 'RTGL-BE-DB-002',
+      severity: 'warning',
+      file: { path: 'migrations/001_drop.sql' },
+      fix: 'Review the destructive migration statement and make the migration policy explicit.',
+    }));
     expect(strictResult.ok).toBe(false);
     expect(strictResult.failOnWarnings).toBe(true);
+    expect(strictResult.nextAction).toEqual(expect.objectContaining({
+      phase: 'db',
+      target: 'database-migrations',
+      files: ['migrations/001_drop.sql'],
+      argv: ['rtgl', 'be', 'db', 'check', '--fail-on-warnings', '--json'],
+    }));
+  });
+
+  it('loads configured migrations dir for package-level db checks', () => {
+    const rootDir = mkdtempSync(path.join(tmpdir(), 'rtgl-be-db-config-dir-'));
+    createdDirs.push(rootDir);
+    mkdirSync(path.join(rootDir, 'database', 'sql'), { recursive: true });
+    writeFileSync(path.join(rootDir, 'rettangoli.config.yaml'), [
+      'be:',
+      '  migrationsDir: ./database/sql',
+      '',
+    ].join('\n'));
+    writeFileSync(path.join(rootDir, 'database', 'sql', '001_init.sql'), 'CREATE TABLE users (id TEXT PRIMARY KEY);\n');
+
+    const result = runBackendDbCheck({
+      cwd: rootDir,
+      runReplay: () => ({
+        ok: true,
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        stdout: '',
+        stderr: '',
+      }),
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.migrationsDir).toBe('./database/sql');
+    expect(result.migrations.map((migration) => migration.path)).toEqual([
+      'database/sql/001_init.sql',
+    ]);
+    expect(result.commands.find((command) => command.id === 'db').argv).toEqual([
+      'rtgl',
+      'be',
+      'db',
+      'check',
+      '--migrations-dir',
+      './database/sql',
+      '--json',
+    ]);
   });
 });

--- a/packages/rettangoli-be/test/cli/test.command.test.js
+++ b/packages/rettangoli-be/test/cli/test.command.test.js
@@ -4,8 +4,8 @@ import { tmpdir } from 'node:os';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { runBackendTests } from '../../src/cli/test.js';
 
-const writeMethod = (rootDir) => {
-  const methodDir = path.join(rootDir, 'src', 'modules', 'health', 'ping');
+const writeMethod = (rootDir, { modulesDir = 'src/modules' } = {}) => {
+  const methodDir = path.join(rootDir, modulesDir, 'health', 'ping');
   mkdirSync(methodDir, { recursive: true });
 
   writeFileSync(path.join(rootDir, 'vitest.config.js'), 'export default {};\n');
@@ -196,6 +196,50 @@ describe('be test command', () => {
     });
   });
 
+  it('loads configured method dirs for package-level tests', () => {
+    const rootDir = mkdtempSync(path.join(tmpdir(), 'rtgl-be-test-config-dir-'));
+    createdDirs.push(rootDir);
+    writeMethod(rootDir, { modulesDir: 'backend/methods' });
+    writeFileSync(path.join(rootDir, 'rettangoli.config.yaml'), [
+      'be:',
+      '  dirs: [./backend/methods]',
+      '',
+    ].join('\n'));
+
+    const runCommand = vi.fn(() => ({
+      status: 0,
+      stdout: 'ok',
+      stderr: '',
+    }));
+
+    const result = runBackendTests({
+      cwd: rootDir,
+      format: 'json',
+      env: {},
+      runCommand,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.files).toEqual(['backend/methods/health/ping/ping.examples.yaml']);
+    expect(result.commands.find((command) => command.id === 'test').argv).toEqual([
+      'rtgl',
+      'be',
+      'test',
+      '--dir',
+      './backend/methods',
+      '--json',
+    ]);
+    expect(JSON.parse(runCommand.mock.calls[0][2].env.RTGL_BE_EXAMPLES_RUNTIME)).toEqual({
+      cwd: rootDir,
+      methodDirs: ['./backend/methods'],
+      middlewareDirs: ['./src/middleware'],
+      setupPath: './src/setup.js',
+      globalMiddleware: [],
+      globalMiddlewareBefore: [],
+      globalMiddlewareAfter: [],
+    });
+  });
+
   it('follows caller package manager when resolving the Vitest runner', () => {
     const rootDir = mkdtempSync(path.join(tmpdir(), 'rtgl-be-test-runner-'));
     createdDirs.push(rootDir);
@@ -267,6 +311,12 @@ describe('be test command', () => {
       'pnpm',
       '--json',
     ]);
+    expect(result.commands.find((command) => command.id === 'test').context).toEqual({
+      runtime: {
+        globalMiddlewareBefore: ['globalBefore'],
+        globalMiddlewareAfter: ['globalAfter'],
+      },
+    });
     expect(result.nextAction.argv).toEqual([
       'rtgl',
       'be',
@@ -285,6 +335,12 @@ describe('be test command', () => {
       'pnpm',
       '--json',
     ]);
+    expect(result.nextAction.context).toEqual({
+      runtime: {
+        globalMiddlewareBefore: ['globalBefore'],
+        globalMiddlewareAfter: ['globalAfter'],
+      },
+    });
     expect(JSON.parse(runCommand.mock.calls[0][2].env.RTGL_BE_EXAMPLES_RUNTIME)).toEqual({
       cwd: rootDir,
       method: 'health.ping',
@@ -401,16 +457,125 @@ describe('be test command', () => {
       format: 'json',
       executable: 'custom-runner',
       runCommand: vi.fn(() => ({
-        status: 0,
+        status: null,
         stdout: '',
         stderr: '',
-        error: new Error('spawn custom-runner ENOENT'),
+        error: Object.assign(new Error('spawn custom-runner ENOENT'), {
+          code: 'ENOENT',
+        }),
       })),
     });
 
     expect(result.ok).toBe(false);
+    expect(result.exitCode).toBe(1);
+    expect(result.phase).toBe('runner');
+    expect(result.diagnostics[0].ruleId).toBe('RTGL-BE-RUNNER-001');
+    expect(result.diagnostics[0].phase).toBe('runner');
     expect(result.diagnostics[0].message).toContain('spawn custom-runner ENOENT');
     expect(result.diagnostics[0].outputTail.stderr).toContain('spawn custom-runner ENOENT');
+    expect(result.diagnostics[0].runner.errorCode).toBe('ENOENT');
+    expect(result.diagnostics[0].files).toEqual([]);
+    expect(result.diagnostics[0].executedFiles).toEqual([]);
+    expect(result.nextAction).toEqual(expect.objectContaining({
+      phase: 'runner',
+      target: 'test-runner',
+      files: [],
+      argv: [
+        'rtgl',
+        'be',
+        'test',
+        '--runner',
+        'custom-runner',
+        '--json',
+      ],
+    }));
+  });
+
+  it('fails runner process errors even when spawn reports status zero', () => {
+    const rootDir = mkdtempSync(path.join(tmpdir(), 'rtgl-be-test-runner-warning-'));
+    createdDirs.push(rootDir);
+    writeMethod(rootDir);
+
+    const result = runBackendTests({
+      cwd: rootDir,
+      format: 'json',
+      env: {},
+      runCommand: vi.fn(() => ({
+        status: 0,
+        stdout: 'ok',
+        stderr: '',
+        error: Object.assign(new Error('spawnSync npm EPERM'), {
+          code: 'EPERM',
+        }),
+      })),
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.exitCode).toBe(1);
+    expect(result.phase).toBe('runner');
+    expect(result.diagnostics[0]).toEqual(expect.objectContaining({
+      ruleId: 'RTGL-BE-RUNNER-001',
+      phase: 'runner',
+      message: 'Backend example runner failed: spawnSync npm EPERM',
+    }));
+    expect(result.diagnostics[0].runner).toEqual(expect.objectContaining({
+      executable: 'npm',
+      errorCode: 'EPERM',
+      status: 0,
+    }));
+    expect(result.nextAction).toEqual(expect.objectContaining({
+      phase: 'runner',
+      target: 'test-runner',
+    }));
+  });
+
+  it('routes runtime contract failures from examples to app check', () => {
+    const rootDir = mkdtempSync(path.join(tmpdir(), 'rtgl-be-test-runtime-contract-fail-'));
+    createdDirs.push(rootDir);
+    writeMethod(rootDir);
+
+    const result = runBackendTests({
+      cwd: rootDir,
+      method: 'health.ping',
+      format: 'json',
+      runCommand: vi.fn(() => ({
+        status: 1,
+        stdout: '',
+        stderr: [
+          '[Runtime] RPC contract validation failed: 1 issue(s)',
+          'Details:',
+          "RTGL-BE-CONTRACT-021 Duplicate middleware name 'globalAuth' found. [src/middleware/globalAuth.js]",
+          '',
+        ].join('\n'),
+      })),
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.phase).toBe('app');
+    expect(result.diagnostics[0]).toEqual(expect.objectContaining({
+      ruleId: 'RTGL-BE-CONTRACT-021',
+      phase: 'app',
+      filePath: 'src/middleware/globalAuth.js',
+    }));
+    expect(result.nextAction).toEqual(expect.objectContaining({
+      phase: 'app',
+      target: 'runtime-app',
+      files: [
+        'src/middleware/globalAuth.js',
+        'src/modules/health/ping/ping.contract.yaml',
+        'src/modules/health/ping/ping.examples.yaml',
+        'src/modules/health/ping/ping.handlers.js',
+      ],
+      argv: [
+        'rtgl',
+        'be',
+        'app',
+        'check',
+        '--method',
+        'health.ping',
+        '--json',
+      ],
+    }));
   });
 
   it('does not run Vitest when no backend examples are found', () => {

--- a/packages/rettangoli-be/test/cli/verify.output.test.js
+++ b/packages/rettangoli-be/test/cli/verify.output.test.js
@@ -162,6 +162,106 @@ describe('be verify output', () => {
     expect(runCommand).toHaveBeenCalledOnce();
   });
 
+  it('loads custom project config for package-level verification', async () => {
+    const rootDir = mkdtempSync(path.join(tmpdir(), 'rtgl-be-verify-config-'));
+    createdDirs.push(rootDir);
+    writeProject(rootDir, { modulesDir: 'backend/methods' });
+    mkdirSync(path.join(rootDir, 'backend', 'middleware'), { recursive: true });
+    writeFileSync(path.join(rootDir, 'backend', 'setup.js'), 'export const setup = { deps: { health: {} } };\n');
+    writeFileSync(path.join(rootDir, 'backend', 'middleware', 'withAuth.js'), [
+      'export const withAuth = () => (next) => async (ctx) => next(ctx);',
+      '',
+    ].join('\n'));
+    writeFileSync(path.join(rootDir, 'vitest.custom.js'), 'export default {};\n');
+    writeFileSync(path.join(rootDir, 'custom-be.yaml'), [
+      'be:',
+      '  dirs: [./backend/methods]',
+      '  middlewareDir: ./backend/middleware',
+      '  setup: ./backend/setup.js',
+      '  outdir: ./backend/generated',
+      '  migrationsDir: ./database/sql',
+      '  globalMiddleware:',
+      '    before: [withAuth]',
+      '',
+    ].join('\n'));
+
+    const runCommand = vi.fn(() => ({
+      status: 0,
+      stdout: '',
+      stderr: '',
+    }));
+
+    const result = await runBackendVerify({
+      cwd: rootDir,
+      configPath: './custom-be.yaml',
+      testConfig: './vitest.custom.js',
+      env: {},
+      runCommand,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.commands.find((command) => command.id === 'check').argv).toEqual([
+      'rtgl',
+      'be',
+      'check',
+      '--dir',
+      './backend/methods',
+      '--middleware-dir',
+      './backend/middleware',
+      '--format',
+      'json',
+    ]);
+    expect(result.commands.find((command) => command.id === 'verify').argv).toEqual([
+      'rtgl',
+      'be',
+      'verify',
+      '--dir',
+      './backend/methods',
+      '--middleware-dir',
+      './backend/middleware',
+      '--setup-path',
+      './backend/setup.js',
+      '--outdir',
+      './backend/generated',
+      '--migrations-dir',
+      './database/sql',
+      '--test-config',
+      './vitest.custom.js',
+      '--json',
+    ]);
+    expect(result.commands.find((command) => command.id === 'verify').context).toEqual({
+      configPath: './custom-be.yaml',
+      runtime: {
+        globalMiddlewareBefore: ['withAuth'],
+      },
+    });
+    expect(result.nextAction.context).toEqual({
+      configPath: './custom-be.yaml',
+      runtime: {
+        globalMiddlewareBefore: ['withAuth'],
+      },
+    });
+    expect(result.files.shared).toEqual(expect.arrayContaining([
+      'backend/setup.js',
+      'custom-be.yaml',
+      'vitest.custom.js',
+    ]));
+    expect(result.build.plan.outdir).toBe('backend/generated');
+    expect(result.build.plan.targets[0].inputSourcePaths).toContain('custom-be.yaml');
+    expect(result.app.files).toContain('backend/middleware/withAuth.js');
+    expect(result.db.migrationsDir).toBe('./database/sql');
+    expect(result.test.files).toEqual(['backend/methods/health/ping/ping.examples.yaml']);
+    expect(JSON.parse(runCommand.mock.calls[0][2].env.RTGL_BE_EXAMPLES_RUNTIME)).toEqual({
+      cwd: rootDir,
+      methodDirs: ['./backend/methods'],
+      middlewareDirs: ['./backend/middleware'],
+      setupPath: './backend/setup.js',
+      globalMiddleware: [],
+      globalMiddlewareBefore: ['withAuth'],
+      globalMiddlewareAfter: [],
+    });
+  });
+
   it('keeps method-scoped verify isolated from unrelated broken methods', async () => {
     const rootDir = mkdtempSync(path.join(tmpdir(), 'rtgl-be-verify-scoped-'));
     createdDirs.push(rootDir);
@@ -449,6 +549,16 @@ describe('be verify output', () => {
     const result = await runBackendVerify({
       cwd: rootDir,
       runCommand,
+      runDbReplay: () => ({
+        ok: false,
+        exitCode: 1,
+        signal: null,
+        timedOut: false,
+        stdout: '',
+        stderr: 'Parse error near line 3: incomplete input',
+        migrationId: '002_bad',
+        migrationPath: 'migrations/002_bad.sql',
+      }),
     });
 
     expect(result.ok).toBe(false);
@@ -537,7 +647,7 @@ describe('be verify output', () => {
       '  params: {}',
       'out:',
       '  result:',
-      '    ok: true',
+      '    wrong: true',
       '',
     ].join('\n'));
 
@@ -558,7 +668,7 @@ describe('be verify output', () => {
     expect(result.failedPhase).toBe('check');
     expect(result.build).toBeUndefined();
     expect(result.test).toBeUndefined();
-    expect(result.diagnostics.map((diagnostic) => diagnostic.ruleId)).toContain('RTGL-BE-CONTRACT-029');
+    expect(result.diagnostics.map((diagnostic) => diagnostic.ruleId)).toContain('RTGL-BE-CONTRACT-028');
     expect(result.diagnostics[0].filePath).toBe('src/modules/health/ping/ping.examples.yaml');
     expect(result.nextAction.argv).toEqual([
       'rtgl',
@@ -590,7 +700,7 @@ describe('be verify output', () => {
       '  params: {}',
       'out:',
       '  result:',
-      '    ok: true',
+      '    wrong: true',
       '',
     ].join('\n'));
 

--- a/packages/rettangoli-be/test/runtime/create-app-from-project.test.js
+++ b/packages/rettangoli-be/test/runtime/create-app-from-project.test.js
@@ -226,6 +226,88 @@ describe('createAppFromProject', () => {
     expect(response.result.ok).toBe(true);
   });
 
+  it('supports async setup factory exports', async () => {
+    const rootDir = mkdtempSync(path.join(tmpdir(), 'rtgl-be-app-setup-factory-'));
+    createdDirs.push(rootDir);
+
+    const srcDir = path.join(rootDir, 'src');
+    mkdirSync(srcDir, { recursive: true });
+
+    writeFileSync(path.join(srcDir, 'setup.js'), [
+      'export const createSetup = async ({ cwd, mode }) => ({',
+      '  deps: {',
+      '    health: {',
+      '      cwd,',
+      '      mode,',
+      '    },',
+      '  },',
+      '});',
+      '',
+    ].join('\n'));
+
+    const methodDir = path.join(srcDir, 'modules', 'health', 'ping');
+    mkdirSync(methodDir, { recursive: true });
+
+    writeFileSync(path.join(methodDir, 'ping.handlers.js'), [
+      'export const healthPingMethod = async ({ deps }) => ({',
+      '  ok: true,',
+      '  cwd: deps.cwd,',
+      '  mode: deps.mode,',
+      '});',
+      '',
+    ].join('\n'));
+    writeFileSync(path.join(methodDir, 'ping.contract.yaml'), [
+      'id: health.ping',
+      'result:',
+      '  schema:',
+      '    type: object',
+      '    additionalProperties: false',
+      '    properties:',
+      '      ok:',
+      '        type: boolean',
+      '      cwd:',
+      '        type: string',
+      '      mode:',
+      '        type: string',
+      '    required: [ok, cwd, mode]',
+      '',
+    ].join('\n'));
+    writeFileSync(path.join(methodDir, 'ping.examples.yaml'), [
+      'case: ok',
+      'request:',
+      '  id: ok',
+      '  params: {}',
+      'out:',
+      '  result:',
+      '    ok: true',
+      `    cwd: ${rootDir}`,
+      '    mode: runtime',
+      '',
+    ].join('\n'));
+
+    const app = await createAppFromProject({
+      cwd: rootDir,
+      methodDirs: ['./src/modules'],
+      middlewareDirs: ['./src/middleware'],
+      setupPath: './src/setup.js',
+    });
+
+    const response = await app.dispatch({
+      request: {
+        jsonrpc: '2.0',
+        id: '1',
+        method: 'health.ping',
+        params: {},
+      },
+    });
+
+    expect(response.result).toEqual({
+      ok: true,
+      cwd: rootDir,
+      mode: 'runtime',
+    });
+  });
+
   it('scopes runtime construction to one method', async () => {
     const rootDir = mkdtempSync(path.join(tmpdir(), 'rtgl-be-app-scoped-'));
     createdDirs.push(rootDir);


### PR DESCRIPTION
## Summary
- add project option resolution across backend check/build/app/db/test/verify flows
- simplify backend contracts/examples with defaults, id alias, nested schemas, headerless examples, inferred proofs, and throws-based domain error examples
- support request.meta example alias, async createSetup factories, generated app parity, and stronger runner/db diagnostics
- update scaffold output and coverage for agent-friendly backend workflows

## Validation
- npm exec -- vitest run test/cli/check.output.test.js test/runtime/create-app-from-project.test.js test/cli/build.output.test.js test/cli/test.command.test.js test/cli/verify.output.test.js --reporter=verbose --config vitest.config.js
- npm exec -- vitest run test/cli/app.output.test.js test/cli/build.output.test.js test/cli/check.output.test.js test/cli/db.output.test.js test/cli/test.command.test.js test/cli/verify.output.test.js test/runtime/create-app-from-project.test.js test/testing/examples.output.test.js --reporter=verbose --config vitest.config.js
- non-trivial temp app using minimal contract/example format: check, app check, build, db check, examples test, generated dispatch, verify all passed
- npm test: 128 passed; 4 server listen tests failed in sandbox with listen EPERM
- npm exec -- vitest run test/runtime/create-server-from-project.test.js --reporter=verbose --config vitest.config.js passed outside sandbox