### PR TITLE
fix(fe): preserve child prop snapshot semantics

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -40,14 +40,14 @@
     },
     "packages/rettangoli-cli": {
       "name": "rtgl",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "bin": {
         "rtgl": "cli.js",
       },
       "dependencies": {
         "@rettangoli/be": "2.0.0",
         "@rettangoli/check": "0.1.2",
-        "@rettangoli/fe": "1.2.1",
+        "@rettangoli/fe": "1.2.2",
         "@rettangoli/sites": "1.2.0",
         "@rettangoli/ui": "1.4.2",
         "@rettangoli/vt": "1.0.5",
@@ -57,7 +57,7 @@
     },
     "packages/rettangoli-fe": {
       "name": "@rettangoli/fe",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "dependencies": {
         "immer": "^10.1.1",
         "jempl": "1.0.1",

--- a/packages/rettangoli-cli/package.json
+++ b/packages/rettangoli-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rtgl",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "CLI tool for Rettangoli - A frontend framework and development toolkit",
   "type": "module",
   "bin": {
@@ -49,7 +49,7 @@
     "js-yaml": "^4.1.0",
     "@rettangoli/check": "0.1.2",
     "@rettangoli/be": "2.0.0",
-    "@rettangoli/fe": "1.2.1",
+    "@rettangoli/fe": "1.2.2",
     "@rettangoli/sites": "1.2.0",
     "@rettangoli/vt": "1.0.5",
     "@rettangoli/ui": "1.4.2"

--- a/packages/rettangoli-fe/docs/handlers.md
+++ b/packages/rettangoli-fe/docs/handlers.md
@@ -96,6 +96,12 @@ Payload shape:
 }
 ```
 
+Props that did not change preserve their reference identity between `oldProps`
+and `newProps`. When a JSON-data object or array is mutated in place, the
+changed prop in `oldProps` contains its value from the previous render.
+Non-JSON values such as `BigInt`, functions, and circular objects are supported
+and compared with `Object.is` rather than cloned.
+
 ## 5. Event Handlers from `.view.yaml`
 
 `refs.*.eventListeners.*.handler` resolves to a handler export in `.handlers.js`.

--- a/packages/rettangoli-fe/package.json
+++ b/packages/rettangoli-fe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rettangoli/fe",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Frontend framework for building reactive web components",
   "type": "module",
   "main": "./src/index.js",

--- a/packages/rettangoli-fe/src/web/componentUpdateHook.js
+++ b/packages/rettangoli-fe/src/web/componentUpdateHook.js
@@ -1,22 +1,155 @@
 import { scheduleFrame } from "./scheduler.js";
 
+export const RETTANGOLI_COMPONENT_MARKER = Symbol.for(
+  "@rettangoli/fe/component",
+);
+
+const propsSnapshots = new WeakMap();
+
+const createReferenceSnapshot = (value) => ({
+  value,
+  hasStructuralSnapshot: false,
+});
+
+const createPropSnapshot = (value) => {
+  if (value === null || typeof value !== "object") {
+    return createReferenceSnapshot(value);
+  }
+
+  try {
+    // Keep the live value for identity and a separate old value only for
+    // detecting and reporting same-reference JSON-data mutations.
+    const serialized = JSON.stringify(value);
+    if (serialized === undefined || typeof structuredClone !== "function") {
+      return createReferenceSnapshot(value);
+    }
+    return {
+      value,
+      hasStructuralSnapshot: true,
+      serialized,
+      oldValue: structuredClone(value),
+    };
+  } catch {
+    return createReferenceSnapshot(value);
+  }
+};
+
+const createPropsSnapshot = (props = {}) => {
+  const entries = new Map();
+  Object.keys(props).forEach((key) => {
+    entries.set(key, createPropSnapshot(props[key]));
+  });
+  return entries;
+};
+
+const propChanged = (previousEntry, nextEntry) => {
+  if (!previousEntry || !nextEntry) return true;
+  if (previousEntry.hasStructuralSnapshot !== nextEntry.hasStructuralSnapshot) {
+    return true;
+  }
+  if (previousEntry.hasStructuralSnapshot) {
+    return previousEntry.serialized !== nextEntry.serialized;
+  }
+  return !Object.is(previousEntry.value, nextEntry.value);
+};
+
+const getChangedPropKeys = (previousSnapshot, nextSnapshot) => {
+  const keys = new Set([...previousSnapshot.keys(), ...nextSnapshot.keys()]);
+  return [...keys].filter((key) =>
+    propChanged(previousSnapshot.get(key), nextSnapshot.get(key)),
+  );
+};
+
+const defineProp = (target, key, value) => {
+  Object.defineProperty(target, key, {
+    configurable: true,
+    enumerable: true,
+    value,
+    writable: true,
+  });
+};
+
+const hasDriftedFromSnapshot = (entry) => {
+  if (!entry.hasStructuralSnapshot) return false;
+  try {
+    return JSON.stringify(entry.value) !== entry.serialized;
+  } catch {
+    return true;
+  }
+};
+
+const createOldProps = (previousSnapshot) => {
+  const oldProps = {};
+  previousSnapshot.forEach((entry, key) => {
+    defineProp(
+      oldProps,
+      key,
+      hasDriftedFromSnapshot(entry) ? entry.oldValue : entry.value,
+    );
+  });
+  return oldProps;
+};
+
+const isRettangoliComponent = (element) => {
+  try {
+    if (element?.[RETTANGOLI_COMPONENT_MARKER] === true) {
+      return true;
+    }
+
+    // Compatibility for separately bundled components built before the brand
+    // existed. These relationships are installed together by the FE runtime.
+    return (
+      typeof element?.elementName === "string" &&
+      typeof element.render === "function" &&
+      typeof element.patch === "function" &&
+      typeof element._snabbdomH === "function" &&
+      element.deps?.render === element.render &&
+      element.deps?.store === element.store &&
+      element.deps?.props === element.props
+    );
+  } catch {
+    return false;
+  }
+};
+
+const storePropsSnapshot = (element, props = {}) => {
+  const snapshot = createPropsSnapshot(props);
+  propsSnapshots.set(element, snapshot);
+  return snapshot;
+};
+
 export const createWebComponentUpdateHook = ({
   scheduleFrameFn = scheduleFrame,
 } = {}) => {
   return {
+    insert: (vnode) => {
+      const element = vnode.elm;
+      if (!isRettangoliComponent(element)) return;
+      storePropsSnapshot(element, vnode.data?.props || {});
+    },
     update: (oldVnode, vnode) => {
+      const element = vnode.elm;
+      if (
+        !isRettangoliComponent(element) ||
+        typeof element.render !== "function"
+      ) {
+        return;
+      }
+
       const oldProps = oldVnode.data?.props || {};
       const newProps = vnode.data?.props || {};
-
-      const propsChanged = JSON.stringify(oldProps) !== JSON.stringify(newProps);
-      if (!propsChanged) {
+      const previousSnapshot =
+        propsSnapshots.get(element) || createPropsSnapshot(oldProps);
+      const nextSnapshot = storePropsSnapshot(element, newProps);
+      const changedPropKeys = getChangedPropKeys(
+        previousSnapshot,
+        nextSnapshot,
+      );
+      if (changedPropKeys.length === 0) {
         return;
       }
 
-      const element = vnode.elm;
-      if (!element || typeof element.render !== "function") {
-        return;
-      }
+      const previousProps = createOldProps(previousSnapshot);
 
       element.setAttribute("isDirty", "true");
       scheduleFrameFn(() => {
@@ -25,7 +158,7 @@ export const createWebComponentUpdateHook = ({
 
         if (element.handlers && element.handlers.handleOnUpdate) {
           const deps = {
-            ...(element.deps),
+            ...element.deps,
             store: element.store,
             render: element.render.bind(element),
             handlers: element.handlers,
@@ -33,7 +166,7 @@ export const createWebComponentUpdateHook = ({
             refs: element.refIds || {},
           };
           element.handlers.handleOnUpdate(deps, {
-            oldProps,
+            oldProps: previousProps,
             newProps,
           });
         }

--- a/packages/rettangoli-fe/src/web/createWebComponentClass.js
+++ b/packages/rettangoli-fe/src/web/createWebComponentClass.js
@@ -15,7 +15,10 @@ import {
   buildObservedAttributes,
 } from "../core/runtime/componentRuntime.js";
 import { initializeComponentDom } from "./componentDom.js";
-import { createWebComponentUpdateHook } from "./componentUpdateHook.js";
+import {
+  createWebComponentUpdateHook,
+  RETTANGOLI_COMPONENT_MARKER,
+} from "./componentUpdateHook.js";
 import { scheduleFrame } from "./scheduler.js";
 
 export const createWebComponentClass = ({
@@ -34,6 +37,7 @@ export const createWebComponentClass = ({
   deps,
 }) => {
   class BaseComponent extends HTMLElement {
+    [RETTANGOLI_COMPONENT_MARKER] = true;
     elementName;
     styles;
     _snabbdomH;

--- a/packages/rettangoli-fe/test/runtime/component-update-hook.test.js
+++ b/packages/rettangoli-fe/test/runtime/component-update-hook.test.js
@@ -1,26 +1,71 @@
 import { describe, expect, it, vi } from "vitest";
-import { createWebComponentUpdateHook } from "../../src/web/componentUpdateHook.js";
+import {
+  createWebComponentUpdateHook,
+  RETTANGOLI_COMPONENT_MARKER,
+} from "../../src/web/componentUpdateHook.js";
+
+const createManagedElement = (overrides = {}) => ({
+  [RETTANGOLI_COMPONENT_MARKER]: true,
+  deps: { marker: "ok" },
+  store: { getState: () => ({}) },
+  refIds: { submitButton: {} },
+  handlers: { handleOnUpdate: vi.fn() },
+  render: vi.fn(),
+  setAttribute: vi.fn(),
+  removeAttribute: vi.fn(),
+  dispatchEvent: vi.fn(),
+  ...overrides,
+});
 
 describe("createWebComponentUpdateHook", () => {
+  it("uses a stable cross-bundle component marker", () => {
+    expect(RETTANGOLI_COMPONENT_MARKER).toBe(
+      Symbol.for("@rettangoli/fe/component"),
+    );
+  });
+
+  it("recognizes pre-brand components built by an older FE bundle", () => {
+    const scheduleFrame = vi.fn((callback) => callback());
+    const updateHook = createWebComponentUpdateHook({
+      scheduleFrameFn: scheduleFrame,
+    });
+    const element = createManagedElement();
+    delete element[RETTANGOLI_COMPONENT_MARKER];
+    element.elementName = "rtgl-select";
+    element.patch = vi.fn();
+    element._snabbdomH = vi.fn();
+    element.props = {};
+    element.deps = {
+      render: element.render,
+      store: element.store,
+      props: element.props,
+    };
+    const options = [{ value: "old" }];
+    const oldVnode = {
+      data: { props: { options } },
+      elm: element,
+    };
+    updateHook.insert(oldVnode);
+
+    options.push({ value: "new" });
+    updateHook.update(oldVnode, {
+      data: { props: { options } },
+      elm: element,
+    });
+
+    expect(scheduleFrame).toHaveBeenCalledTimes(1);
+    expect(element.render).toHaveBeenCalledTimes(1);
+    expect(
+      element.handlers.handleOnUpdate.mock.calls[0][1].oldProps.options,
+    ).toEqual([{ value: "old" }]);
+  });
+
   it("schedules re-render and handleOnUpdate when props changed", () => {
     const scheduleFrame = vi.fn((callback) => callback());
-    const updateHook = createWebComponentUpdateHook({ scheduleFrameFn: scheduleFrame });
-
-    const render = vi.fn();
-    const handleOnUpdate = vi.fn();
-    const setAttribute = vi.fn();
-    const removeAttribute = vi.fn();
-    const dispatchEvent = vi.fn();
-    const element = {
-      deps: { marker: "ok" },
-      store: { getState: () => ({}) },
-      refIds: { submitButton: {} },
-      handlers: { handleOnUpdate },
-      render,
-      setAttribute,
-      removeAttribute,
-      dispatchEvent,
-    };
+    const updateHook = createWebComponentUpdateHook({
+      scheduleFrameFn: scheduleFrame,
+    });
+    const element = createManagedElement();
 
     updateHook.update(
       { data: { props: { value: "a" } } },
@@ -28,11 +73,11 @@ describe("createWebComponentUpdateHook", () => {
     );
 
     expect(scheduleFrame).toHaveBeenCalledTimes(1);
-    expect(setAttribute).toHaveBeenCalledWith("isDirty", "true");
-    expect(render).toHaveBeenCalledTimes(1);
-    expect(removeAttribute).toHaveBeenCalledWith("isDirty");
-    expect(handleOnUpdate).toHaveBeenCalledTimes(1);
-    expect(handleOnUpdate.mock.calls[0][1]).toEqual({
+    expect(element.setAttribute).toHaveBeenCalledWith("isDirty", "true");
+    expect(element.render).toHaveBeenCalledTimes(1);
+    expect(element.removeAttribute).toHaveBeenCalledWith("isDirty");
+    expect(element.handlers.handleOnUpdate).toHaveBeenCalledTimes(1);
+    expect(element.handlers.handleOnUpdate.mock.calls[0][1]).toEqual({
       oldProps: { value: "a" },
       newProps: { value: "b" },
     });
@@ -40,14 +85,263 @@ describe("createWebComponentUpdateHook", () => {
 
   it("does nothing when props are unchanged", () => {
     const scheduleFrame = vi.fn();
-    const updateHook = createWebComponentUpdateHook({ scheduleFrameFn: scheduleFrame });
-    const render = vi.fn();
+    const updateHook = createWebComponentUpdateHook({
+      scheduleFrameFn: scheduleFrame,
+    });
+    const element = createManagedElement();
 
     updateHook.update(
       { data: { props: { value: "a" } } },
-      { data: { props: { value: "a" } }, elm: { render } },
+      { data: { props: { value: "a" } }, elm: element },
     );
 
+    expect(scheduleFrame).not.toHaveBeenCalled();
+    expect(element.render).not.toHaveBeenCalled();
+  });
+
+  it("detects in-place mutations to JSON-data props", () => {
+    const scheduleFrame = vi.fn((callback) => callback());
+    const updateHook = createWebComponentUpdateHook({
+      scheduleFrameFn: scheduleFrame,
+    });
+    const element = createManagedElement();
+    const options = [
+      { value: "one", label: "One" },
+      { value: "two", label: "Two" },
+    ];
+    const oldVnode = {
+      data: { props: { options } },
+      elm: element,
+    };
+    updateHook.insert(oldVnode);
+
+    options.push(
+      { value: "three", label: "Three" },
+      { value: "four", label: "Four" },
+    );
+    updateHook.update(oldVnode, {
+      data: { props: { options } },
+      elm: element,
+    });
+
+    expect(scheduleFrame).toHaveBeenCalledTimes(1);
+    const payload = element.handlers.handleOnUpdate.mock.calls[0][1];
+    expect(payload.oldProps.options).toEqual([
+      { value: "one", label: "One" },
+      { value: "two", label: "Two" },
+    ]);
+    expect(payload.oldProps.options).not.toBe(options);
+    expect(payload.newProps.options).toBe(options);
+    expect(payload.newProps.options).toHaveLength(4);
+  });
+
+  it("preserves references for props unchanged by an in-place mutation", () => {
+    const scheduleFrame = vi.fn((callback) => callback());
+    const updateHook = createWebComponentUpdateHook({
+      scheduleFrameFn: scheduleFrame,
+    });
+    const element = createManagedElement();
+    const options = [{ value: "bug", label: "Bug" }];
+    const selectedValues = ["bug"];
+    const context = { projectId: "project-1" };
+    context.self = context;
+    const oldVnode = {
+      data: { props: { options, selectedValues, context } },
+      elm: element,
+    };
+    updateHook.insert(oldVnode);
+
+    options.push({ value: "platform", label: "Platform" });
+    updateHook.update(oldVnode, {
+      data: { props: { options, selectedValues, context } },
+      elm: element,
+    });
+
+    const payload = element.handlers.handleOnUpdate.mock.calls[0][1];
+    expect(payload.oldProps.selectedValues).toBe(selectedValues);
+    expect(payload.newProps.selectedValues).toBe(selectedValues);
+    expect(payload.oldProps.context).toBe(context);
+    expect(payload.newProps.context).toBe(context);
+  });
+
+  it("refreshes the baseline after a structurally equal replacement", () => {
+    const scheduleFrame = vi.fn((callback) => callback());
+    const updateHook = createWebComponentUpdateHook({
+      scheduleFrameFn: scheduleFrame,
+    });
+    const element = createManagedElement();
+    const firstOptions = [{ value: "one" }];
+    const firstVnode = {
+      data: { props: { options: firstOptions } },
+      elm: element,
+    };
+    updateHook.insert(firstVnode);
+
+    const nextOptions = [{ value: "one" }];
+    const nextVnode = {
+      data: { props: { options: nextOptions } },
+      elm: element,
+    };
+    updateHook.update(firstVnode, nextVnode);
+    expect(scheduleFrame).not.toHaveBeenCalled();
+
+    nextOptions.push({ value: "two" });
+    updateHook.update(nextVnode, {
+      data: { props: { options: nextOptions } },
+      elm: element,
+    });
+
+    expect(scheduleFrame).toHaveBeenCalledTimes(1);
+    expect(
+      element.handlers.handleOnUpdate.mock.calls[0][1].oldProps.options,
+    ).toEqual([{ value: "one" }]);
+  });
+
+  it("retains exact old and new references for a deep-equal replacement", () => {
+    const scheduleFrame = vi.fn((callback) => callback());
+    const updateHook = createWebComponentUpdateHook({
+      scheduleFrameFn: scheduleFrame,
+    });
+    const element = createManagedElement();
+    const oldOptions = [{ value: "one" }];
+    const newOptions = [{ value: "one" }];
+    const oldVnode = {
+      data: { props: { options: oldOptions, disabled: false } },
+      elm: element,
+    };
+    updateHook.insert(oldVnode);
+
+    updateHook.update(oldVnode, {
+      data: { props: { options: newOptions, disabled: true } },
+      elm: element,
+    });
+
+    const payload = element.handlers.handleOnUpdate.mock.calls[0][1];
+    expect(payload.oldProps.options).toBe(oldOptions);
+    expect(payload.newProps.options).toBe(newOptions);
+  });
+
+  it("reports the rendered value when a prop is mutated and then replaced", () => {
+    const scheduleFrame = vi.fn((callback) => callback());
+    const updateHook = createWebComponentUpdateHook({
+      scheduleFrameFn: scheduleFrame,
+    });
+    const element = createManagedElement();
+    const oldOptions = [{ value: "rendered" }];
+    const oldVnode = {
+      data: { props: { options: oldOptions } },
+      elm: element,
+    };
+    updateHook.insert(oldVnode);
+
+    oldOptions.push({ value: "never-rendered" });
+    const newOptions = [{ value: "replacement" }];
+    updateHook.update(oldVnode, {
+      data: { props: { options: newOptions } },
+      elm: element,
+    });
+
+    const payload = element.handlers.handleOnUpdate.mock.calls[0][1];
+    expect(payload.oldProps.options).toEqual([{ value: "rendered" }]);
+    expect(payload.oldProps.options).not.toBe(oldOptions);
+    expect(payload.newProps.options).toBe(newOptions);
+  });
+
+  it("supports BigInt props during insertion and updates", () => {
+    const scheduleFrame = vi.fn((callback) => callback());
+    const updateHook = createWebComponentUpdateHook({
+      scheduleFrameFn: scheduleFrame,
+    });
+    const element = createManagedElement();
+    const oldVnode = {
+      data: { props: { selectedValue: 1n } },
+      elm: element,
+    };
+
+    expect(() => updateHook.insert(oldVnode)).not.toThrow();
+    updateHook.update(oldVnode, {
+      data: { props: { selectedValue: 2n } },
+      elm: element,
+    });
+
+    expect(scheduleFrame).toHaveBeenCalledTimes(1);
+    expect(element.handlers.handleOnUpdate.mock.calls[0][1]).toEqual({
+      oldProps: { selectedValue: 1n },
+      newProps: { selectedValue: 2n },
+    });
+  });
+
+  it("supports circular props and preserves their identity", () => {
+    const scheduleFrame = vi.fn((callback) => callback());
+    const updateHook = createWebComponentUpdateHook({
+      scheduleFrameFn: scheduleFrame,
+    });
+    const element = createManagedElement();
+    const context = { projectId: "project-1" };
+    context.self = context;
+    const oldVnode = {
+      data: { props: { context, disabled: false } },
+      elm: element,
+    };
+
+    expect(() => updateHook.insert(oldVnode)).not.toThrow();
+    updateHook.update(oldVnode, {
+      data: { props: { context, disabled: true } },
+      elm: element,
+    });
+
+    const payload = element.handlers.handleOnUpdate.mock.calls[0][1];
+    expect(payload.oldProps.context).toBe(context);
+    expect(payload.newProps.context).toBe(context);
+    expect(payload.oldProps.disabled).toBe(false);
+    expect(payload.newProps.disabled).toBe(true);
+  });
+
+  it("preserves opaque prop identities when another prop changes", () => {
+    const scheduleFrame = vi.fn((callback) => callback());
+    const updateHook = createWebComponentUpdateHook({
+      scheduleFrameFn: scheduleFrame,
+    });
+    const element = createManagedElement();
+    const callback = () => {};
+    const createdAt = new Date("2026-07-18T00:00:00.000Z");
+    const oldVnode = {
+      data: { props: { callback, createdAt, value: "old" } },
+      elm: element,
+    };
+    updateHook.insert(oldVnode);
+
+    updateHook.update(oldVnode, {
+      data: { props: { callback, createdAt, value: "new" } },
+      elm: element,
+    });
+
+    const payload = element.handlers.handleOnUpdate.mock.calls[0][1];
+    expect(payload.oldProps.callback).toBe(callback);
+    expect(payload.newProps.callback).toBe(callback);
+    expect(payload.oldProps.createdAt).toBe(createdAt);
+    expect(payload.newProps.createdAt).toBe(createdAt);
+  });
+
+  it("does not inspect or update unrelated custom elements", () => {
+    const scheduleFrame = vi.fn();
+    const updateHook = createWebComponentUpdateHook({
+      scheduleFrameFn: scheduleFrame,
+    });
+    const render = vi.fn();
+    const props = new Proxy(
+      {},
+      {
+        ownKeys() {
+          throw new Error("foreign props were inspected");
+        },
+      },
+    );
+    const oldVnode = { data: { props }, elm: { render } };
+    const nextVnode = { data: { props }, elm: oldVnode.elm };
+
+    expect(() => updateHook.insert(oldVnode)).not.toThrow();
+    expect(() => updateHook.update(oldVnode, nextVnode)).not.toThrow();
     expect(scheduleFrame).not.toHaveBeenCalled();
     expect(render).not.toHaveBeenCalled();
   });

--- a/packages/rettangoli-fe/test/runtime/create-component.contract.test.js
+++ b/packages/rettangoli-fe/test/runtime/create-component.contract.test.js
@@ -1,5 +1,6 @@
 import { parse } from "jempl";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { RETTANGOLI_COMPONENT_MARKER } from "../../src/web/componentUpdateHook.js";
 
 let createComponent;
 let createI18nRuntime;
@@ -258,6 +259,12 @@ afterAll(() => {
 });
 
 describe("createComponent runtime contracts", () => {
+  it("brands instances for framework-owned child update hooks", () => {
+    const TestComponent = createComponentClass();
+
+    expect(new TestComponent()[RETTANGOLI_COMPONENT_MARKER]).toBe(true);
+  });
+
   it("binds named methods with payload defaulting to object", () => {
     const TestComponent = createComponentClass({
       methods: {

--- a/packages/rettangoli-ui/spec/tagSelect.handlers.spec.js
+++ b/packages/rettangoli-ui/spec/tagSelect.handlers.spec.js
@@ -121,6 +121,46 @@ describe("rtgl-tag-select handlers", () => {
     expect(render).toHaveBeenCalledTimes(1);
   });
 
+  it("preserves an uncontrolled draft when only options changed", () => {
+    const selectedValues = ["bug"];
+    const options = [
+      { value: "bug", label: "Bug" },
+      { value: "platform", label: "Platform" },
+    ];
+    const store = createStore({
+      isOpen: true,
+      hasSelectedValues: true,
+      selectedValues: ["bug"],
+      draftSelectedValues: ["bug", "platform"],
+    });
+    const render = vi.fn();
+
+    handleOnUpdate(
+      {
+        store,
+        render,
+        refs: {},
+      },
+      {
+        oldProps: {
+          options: [{ value: "bug", label: "Bug" }],
+          selectedValues,
+        },
+        newProps: {
+          options,
+          selectedValues,
+        },
+      },
+    );
+
+    expect(store.getState().selectedValues).toEqual(["bug"]);
+    expect(store.getState().draftSelectedValues).toEqual([
+      "bug",
+      "platform",
+    ]);
+    expect(render).toHaveBeenCalledTimes(1);
+  });
+
   it("emits open-change when an open tag select becomes disabled", () => {
     const store = createStore({
       isOpen: true,


### PR DESCRIPTION
## Summary

- detect in-place JSON-data prop mutations without cloning unchanged props
- support BigInt, circular, function, and opaque prop values without insertion failures
- scope snapshots to Rettangoli components across bundles while retaining compatibility with pre-brand UI components
- preserve uncontrolled tag-select draft state when another prop changes
- cover mutation-then-replacement and baseline refresh edge cases

## Verification

- Rettangoli FE: 202/202 tests passed
- Rettangoli UI: 177/177 tests passed
- Visual regression: 313/313 captures, 0/350 mismatches
- git diff --check passed

Follow-up to the already-merged #415.