### PR TITLE
feat(fe): support public directory in watch mode

### DIFF
--- a/apps/rettangoli.dev/pages/fe/docs/guides/cli.md
+++ b/apps/rettangoli.dev/pages/fe/docs/guides/cli.md
@@ -48,6 +48,18 @@ rtgl fe watch
 
 Uses Vite (`vite.createServer`) for dev serving and full reload on FE file changes. Component directories, the setup module, and i18n sources are watched explicitly, including when they are outside the served static root.
 
+Use `fe.publicDir` to serve a directory of static assets at `/` without Vite
+transformations:
+
+```yaml
+fe:
+  publicDir: "./static"
+```
+
+The equivalent CLI option is `rtgl fe watch --public-dir ./static`. Relative
+paths are resolved from the project root. This is useful when binary assets use
+extensionless filenames that Vite would otherwise treat as JavaScript modules.
+
 ## Vite Integration Details
 
 FE keeps the same CLI interface and integrates Vite internally.
@@ -159,6 +171,7 @@ fe:
     - "./src/pages"
   setup: "setup.js"
   outfile: "./dist/bundle.js"
+  publicDir: "./static"
   i18n:
     dir: "./src/i18n"
     defaultLocale: "en"
@@ -175,6 +188,7 @@ fe:
 | `dirs` | Directories to scan for component files |
 | `setup` | Setup script that exports custom dependencies |
 | `outfile` | Output path for the bundled JavaScript |
+| `publicDir` | Optional directory served at `/` without transformations in watch mode |
 | `i18n.dir` | Directory containing locale YAML files |
 | `i18n.defaultLocale` | Initial locale used by the runtime |
 | `i18n.fallbackLocale` | Locale used if another locale cannot be loaded |

--- a/packages/rettangoli-cli/cli.js
+++ b/packages/rettangoli-cli/cli.js
@@ -417,6 +417,10 @@ feCommand
   .description("Watch for changes")
   .option("-p, --port <port>", "The port to use", parsePortOption, 3001)
   .option("-s, --setup-path <path>", "Custom setup file path")
+  .option(
+    "--public-dir <path>",
+    "Directory to serve as untransformed static assets",
+  )
   .addHelpText(
     "after",
     `
@@ -427,6 +431,7 @@ Examples:
   $ rettangoli fe watch -p 4000
   $ rettangoli fe watch -s src/setup.tauri.js
   $ rettangoli fe watch --setup-path src/setup.web.js
+  $ rettangoli fe watch --public-dir static
 `,
   )
   .action(async (options) => {
@@ -457,6 +462,9 @@ Examples:
     // Use config outfile if not specified via CLI option
     if (!options.outfile && config.fe.outfile) {
       options.outfile = config.fe.outfile;
+    }
+    if (options.publicDir === undefined && config.fe.publicDir !== undefined) {
+      options.publicDir = config.fe.publicDir;
     }
 
     await watch(options);

--- a/packages/rettangoli-fe/README.md
+++ b/packages/rettangoli-fe/README.md
@@ -95,6 +95,7 @@ src/
 
 - `rtgl fe build` uses Vite 8's Rolldown-powered `vite.build()` with a virtual entry module generated from configured component files.
 - `rtgl fe watch` uses `vite.createServer()`, warms the virtual entry during startup, and serves the configured `outfile` path via middleware.
+- Watch projects can configure `fe.publicDir` to serve static assets from the project root without Vite transformations.
 - FE runtime source is generated in memory (virtual module), so no temporary generated JS files are required.
 - Contract validation, YAML parsing, and template parsing still run before code generation.
 - Component directories, setup files, and locale files are registered explicitly so watch mode also sees sources outside the served static root.
@@ -125,6 +126,7 @@ fe:
     - "./src/pages"
   setup: "setup.js"
   outfile: "./dist/bundle.js"
+  publicDir: "./static"
   i18n:
     dir: "./src/i18n"
     defaultLocale: "en"
@@ -135,6 +137,10 @@ fe:
   examples:
     outputDir: "./vt/specs/examples"
 ```
+
+`publicDir` is optional and only affects `rtgl fe watch`. Its files are served
+at `/` without Vite transformations. This is useful for extensionless or other
+binary assets that must retain their source filenames.
 
 ## Setup Contract
 

--- a/packages/rettangoli-fe/src/cli/watch.js
+++ b/packages/rettangoli-fe/src/cli/watch.js
@@ -43,13 +43,17 @@ export const createWatchServer = async (options = {}) => {
     outfile = "./vt/static/main.js",
     setup = "setup.js",
     i18n = null,
+    publicDir,
   } = options;
 
   const { root, publicEntryPath } = resolveServeContext({ cwd, outfile });
+  const resolvedPublicDir =
+    typeof publicDir === "string" ? path.resolve(cwd, publicDir) : publicDir;
 
   const server = await createServer({
     clearScreen: false,
     configFile: false,
+    publicDir: resolvedPublicDir,
     root,
     server: {
       port,

--- a/packages/rettangoli-fe/test/cli/vite-runtime.integration.test.js
+++ b/packages/rettangoli-fe/test/cli/vite-runtime.integration.test.js
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { Writable } from "node:stream";
 import { fileURLToPath } from "node:url";
 import {
   existsSync,
@@ -80,27 +81,40 @@ const createFixtureProject = ({
 const requestFromMiddleware = async (server, url) =>
   await new Promise((resolve, reject) => {
     const headers = new Map();
+    const chunks = [];
     const req = {
       url,
       originalUrl: url,
       method: "GET",
       headers: {},
     };
-    const res = {
-      statusCode: 200,
-      getHeader(name) {
-        return headers.get(String(name).toLowerCase());
+    const res = new Writable({
+      write(chunk, _encoding, callback) {
+        chunks.push(Buffer.from(chunk));
+        callback();
       },
-      setHeader(name, value) {
-        headers.set(String(name).toLowerCase(), value);
-      },
-      end(body = "") {
+      final(callback) {
+        const rawBody = Buffer.concat(chunks);
         resolve({
-          statusCode: this.statusCode,
+          statusCode: res.statusCode,
           headers,
-          body: String(body),
+          body: String(rawBody),
+          rawBody,
         });
+        callback();
       },
+    });
+    res.statusCode = 200;
+    res.getHeader = (name) => headers.get(String(name).toLowerCase());
+    res.setHeader = (name, value) => {
+      headers.set(String(name).toLowerCase(), value);
+    };
+    res.writeHead = (statusCode, responseHeaders = {}) => {
+      res.statusCode = statusCode;
+      Object.entries(responseHeaders).forEach(([name, value]) => {
+        res.setHeader(name, value);
+      });
+      return res;
     };
 
     server.middlewares.handle(req, res, (error) => {
@@ -113,6 +127,7 @@ const requestFromMiddleware = async (server, url) =>
         statusCode: res.statusCode,
         headers,
         body: "",
+        rawBody: Buffer.alloc(0),
       });
     });
   });
@@ -251,6 +266,41 @@ describe("vite runtime integration", () => {
     expect(response.body).toContain("x-counter");
     expect(response.body).toContain("customElements.define");
     expect(response.body).not.toContain("__STALE_FE_BUNDLE__");
+  });
+
+  it("serves extensionless files from the configured public directory without transforming them", async () => {
+    const rootDir = createFixtureProject();
+    createdDirs.push(rootDir);
+
+    const publicFilePath = path.join(
+      rootDir,
+      "static",
+      "templates",
+      "default",
+      "files",
+      "font-file-id",
+    );
+    const publicFileBytes = Buffer.from([0, 1, 0, 0, 255]);
+    mkdirSync(path.dirname(publicFilePath), { recursive: true });
+    writeFileSync(publicFilePath, publicFileBytes);
+
+    const server = await createWatchServer({
+      cwd: rootDir,
+      dirs: ["components"],
+      setup: "setup.js",
+      outfile: "vt/static/public/main.js",
+      publicDir: "static",
+    });
+    servers.push(server);
+
+    const response = await requestFromMiddleware(
+      server,
+      "/templates/default/files/font-file-id",
+    );
+
+    expect(response.statusCode).toBe(200);
+    expect(response.rawBody).toEqual(publicFileBytes);
+    expect(response.body).not.toContain("export default");
   });
 
   it("refreshes the generated entry when an outside-root YAML source changes", async () => {


### PR DESCRIPTION
## Summary
- add `fe.publicDir` configuration and `rtgl fe watch --public-dir` CLI support
- resolve relative public-directory paths from the project root and pass them to Vite so assets are served without transforms
- document the watch-mode option and add regression coverage for byte-exact extensionless binary assets

## Testing
- `bun run test` in `packages/rettangoli-fe` (191 passed)
- `node --check packages/rettangoli-fe/src/cli/watch.js`
- `node --check packages/rettangoli-cli/cli.js`
- `node packages/rettangoli-cli/cli.js fe watch --help`