### PR TITLE
fix(ui): harden form field handling

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -113,7 +113,7 @@
     },
     "packages/rettangoli-ui": {
       "name": "@rettangoli/ui",
-      "version": "1.10.0",
+      "version": "1.10.1",
       "dependencies": {
         "@rettangoli/fe": "1.2.0",
         "jempl": "1.0.1",

--- a/packages/rettangoli-ui/DEVELOPMENT.md
+++ b/packages/rettangoli-ui/DEVELOPMENT.md
@@ -232,6 +232,15 @@ Canonical `inputType` values are kebab-case only:
 - `read-only-text`
 - `slot`
 
+### Form field paths
+
+- every data field name must be a non-empty string
+- dotted field paths are supported for nested values (`user.email`)
+- path traversal uses own properties only
+- bracket notation is not supported
+- `__proto__`, `constructor`, and `prototype` are reserved and rejected in any path segment
+- legacy flat dotted defaults are normalized to nested values when written
+
 ## Events: Naming and Payloads
 
 ### Naming rules

--- a/packages/rettangoli-ui/docs/changelog.md
+++ b/packages/rettangoli-ui/docs/changelog.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Improvements
+- `rtgl-form`: rejects unsafe, bracket-style, and reserved field paths without mutating prototypes; preserves invalid-path errors during reactive validation; and keeps conditional value pruning safe with frozen store state.
 - `rtgl-dialog`: added `bare` mode for consumer-owned modal visuals while preserving native modality, focus containment, and close requests.
 - `rtgl-dialog`: keeps sequential keyboard focus inside the modal across slotted and open-shadow content instead of allowing focus to fall back to the page body at a tab boundary.
 - `rtgl-dialog`: fixed the open animation so adaptive centering is applied before the first paint, preventing the dialog from jumping from a top-biased position into the centered final state.

--- a/packages/rettangoli-ui/package.json
+++ b/packages/rettangoli-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rettangoli/ui",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "A UI component library for building web interfaces.",
   "main": "dist/rettangoli-esm.min.js",
   "type": "module",

--- a/packages/rettangoli-ui/spec/form.handlers.spec.js
+++ b/packages/rettangoli-ui/spec/form.handlers.spec.js
@@ -1,21 +1,17 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { handleOnUpdate } from "../src/components/form/form.handlers.js";
+import { bindStore } from "../../rettangoli-fe/src/core/runtime/store.js";
 import {
-  createInitialState,
-  resetFormValues,
-} from "../src/components/form/form.store.js";
+  handleOnUpdate,
+  handleValueChange,
+  handleValueInput,
+} from "../src/components/form/form.handlers.js";
+import * as formStore from "../src/components/form/form.store.js";
 
-const createStore = (overrides = {}) => {
-  const state = {
-    ...structuredClone(createInitialState()),
-    ...overrides,
-  };
-
-  return {
-    getState: () => state,
-    resetFormValues: (payload) => resetFormValues({ state }, payload),
-  };
+const createStore = ({ props, formValues = {} }) => {
+  const store = bindStore(formStore, props, {});
+  store.resetFormValues({ defaultValues: formValues });
+  return store;
 };
 
 const createRef = () => ({
@@ -23,7 +19,7 @@ const createRef = () => ({
   removeAttribute: vi.fn(),
 });
 
-describe("rtgl-form handleOnUpdate", () => {
+describe("rtgl-form handlers", () => {
   const form = {
     fields: [
       {
@@ -40,48 +36,65 @@ describe("rtgl-form handleOnUpdate", () => {
   };
 
   it("re-seeds form values when the form key changes", () => {
-    const store = createStore({
-      formValues: {
+    const oldProps = {
+      key: "section-form-1",
+      form,
+      defaultValues: {
         inheritPresentationFromSelectedLine: false,
       },
+    };
+    const newProps = {
+      key: "section-form-2",
+      form,
+      defaultValues: {
+        inheritPresentationFromSelectedLine: true,
+      },
+    };
+    const store = createStore({
+      props: newProps,
+      formValues: oldProps.defaultValues,
     });
+    const render = vi.fn();
 
     handleOnUpdate(
       {
         store,
-        render: vi.fn(),
+        render,
         refs: {
           field0: createRef(),
         },
       },
       {
-        oldProps: {
-          key: "section-form-1",
-          form,
-          defaultValues: {
-            inheritPresentationFromSelectedLine: false,
-          },
-        },
-        newProps: {
-          key: "section-form-2",
-          form,
-          defaultValues: {
-            inheritPresentationFromSelectedLine: true,
-          },
-        },
+        oldProps,
+        newProps,
       },
     );
 
     expect(store.getState().formValues).toEqual({
       inheritPresentationFromSelectedLine: true,
     });
+    expect(Object.isFrozen(store.getState().formValues)).toBe(true);
+    expect(render).toHaveBeenCalledTimes(1);
   });
 
   it("does not re-seed form values when only defaultValues changes", () => {
-    const store = createStore({
-      formValues: {
+    const oldProps = {
+      key: "section-form-1",
+      form,
+      defaultValues: {
         inheritPresentationFromSelectedLine: false,
       },
+    };
+    const newProps = {
+      key: "section-form-1",
+      form,
+      defaultValues: {
+        inheritPresentationFromSelectedLine: true,
+      },
+    };
+    const store = createStore({
+      props: newProps,
+      formValues: oldProps.defaultValues,
     });
 
     handleOnUpdate(
@@ -93,20 +106,8 @@ describe("rtgl-form handleOnUpdate", () => {
         },
       },
       {
-        oldProps: {
-          key: "section-form-1",
-          form,
-          defaultValues: {
-            inheritPresentationFromSelectedLine: false,
-          },
-        },
-        newProps: {
-          key: "section-form-1",
-          form,
-          defaultValues: {
-            inheritPresentationFromSelectedLine: true,
-          },
-        },
+        oldProps,
+        newProps,
       },
     );
 
@@ -114,4 +115,195 @@ describe("rtgl-form handleOnUpdate", () => {
       inheritPresentationFromSelectedLine: false,
     });
   });
+
+  it("prunes newly hidden fields through the live bound props", () => {
+    const oldForm = {
+      fields: [
+        { name: "visible", type: "input-text" },
+        { name: "removed", type: "input-text" },
+      ],
+    };
+    const newForm = {
+      fields: [{ name: "visible", type: "input-text" }],
+    };
+    const liveProps = {
+      key: "stable-key",
+      form: oldForm,
+    };
+    const store = createStore({
+      props: liveProps,
+      formValues: {
+        visible: "keep",
+        removed: "prune",
+      },
+    });
+    const before = store.getState();
+    const render = vi.fn();
+
+    liveProps.form = newForm;
+    handleOnUpdate(
+      {
+        store,
+        render,
+        refs: {
+          field0: createRef(),
+        },
+      },
+      {
+        oldProps: { key: "stable-key", form: oldForm },
+        newProps: { key: "stable-key", form: newForm },
+      },
+    );
+
+    expect(before.formValues).toEqual({
+      visible: "keep",
+      removed: "prune",
+    });
+    expect(store.getState().formValues).toEqual({ visible: "keep" });
+    expect(Object.isFrozen(store.getState().formValues)).toBe(true);
+    expect(render).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    ["input", handleValueInput, "form-input"],
+    ["change", handleValueChange, "form-change"],
+  ])(
+    "updates and prunes atomically on value %s",
+    (_label, handler, eventName) => {
+      const props = {
+        form: {
+          fields: [
+            {
+              name: "mode",
+              type: "select",
+              options: [
+                { label: "Basic", value: "basic" },
+                { label: "Advanced", value: "advanced" },
+              ],
+            },
+            {
+              name: "secret",
+              type: "input-text",
+              $when: 'formValues.mode == "advanced"',
+            },
+          ],
+        },
+      };
+      const store = createStore({
+        props,
+        formValues: {
+          mode: "advanced",
+          secret: "remove",
+        },
+      });
+      const before = store.getState();
+      const render = vi.fn();
+      const dispatchEvent = vi.fn();
+      const currentTarget = {
+        dataset: { fieldName: "mode" },
+        removeAttribute: vi.fn(),
+        setAttribute: vi.fn(),
+      };
+
+      handler(
+        {
+          store,
+          dispatchEvent,
+          render,
+          props,
+        },
+        {
+          _event: {
+            currentTarget,
+            detail: { value: "basic" },
+          },
+        },
+      );
+
+      expect(before.formValues).toEqual({
+        mode: "advanced",
+        secret: "remove",
+      });
+      expect(store.getState().formValues).toEqual({ mode: "basic" });
+      expect(Object.isFrozen(store.getState().formValues)).toBe(true);
+      expect(render).toHaveBeenCalledTimes(1);
+      expect(dispatchEvent).toHaveBeenCalledTimes(1);
+      const dispatchedEvent = dispatchEvent.mock.calls[0][0];
+      expect(dispatchedEvent.type).toBe(eventName);
+      expect(dispatchedEvent.detail).toEqual({
+        name: "mode",
+        value: "basic",
+        values: { mode: "basic" },
+      });
+    },
+  );
+
+  it.each([
+    ["input", handleValueInput, "form-input"],
+    ["change", handleValueChange, "form-change"],
+  ])(
+    "preserves invalid-path errors during reactive %s validation",
+    (_label, handler, eventName) => {
+      const fieldName = "profile[0].name";
+      const props = {
+        form: {
+          fields: [
+            {
+              name: fieldName,
+              type: "input-text",
+              required: true,
+            },
+          ],
+        },
+      };
+      const store = createStore({ props });
+      const initialValidation = formStore.validateForm(
+        props.form.fields,
+        store.getState().formValues,
+      );
+      store.setErrors({ errors: initialValidation.errors });
+      store.setReactiveMode();
+      const render = vi.fn();
+      const dispatchEvent = vi.fn();
+
+      handler(
+        {
+          store,
+          dispatchEvent,
+          render,
+          props,
+        },
+        {
+          _event: {
+            currentTarget: {
+              dataset: { fieldName },
+              removeAttribute: vi.fn(),
+              setAttribute: vi.fn(),
+            },
+            detail: { value: "updated" },
+          },
+        },
+      );
+
+      expect(
+        Object.prototype.hasOwnProperty.call(
+          store.getState().errors,
+          fieldName,
+        ),
+      ).toBe(true);
+      expect(store.getState().errors[fieldName]).toBe(
+        "Invalid form field path",
+      );
+      expect(store.getState().formValues).toEqual({});
+      expect(render).toHaveBeenCalledTimes(1);
+      expect(dispatchEvent).toHaveBeenCalledTimes(1);
+      const dispatchedEvent = dispatchEvent.mock.calls[0][0];
+      expect(dispatchedEvent.type).toBe(eventName);
+      expect(dispatchedEvent.detail).toEqual({
+        name: fieldName,
+        value: "updated",
+        values: {},
+      });
+    },
+  );
 });

--- a/packages/rettangoli-ui/spec/form.store.integration.spec.js
+++ b/packages/rettangoli-ui/spec/form.store.integration.spec.js
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+
+import { bindStore } from "../../rettangoli-fe/src/core/runtime/store.js";
+import * as formStore from "../src/components/form/form.store.js";
+
+const createConditionalFormProps = () => ({
+  form: {
+    fields: [
+      {
+        name: "mode",
+        type: "select",
+        options: [
+          { label: "Basic", value: "basic" },
+          { label: "Advanced", value: "advanced" },
+        ],
+      },
+      {
+        name: "secret",
+        type: "input-text",
+        $when: 'formValues.mode == "advanced"',
+      },
+    ],
+  },
+});
+
+describe("rtgl-form bound store integration", () => {
+  it("rejects unsafe paths through bound form write actions", () => {
+    const pollutionKey = "__rtglBoundFormPollutionProbe";
+    const props = {
+      form: {
+        fields: [{ name: "safe", type: "input-text" }],
+      },
+    };
+    const store = bindStore(formStore, props, {});
+
+    try {
+      store.setFormValues({
+        values: {
+          safe: "kept",
+          [`__proto__.${pollutionKey}`]: "polluted",
+          [`items.__proto__.${pollutionKey}`]: "polluted",
+        },
+      });
+      store.setFormFieldValue({
+        name: `constructor.prototype.${pollutionKey}`,
+        value: "polluted",
+      });
+
+      expect(store.getState().formValues).toEqual({ safe: "kept" });
+      expect(Object.prototype[pollutionKey]).toBeUndefined();
+      expect(Array.prototype[pollutionKey]).toBeUndefined();
+    } finally {
+      delete Object.prototype[pollutionKey];
+      delete Array.prototype[pollutionKey];
+    }
+  });
+
+  it("sets and prunes a conditional value atomically", () => {
+    const props = createConditionalFormProps();
+    const store = bindStore(formStore, props, {});
+    store.resetFormValues({
+      defaultValues: {
+        mode: "advanced",
+        secret: "keep",
+      },
+    });
+    const before = store.getState();
+
+    store.setFormFieldValue({ name: "mode", value: "basic" });
+
+    const after = store.getState();
+    expect(after).not.toBe(before);
+    expect(before.formValues).toEqual({
+      mode: "advanced",
+      secret: "keep",
+    });
+    expect(after.formValues).toEqual({ mode: "basic" });
+    expect(Object.isFrozen(before)).toBe(true);
+    expect(Object.isFrozen(before.formValues)).toBe(true);
+    expect(Object.isFrozen(after)).toBe(true);
+    expect(Object.isFrozen(after.formValues)).toBe(true);
+  });
+
+  it("prunes an already frozen state through the bound action", () => {
+    const props = createConditionalFormProps();
+    const store = bindStore(formStore, props, {});
+    store.resetFormValues({
+      defaultValues: {
+        mode: "basic",
+        secret: "stale",
+      },
+    });
+
+    expect(Object.isFrozen(store.getState().formValues)).toBe(true);
+    expect(() => store.pruneHiddenValues()).not.toThrow();
+    expect(store.getState().formValues).toEqual({ mode: "basic" });
+  });
+
+  it("stores and clears an own __proto__ validation error safely", () => {
+    const props = {
+      form: {
+        fields: [{ name: "__proto__", type: "input-text" }],
+      },
+    };
+    const store = bindStore(formStore, props, {});
+    const errors = JSON.parse('{"__proto__":"Invalid form field path"}');
+
+    store.setErrors({ errors });
+
+    expect(store.selectViewData().flatFields[0]._error).toBe(
+      "Invalid form field path",
+    );
+    expect(
+      Object.prototype.hasOwnProperty.call(
+        store.getState().errors,
+        "__proto__",
+      ),
+    ).toBe(true);
+
+    store.clearFieldError({ name: "__proto__" });
+
+    expect(store.selectViewData().flatFields[0]._error).toBeNull();
+    expect(
+      Object.prototype.hasOwnProperty.call(
+        store.getState().errors,
+        "__proto__",
+      ),
+    ).toBe(false);
+  });
+});

--- a/packages/rettangoli-ui/spec/form.store.security.spec.js
+++ b/packages/rettangoli-ui/spec/form.store.security.spec.js
@@ -1,0 +1,262 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  get,
+  selectFormValues,
+  set,
+  validateForm,
+} from "../src/components/form/form.store.js";
+
+const pollutionKey = "__rtglFormPollutionProbe";
+
+const clearPollutionProbe = () => {
+  delete Object.prototype[pollutionKey];
+  delete Array.prototype[pollutionKey];
+};
+
+afterEach(() => {
+  clearPollutionProbe();
+});
+
+describe("rtgl-form safe field paths", () => {
+  it.each([
+    ["terminal __proto__", () => ({}), "__proto__"],
+    ["root __proto__", () => ({}), `__proto__.${pollutionKey}`],
+    ["nested terminal __proto__", () => ({ profile: {} }), "profile.__proto__"],
+    [
+      "nested __proto__",
+      () => ({ profile: {} }),
+      `profile.__proto__.${pollutionKey}`,
+    ],
+    [
+      "array __proto__",
+      () => ({ items: [] }),
+      `items.__proto__.${pollutionKey}`,
+    ],
+    [
+      "constructor prototype",
+      () => ({}),
+      `constructor.prototype.${pollutionKey}`,
+    ],
+    ["terminal constructor", () => ({}), "constructor"],
+    [
+      "nested constructor",
+      () => ({ profile: {} }),
+      `profile.constructor.${pollutionKey}`,
+    ],
+    ["terminal prototype", () => ({}), "prototype"],
+    ["root prototype", () => ({}), `prototype.${pollutionKey}`],
+    [
+      "nested prototype",
+      () => ({ profile: {} }),
+      `profile.prototype.${pollutionKey}`,
+    ],
+  ])(
+    "rejects %s paths without mutating the target",
+    (_label, createTarget, path) => {
+      const target = createTarget();
+      const expected = structuredClone(target);
+      const prototypeSnapshots = [target, ...Object.values(target)]
+        .filter((value) => value !== null && typeof value === "object")
+        .map((value) => [value, Object.getPrototypeOf(value)]);
+
+      try {
+        expect(set(target, path, { [pollutionKey]: "polluted" })).toBe(target);
+        expect(Object.prototype[pollutionKey]).toBeUndefined();
+        expect(Array.prototype[pollutionKey]).toBeUndefined();
+        prototypeSnapshots.forEach(([value, prototype]) => {
+          expect(Object.getPrototypeOf(value)).toBe(prototype);
+        });
+        expect(target).toEqual(expected);
+        expect(get(target, path, "fallback")).toBe("fallback");
+      } finally {
+        clearPollutionProbe();
+      }
+    },
+  );
+
+  it("does not read or mutate inherited branches", () => {
+    const inherited = {
+      user: {
+        name: "Inherited",
+      },
+    };
+    const target = Object.create(inherited);
+
+    expect(get(target, "user.name", "fallback")).toBe("fallback");
+
+    set(target, "user.name", "Owned");
+
+    expect(Object.prototype.hasOwnProperty.call(target, "user")).toBe(true);
+    expect(target.user).toEqual({ name: "Owned" });
+    expect(inherited.user).toEqual({ name: "Inherited" });
+  });
+
+  it("does not invoke inherited setters while creating own branches", () => {
+    let setterCalls = 0;
+    const prototype = {};
+    Object.defineProperty(prototype, "user", {
+      configurable: true,
+      set() {
+        setterCalls++;
+      },
+    });
+    const target = Object.create(prototype);
+
+    set(target, "user.name", "Owned");
+
+    expect(setterCalls).toBe(0);
+    expect(Object.prototype.hasOwnProperty.call(target, "user")).toBe(true);
+    expect(target.user).toEqual({ name: "Owned" });
+  });
+
+  it("returns the fallback for primitive and null intermediates", () => {
+    expect(get({ user: "text" }, "user.name", "fallback")).toBe("fallback");
+    expect(get({ user: null }, "user.name", "fallback")).toBe("fallback");
+  });
+
+  it("preserves safe dotted-path normalization", () => {
+    const target = {
+      "user.email": "old@example.com",
+      sibling: true,
+    };
+
+    expect(set(target, "user.email", "new@example.com")).toBe(target);
+    expect(target).toEqual({
+      user: {
+        email: "new@example.com",
+      },
+      sibling: true,
+    });
+    expect(get(target, "user.email")).toBe("new@example.com");
+  });
+
+  it("preserves nested-over-flat reads and own array traversal", () => {
+    const target = {
+      "user.email": "flat@example.com",
+      user: {
+        email: "nested@example.com",
+      },
+      items: [{ name: "First" }],
+    };
+
+    expect(get(target, "user.email")).toBe("nested@example.com");
+    expect(get(target, "items.0.name")).toBe("First");
+  });
+
+  it("selects own falsy values and omits missing values", () => {
+    const fields = [
+      { name: "enabled", type: "checkbox" },
+      { name: "count", type: "input-number" },
+      { name: "label", type: "input-text" },
+      { name: "choice", type: "select" },
+      { name: "missing", type: "input-text" },
+    ];
+
+    expect(
+      selectFormValues({
+        state: {
+          formValues: {
+            enabled: false,
+            count: 0,
+            label: "",
+            choice: null,
+          },
+        },
+        props: { form: { fields } },
+      }),
+    ).toEqual({
+      enabled: false,
+      count: 0,
+      label: "",
+      choice: null,
+    });
+  });
+
+  it("does not expose values inherited from Object.prototype", () => {
+    Object.prototype[pollutionKey] = "inherited";
+
+    try {
+      const values = selectFormValues({
+        state: { formValues: {} },
+        props: {
+          form: {
+            fields: [{ name: pollutionKey, type: "input-text" }],
+          },
+        },
+      });
+
+      expect(values).toEqual({});
+    } finally {
+      clearPollutionProbe();
+    }
+  });
+
+  it("does not copy a JSON-owned __proto__ path into the output prototype", () => {
+    const formValues = JSON.parse(
+      `{"__proto__":{"${pollutionKey}":"polluted"}}`,
+    );
+
+    try {
+      const values = selectFormValues({
+        state: { formValues },
+        props: {
+          form: {
+            fields: [
+              {
+                name: `__proto__.${pollutionKey}`,
+                type: "input-text",
+              },
+            ],
+          },
+        },
+      });
+
+      expect(values).toEqual({});
+      expect(Object.prototype[pollutionKey]).toBeUndefined();
+    } finally {
+      clearPollutionProbe();
+    }
+  });
+
+  it.each([
+    "__proto__",
+    `profile.__proto__.${pollutionKey}`,
+    `constructor.prototype.${pollutionKey}`,
+    `profile.prototype.${pollutionKey}`,
+  ])("reports an invalid form configuration for reserved path %s", (path) => {
+    const result = validateForm(
+      [{ name: path, type: "input-text", required: true }],
+      {},
+    );
+
+    expect(result.valid).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(result.errors, path)).toBe(
+      true,
+    );
+    expect(result.errors[path]).toBe("Invalid form field path");
+    expect(Object.prototype[pollutionKey]).toBeUndefined();
+  });
+
+  it.each([
+    ["symbol", Symbol("field")],
+    ["number", 42],
+    ["empty string", ""],
+    ["missing", undefined],
+  ])(
+    "reports an invalid form configuration for a %s field name",
+    (_label, name) => {
+      const result = validateForm(
+        [{ name, type: "input-text", required: true }],
+        {},
+      );
+
+      expect(result).toEqual({
+        valid: false,
+        errors: {
+          "$invalidFieldPath:0": "Invalid form field path",
+        },
+      });
+    },
+  );
+});

--- a/packages/rettangoli-ui/src/components/form/form.handlers.js
+++ b/packages/rettangoli-ui/src/components/form/form.handlers.js
@@ -5,8 +5,6 @@ import {
   selectFormValues,
   collectAllDataFields,
   getDefaultValue,
-  pruneHiddenValues,
-  validateField,
   validateForm,
 } from "./form.store.js";
 
@@ -160,8 +158,8 @@ export const handleOnUpdate = (deps, payload) => {
     initFormValues(store, newProps);
   }
 
+  store.pruneHiddenValues();
   const state = store.getState();
-  pruneHiddenValues({ state, props: newProps });
   const form = selectForm({ state, props: newProps });
   updateFieldAttributes({
     form,
@@ -184,7 +182,6 @@ export const handleValueInput = (deps, payload) => {
   store.setFormFieldValue({ name, value });
 
   const state = store.getState();
-  pruneHiddenValues({ state, props });
   const form = selectForm({ state, props });
   const dataFields = collectAllDataFields(form.fields || []);
   const field = dataFields.find((f) => f.name === name);
@@ -198,7 +195,10 @@ export const handleValueInput = (deps, payload) => {
   // Reactive validation
   if (state.reactiveMode) {
     if (field) {
-      const error = validateField(field, value);
+      const { errors } = validateForm([field], state.formValues);
+      const error = Object.prototype.hasOwnProperty.call(errors, name)
+        ? errors[name]
+        : null;
       if (error) {
         store.setErrors({ errors: { ...state.errors, [name]: error } });
       } else {
@@ -234,7 +234,6 @@ export const handleValueChange = (deps, payload) => {
   store.setFormFieldValue({ name, value });
 
   const state = store.getState();
-  pruneHiddenValues({ state, props });
   const form = selectForm({ state, props });
   const dataFields = collectAllDataFields(form.fields || []);
   const field = dataFields.find((f) => f.name === name);
@@ -248,7 +247,10 @@ export const handleValueChange = (deps, payload) => {
   // Reactive validation
   if (state.reactiveMode) {
     if (field) {
-      const error = validateField(field, value);
+      const { errors } = validateForm([field], state.formValues);
+      const error = Object.prototype.hasOwnProperty.call(errors, name)
+        ? errors[name]
+        : null;
       if (error) {
         store.setErrors({ errors: { ...state.errors, [name]: error } });
       } else {

--- a/packages/rettangoli-ui/src/components/form/form.store.js
+++ b/packages/rettangoli-ui/src/components/form/form.store.js
@@ -21,6 +21,63 @@ const isObjectLike = (value) => value !== null && typeof value === "object";
 const isPlainObject = (value) => isObjectLike(value) && !Array.isArray(value);
 const isPathLike = (path) => typeof path === "string" && path.includes(".");
 const hasBracketPathToken = (path) => typeof path === "string" && /[\[\]]/.test(path);
+const unsafePathSegments = new Set(["__proto__", "constructor", "prototype"]);
+const hasOwn = (obj, key) => Object.prototype.hasOwnProperty.call(obj, key);
+
+const parseSafePath = (path) => {
+  if (
+    typeof path !== "string" ||
+    path.length === 0 ||
+    hasBracketPathToken(path)
+  ) {
+    return null;
+  }
+
+  const keys = path.split(".").filter((key) => key !== "");
+  if (keys.length === 0 || keys.some((key) => unsafePathSegments.has(key))) {
+    return null;
+  }
+
+  return keys;
+};
+
+const defineOwnValue = (obj, key, value) => {
+  Object.defineProperty(obj, key, {
+    configurable: true,
+    enumerable: true,
+    value,
+    writable: true,
+  });
+};
+
+const findInheritedDescriptor = (obj, key) => {
+  let prototype = Object.getPrototypeOf(obj);
+  while (prototype) {
+    const descriptor = Object.getOwnPropertyDescriptor(prototype, key);
+    if (descriptor) return descriptor;
+    prototype = Object.getPrototypeOf(prototype);
+  }
+  return null;
+};
+
+const setOwnValue = (obj, key, value) => {
+  const ownDescriptor = Object.getOwnPropertyDescriptor(obj, key);
+  const inheritedDescriptor = ownDescriptor
+    ? null
+    : findInheritedDescriptor(obj, key);
+  const descriptor = ownDescriptor || inheritedDescriptor;
+  const assignmentCouldBeIntercepted =
+    descriptor &&
+    (!Object.prototype.hasOwnProperty.call(descriptor, "value") ||
+      descriptor.writable === false);
+
+  if (assignmentCouldBeIntercepted) {
+    defineOwnValue(obj, key, value);
+    return;
+  }
+
+  obj[key] = value;
+};
 
 function pickByPaths(obj, paths) {
   const result = {};
@@ -73,14 +130,14 @@ function normalizeWhenDirectives(form) {
 
 // Nested property access utilities
 export const get = (obj, path, defaultValue = undefined) => {
-  if (!path) return defaultValue;
   if (!isObjectLike(obj)) return defaultValue;
-  if (hasBracketPathToken(path)) return defaultValue;
-  const keys = path.split(".").filter((key) => key !== "");
+  const keys = parseSafePath(path);
+  if (!keys) return defaultValue;
+
   let current = obj;
   for (const key of keys) {
-    if (current === null || current === undefined || !(key in current)) {
-      if (Object.prototype.hasOwnProperty.call(obj, path)) {
+    if (!isObjectLike(current) || !hasOwn(current, key)) {
+      if (hasOwn(obj, path)) {
         return obj[path];
       }
       return defaultValue;
@@ -91,32 +148,26 @@ export const get = (obj, path, defaultValue = undefined) => {
 };
 
 export const set = (obj, path, value) => {
-  if (!isObjectLike(obj) || typeof path !== "string" || path.length === 0) {
+  if (!isObjectLike(obj)) {
     return obj;
   }
-  if (hasBracketPathToken(path)) {
-    return obj;
-  }
-  const keys = path.split(".").filter((key) => key !== "");
-  if (keys.length === 0) {
-    return obj;
-  }
-  if (isPathLike(path) && Object.prototype.hasOwnProperty.call(obj, path)) {
+
+  const keys = parseSafePath(path);
+  if (!keys) return obj;
+
+  if (isPathLike(path) && hasOwn(obj, path)) {
     delete obj[path];
   }
+
   let current = obj;
   for (let i = 0; i < keys.length - 1; i++) {
     const key = keys[i];
-    if (
-      !(key in current) ||
-      typeof current[key] !== "object" ||
-      current[key] === null
-    ) {
-      current[key] = {};
+    if (!hasOwn(current, key) || !isObjectLike(current[key])) {
+      setOwnValue(current, key, {});
     }
     current = current[key];
   }
-  current[keys[keys.length - 1]] = value;
+  setOwnValue(current, keys[keys.length - 1], value);
   return obj;
 };
 
@@ -357,11 +408,20 @@ export const validateForm = (fields, formValues) => {
   const errors = {};
   const dataFields = collectAllDataFields(fields);
 
-  for (const field of dataFields) {
+  for (const [index, field] of dataFields.entries()) {
+    if (!parseSafePath(field.name)) {
+      const errorKey =
+        typeof field.name === "string" && field.name.length > 0
+          ? field.name
+          : `$invalidFieldPath:${index}`;
+      defineOwnValue(errors, errorKey, "Invalid form field path");
+      continue;
+    }
+
     const value = get(formValues, field.name);
     const error = validateField(field, value);
     if (error) {
-      errors[field.name] = error;
+      defineOwnValue(errors, field.name, error);
     }
   }
 
@@ -502,7 +562,9 @@ export const selectViewData = ({ state, props }) => {
     field._disabled = formDisabled || !!field.disabled;
 
     if (isData && field.name) {
-      field._error = state.errors[field.name] || null;
+      field._error = hasOwn(state.errors, field.name)
+        ? state.errors[field.name]
+        : null;
     }
 
     // Type-specific computed props
@@ -619,12 +681,13 @@ export const resetFormValues = ({ state }, payload = {}) => {
 };
 
 export const setErrors = ({ state }, payload = {}) => {
-  state.errors = payload.errors || {};
+  const errors = isPlainObject(payload.errors) ? payload.errors : {};
+  state.errors = Object.fromEntries(Object.entries(errors));
 };
 
 export const clearFieldError = ({ state }, payload = {}) => {
   const { name } = payload;
-  if (name && state.errors[name]) {
+  if (name && hasOwn(state.errors, name)) {
     delete state.errors[name];
   }
 };


### PR DESCRIPTION
## Summary

- reject unsafe, bracket-style, and reserved form field paths without prototype mutation
- use own-property-safe reads, writes, validation errors, and bound-store pruning
- preserve invalid-path configuration errors during reactive input and change validation
- keep explicit render behavior unchanged: one render per handler path
- bump @rettangoli/ui to 1.10.1 and update the root lockfile and changelog

## Verification

- bun run test: 178 tests passed across 18 files
- focused form tests: 40 passed
- frozen root install: no lockfile changes
- FE generation, UI development bundle, and CSS copy completed
- visual capture: 313/313 succeeded
- visual report: 0 mismatches across 350 images
- git diff --check passed

## Known existing gate

bun run check:contracts still reports the existing 239 repository diagnostics: 8 legacy component-directory naming errors and 231 unknown custom-element registry errors. This change does not add contract diagnostics.