### PR TITLE
Release backend packages 2.0.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
     },
     "packages/rettangoli-be": {
       "name": "@rettangoli/be",
-      "version": "1.1.0",
+      "version": "2.0.0",
       "dependencies": {
         "ajv": "^8.17.1",
         "chokidar": "^4.0.3",
@@ -40,12 +40,12 @@
     },
     "packages/rettangoli-cli": {
       "name": "rtgl",
-      "version": "1.5.0",
+      "version": "2.0.0",
       "bin": {
         "rtgl": "cli.js",
       },
       "dependencies": {
-        "@rettangoli/be": "1.1.0",
+        "@rettangoli/be": "2.0.0",
         "@rettangoli/check": "0.1.2",
         "@rettangoli/fe": "1.2.0",
         "@rettangoli/sites": "1.2.0",

--- a/packages/rettangoli-be/package.json
+++ b/packages/rettangoli-be/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rettangoli/be",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "Backend framework for Rettangoli JSON-RPC applications",
   "type": "module",
   "main": "./src/index.js",

--- a/packages/rettangoli-cli/package.json
+++ b/packages/rettangoli-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rtgl",
-  "version": "1.5.0",
+  "version": "2.0.0",
   "description": "CLI tool for Rettangoli - A frontend framework and development toolkit",
   "type": "module",
   "bin": {
@@ -48,7 +48,7 @@
     "commander": "^14.0.0",
     "js-yaml": "^4.1.0",
     "@rettangoli/check": "0.1.2",
-    "@rettangoli/be": "1.1.0",
+    "@rettangoli/be": "2.0.0",
     "@rettangoli/fe": "1.2.0",
     "@rettangoli/sites": "1.2.0",
     "@rettangoli/vt": "1.0.5",


### PR DESCRIPTION
Summary: bump @rettangoli/be to 2.0.0, bump rtgl to 2.0.0, point rtgl at @rettangoli/be 2.0.0, and refresh bun.lock. Verification: bun install passed; npm test passed 128 tests with only the known sandbox EPERM server bind failures; server test slice passed outside sandbox; node ../rettangoli-cli/cli.js be --help passed.