### PR TITLE
Fix outline button background

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -113,7 +113,7 @@
     },
     "packages/rettangoli-ui": {
       "name": "@rettangoli/ui",
-      "version": "1.9.0",
+      "version": "1.9.1",
       "dependencies": {
         "@rettangoli/fe": "1.2.0",
         "jempl": "1.0.1",

--- a/packages/rettangoli-ui/package.json
+++ b/packages/rettangoli-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rettangoli/ui",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "A UI component library for building web interfaces.",
   "main": "dist/rettangoli-esm.min.js",
   "type": "module",

--- a/packages/rettangoli-ui/src/styles/buttonMarginStyles.js
+++ b/packages/rettangoli-ui/src/styles/buttonMarginStyles.js
@@ -57,7 +57,7 @@ const styles = {
       color: var(--primary-foreground);
     `,
     ol: `
-      background-color: transparent;
+      background-color: var(--background);
       color: var(--foreground);
       border-width: 1px;
     `,


### PR DESCRIPTION
## Summary

- use the theme background token for outline button surfaces
- keep ghost and link button backgrounds transparent
- bump @rettangoli/ui from 1.9.0 to 1.9.1

## Validation

- bun run test (142 tests passed)
- bun run build:dev
- focused generated-style assertion for the outline variant

## Known repository check

- bun run check:contracts currently reports 239 pre-existing component identity and primitive registry diagnostics unrelated to this change