### PR TITLE
Improve FE runtime, watch mode, and form safety

### DIFF
--- a/apps/rettangoli.dev/pages/fe/docs/guides/cli.md
+++ b/apps/rettangoli.dev/pages/fe/docs/guides/cli.md
@@ -48,6 +48,18 @@ rtgl fe watch
 
 Uses Vite (`vite.createServer`) for dev serving and full reload on FE file changes. Component directories, the setup module, and i18n sources are watched explicitly, including when they are outside the served static root.
 
+Use `fe.publicDir` to serve a directory of static assets at `/` without Vite
+transformations:
+
+```yaml
+fe:
+  publicDir: "./static"
+```
+
+The equivalent CLI option is `rtgl fe watch --public-dir ./static`. Relative
+paths are resolved from the project root. This is useful when binary assets use
+extensionless filenames that Vite would otherwise treat as JavaScript modules.
+
 ## Vite Integration Details
 
 FE keeps the same CLI interface and integrates Vite internally.
@@ -159,6 +171,7 @@ fe:
     - "./src/pages"
   setup: "setup.js"
   outfile: "./dist/bundle.js"
+  publicDir: "./static"
   i18n:
     dir: "./src/i18n"
     defaultLocale: "en"
@@ -175,6 +188,7 @@ fe:
 | `dirs` | Directories to scan for component files |
 | `setup` | Setup script that exports custom dependencies |
 | `outfile` | Output path for the bundled JavaScript |
+| `publicDir` | Optional directory served at `/` without transformations in watch mode |
 | `i18n.dir` | Directory containing locale YAML files |
 | `i18n.defaultLocale` | Initial locale used by the runtime |
 | `i18n.fallbackLocale` | Locale used if another locale cannot be loaded |

--- a/bun.lock
+++ b/bun.lock
@@ -40,14 +40,14 @@
     },
     "packages/rettangoli-cli": {
       "name": "rtgl",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "bin": {
         "rtgl": "cli.js",
       },
       "dependencies": {
         "@rettangoli/be": "2.0.0",
         "@rettangoli/check": "0.1.2",
-        "@rettangoli/fe": "1.2.1",
+        "@rettangoli/fe": "1.2.2",
         "@rettangoli/sites": "1.2.0",
         "@rettangoli/ui": "1.4.2",
         "@rettangoli/vt": "1.0.5",
@@ -57,7 +57,7 @@
     },
     "packages/rettangoli-fe": {
       "name": "@rettangoli/fe",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "dependencies": {
         "immer": "^10.1.1",
         "jempl": "1.0.1",

--- a/bun.lock
+++ b/bun.lock
@@ -113,7 +113,7 @@
     },
     "packages/rettangoli-ui": {
       "name": "@rettangoli/ui",
-      "version": "1.10.0",
+      "version": "1.10.1",
       "dependencies": {
         "@rettangoli/fe": "1.2.0",
         "jempl": "1.0.1",

--- a/packages/rettangoli-cli/cli.js
+++ b/packages/rettangoli-cli/cli.js
@@ -417,6 +417,10 @@ feCommand
   .description("Watch for changes")
   .option("-p, --port <port>", "The port to use", parsePortOption, 3001)
   .option("-s, --setup-path <path>", "Custom setup file path")
+  .option(
+    "--public-dir <path>",
+    "Directory to serve as untransformed static assets",
+  )
   .addHelpText(
     "after",
     `
@@ -427,6 +431,7 @@ Examples:
   $ rettangoli fe watch -p 4000
   $ rettangoli fe watch -s src/setup.tauri.js
   $ rettangoli fe watch --setup-path src/setup.web.js
+  $ rettangoli fe watch --public-dir static
 `,
   )
   .action(async (options) => {
@@ -457,6 +462,9 @@ Examples:
     // Use config outfile if not specified via CLI option
     if (!options.outfile && config.fe.outfile) {
       options.outfile = config.fe.outfile;
+    }
+    if (options.publicDir === undefined && config.fe.publicDir !== undefined) {
+      options.publicDir = config.fe.publicDir;
     }
 
     await watch(options);

--- a/packages/rettangoli-cli/package.json
+++ b/packages/rettangoli-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rtgl",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "CLI tool for Rettangoli - A frontend framework and development toolkit",
   "type": "module",
   "bin": {
@@ -49,7 +49,7 @@
     "js-yaml": "^4.1.0",
     "@rettangoli/check": "0.1.2",
     "@rettangoli/be": "2.0.0",
-    "@rettangoli/fe": "1.2.1",
+    "@rettangoli/fe": "1.2.2",
     "@rettangoli/sites": "1.2.0",
     "@rettangoli/vt": "1.0.5",
     "@rettangoli/ui": "1.4.2"

--- a/packages/rettangoli-fe/README.md
+++ b/packages/rettangoli-fe/README.md
@@ -95,6 +95,7 @@ src/
 
 - `rtgl fe build` uses Vite 8's Rolldown-powered `vite.build()` with a virtual entry module generated from configured component files.
 - `rtgl fe watch` uses `vite.createServer()`, warms the virtual entry during startup, and serves the configured `outfile` path via middleware.
+- Watch projects can configure `fe.publicDir` to serve static assets from the project root without Vite transformations.
 - FE runtime source is generated in memory (virtual module), so no temporary generated JS files are required.
 - Contract validation, YAML parsing, and template parsing still run before code generation.
 - Component directories, setup files, and locale files are registered explicitly so watch mode also sees sources outside the served static root.
@@ -125,6 +126,7 @@ fe:
     - "./src/pages"
   setup: "setup.js"
   outfile: "./dist/bundle.js"
+  publicDir: "./static"
   i18n:
     dir: "./src/i18n"
     defaultLocale: "en"
@@ -135,6 +137,10 @@ fe:
   examples:
     outputDir: "./vt/specs/examples"
 ```
+
+`publicDir` is optional and only affects `rtgl fe watch`. Its files are served
+at `/` without Vite transformations. This is useful for extensionless or other
+binary assets that must retain their source filenames.
 
 ## Setup Contract
 

--- a/packages/rettangoli-fe/docs/handlers.md
+++ b/packages/rettangoli-fe/docs/handlers.md
@@ -96,6 +96,12 @@ Payload shape:
 }
 ```
 
+Props that did not change preserve their reference identity between `oldProps`
+and `newProps`. When a JSON-data object or array is mutated in place, the
+changed prop in `oldProps` contains its value from the previous render.
+Non-JSON values such as `BigInt`, functions, and circular objects are supported
+and compared with `Object.is` rather than cloned.
+
 ## 5. Event Handlers from `.view.yaml`
 
 `refs.*.eventListeners.*.handler` resolves to a handler export in `.handlers.js`.

--- a/packages/rettangoli-fe/docs/handlers.md
+++ b/packages/rettangoli-fe/docs/handlers.md
@@ -97,10 +97,16 @@ Payload shape:
 ```
 
 Props that did not change preserve their reference identity between `oldProps`
-and `newProps`. When a JSON-data object or array is mutated in place, the
-changed prop in `oldProps` contains its value from the previous render.
-Non-JSON values such as `BigInt`, functions, and circular objects are supported
-and compared with `Object.is` rather than cloned.
+and `newProps`. When a plain JSON-data object or array is mutated in place, the
+changed prop in `oldProps` contains its value from the previous render. Opaque
+values such as `BigInt`, functions, circular objects, `Date`, `Map`, `Set`,
+`RegExp`, `ArrayBuffer`, and class instances are supported and compared with
+`Object.is` rather than cloned. Replacing an opaque value's reference triggers
+an update; mutating it in place does not.
+
+Multiple parent updates before the next scheduled frame are coalesced into one
+child update. Its payload contains the props from before the first update and
+the latest props available when that frame runs.
 
 ## 5. Event Handlers from `.view.yaml`
 

--- a/packages/rettangoli-fe/package.json
+++ b/packages/rettangoli-fe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rettangoli/fe",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Frontend framework for building reactive web components",
   "type": "module",
   "main": "./src/index.js",

--- a/packages/rettangoli-fe/src/cli/watch.js
+++ b/packages/rettangoli-fe/src/cli/watch.js
@@ -43,13 +43,17 @@ export const createWatchServer = async (options = {}) => {
     outfile = "./vt/static/main.js",
     setup = "setup.js",
     i18n = null,
+    publicDir,
   } = options;
 
   const { root, publicEntryPath } = resolveServeContext({ cwd, outfile });
+  const resolvedPublicDir =
+    typeof publicDir === "string" ? path.resolve(cwd, publicDir) : publicDir;
 
   const server = await createServer({
     clearScreen: false,
     configFile: false,
+    publicDir: resolvedPublicDir,
     root,
     server: {
       port,

--- a/packages/rettangoli-fe/src/cli/watch.js
+++ b/packages/rettangoli-fe/src/cli/watch.js
@@ -48,7 +48,9 @@ export const createWatchServer = async (options = {}) => {
 
   const { root, publicEntryPath } = resolveServeContext({ cwd, outfile });
   const resolvedPublicDir =
-    typeof publicDir === "string" ? path.resolve(cwd, publicDir) : publicDir;
+    typeof publicDir === "string" && publicDir.length > 0
+      ? path.resolve(cwd, publicDir)
+      : publicDir;
 
   const server = await createServer({
     clearScreen: false,

--- a/packages/rettangoli-fe/src/web/componentUpdateHook.js
+++ b/packages/rettangoli-fe/src/web/componentUpdateHook.js
@@ -5,11 +5,100 @@ export const RETTANGOLI_COMPONENT_MARKER = Symbol.for(
 );
 
 const propsSnapshots = new WeakMap();
+const pendingUpdates = new WeakMap();
 
 const createReferenceSnapshot = (value) => ({
   value,
   hasStructuralSnapshot: false,
 });
+
+const hasUnsupportedToJSONOrPrototypeCycle = (value) => {
+  const visited = new Set();
+  let current = value;
+
+  while (current !== null) {
+    if (visited.has(current)) return true;
+    visited.add(current);
+
+    const descriptor = Object.getOwnPropertyDescriptor(current, "toJSON");
+    if (descriptor) {
+      if (!("value" in descriptor)) return true;
+      return typeof descriptor.value === "function";
+    }
+    current = Object.getPrototypeOf(current);
+  }
+
+  return false;
+};
+
+const isJsonData = (value, ancestors = new Set()) => {
+  if (value === null) return true;
+
+  const valueType = typeof value;
+  if (valueType === "string" || valueType === "boolean") return true;
+  if (valueType === "number") {
+    return Number.isFinite(value) && !Object.is(value, -0);
+  }
+  if (valueType !== "object") return false;
+
+  if (ancestors.has(value)) return false;
+
+  const isArray = Array.isArray(value);
+  const prototype = Object.getPrototypeOf(value);
+  if (
+    (isArray && prototype !== Array.prototype) ||
+    (!isArray && prototype !== Object.prototype && prototype !== null)
+  ) {
+    return false;
+  }
+
+  if (hasUnsupportedToJSONOrPrototypeCycle(value)) return false;
+
+  ancestors.add(value);
+  try {
+    if (isArray) {
+      const ownKeys = Reflect.ownKeys(value);
+      if (ownKeys.length !== value.length + 1 || !ownKeys.includes("length")) {
+        return false;
+      }
+
+      for (let index = 0; index < value.length; index += 1) {
+        const descriptor = Object.getOwnPropertyDescriptor(
+          value,
+          String(index),
+        );
+        if (
+          !descriptor ||
+          !("value" in descriptor) ||
+          !descriptor.enumerable ||
+          !isJsonData(descriptor.value, ancestors)
+        ) {
+          return false;
+        }
+      }
+
+      return true;
+    }
+
+    for (const key of Reflect.ownKeys(value)) {
+      if (typeof key !== "string") return false;
+
+      const descriptor = Object.getOwnPropertyDescriptor(value, key);
+      if (
+        !descriptor ||
+        !("value" in descriptor) ||
+        !descriptor.enumerable ||
+        !isJsonData(descriptor.value, ancestors)
+      ) {
+        return false;
+      }
+    }
+
+    return true;
+  } finally {
+    ancestors.delete(value);
+  }
+};
 
 const createPropSnapshot = (value) => {
   if (value === null || typeof value !== "object") {
@@ -17,6 +106,10 @@ const createPropSnapshot = (value) => {
   }
 
   try {
+    if (!isJsonData(value)) {
+      return createReferenceSnapshot(value);
+    }
+
     // Keep the live value for identity and a separate old value only for
     // detecting and reporting same-reference JSON-data mutations.
     const serialized = JSON.stringify(value);
@@ -72,6 +165,7 @@ const defineProp = (target, key, value) => {
 const hasDriftedFromSnapshot = (entry) => {
   if (!entry.hasStructuralSnapshot) return false;
   try {
+    if (!isJsonData(entry.value)) return true;
     return JSON.stringify(entry.value) !== entry.serialized;
   } catch {
     return true;
@@ -118,6 +212,48 @@ const storePropsSnapshot = (element, props = {}) => {
   return snapshot;
 };
 
+const runPendingUpdate = (element, pendingUpdate) => {
+  if (pendingUpdates.get(element) !== pendingUpdate) return;
+
+  pendingUpdates.delete(element);
+
+  // Prop values remain live references between the parent render and this
+  // frame. Refresh the latest snapshot so the stored baseline matches the
+  // value the child is about to render.
+  pendingUpdate.nextSnapshot = createPropsSnapshot(pendingUpdate.newProps);
+  propsSnapshots.set(element, pendingUpdate.nextSnapshot);
+  const nextSnapshot = pendingUpdate.nextSnapshot;
+  const changedPropKeys = getChangedPropKeys(
+    pendingUpdate.previousSnapshot,
+    nextSnapshot,
+  );
+
+  if (changedPropKeys.length === 0) {
+    element.removeAttribute("isDirty");
+    return;
+  }
+
+  const previousProps = createOldProps(pendingUpdate.previousSnapshot);
+
+  element.render();
+  element.removeAttribute("isDirty");
+
+  if (element.handlers && element.handlers.handleOnUpdate) {
+    const deps = {
+      ...element.deps,
+      store: element.store,
+      render: element.render.bind(element),
+      handlers: element.handlers,
+      dispatchEvent: element.dispatchEvent.bind(element),
+      refs: element.refIds || {},
+    };
+    element.handlers.handleOnUpdate(deps, {
+      oldProps: previousProps,
+      newProps: pendingUpdate.newProps,
+    });
+  }
+};
+
 export const createWebComponentUpdateHook = ({
   scheduleFrameFn = scheduleFrame,
 } = {}) => {
@@ -138,38 +274,36 @@ export const createWebComponentUpdateHook = ({
 
       const oldProps = oldVnode.data?.props || {};
       const newProps = vnode.data?.props || {};
+      const pendingUpdate = pendingUpdates.get(element);
+
+      if (pendingUpdate) {
+        pendingUpdate.newProps = newProps;
+        pendingUpdate.nextSnapshot = createPropsSnapshot(newProps);
+        return;
+      }
+
       const previousSnapshot =
         propsSnapshots.get(element) || createPropsSnapshot(oldProps);
-      const nextSnapshot = storePropsSnapshot(element, newProps);
+      const nextSnapshot = createPropsSnapshot(newProps);
       const changedPropKeys = getChangedPropKeys(
         previousSnapshot,
         nextSnapshot,
       );
       if (changedPropKeys.length === 0) {
+        propsSnapshots.set(element, nextSnapshot);
         return;
       }
 
-      const previousProps = createOldProps(previousSnapshot);
+      const nextPendingUpdate = {
+        previousSnapshot,
+        newProps,
+        nextSnapshot,
+      };
+      pendingUpdates.set(element, nextPendingUpdate);
 
       element.setAttribute("isDirty", "true");
       scheduleFrameFn(() => {
-        element.render();
-        element.removeAttribute("isDirty");
-
-        if (element.handlers && element.handlers.handleOnUpdate) {
-          const deps = {
-            ...element.deps,
-            store: element.store,
-            render: element.render.bind(element),
-            handlers: element.handlers,
-            dispatchEvent: element.dispatchEvent.bind(element),
-            refs: element.refIds || {},
-          };
-          element.handlers.handleOnUpdate(deps, {
-            oldProps: previousProps,
-            newProps,
-          });
-        }
+        runPendingUpdate(element, nextPendingUpdate);
       });
     },
   };

--- a/packages/rettangoli-fe/src/web/componentUpdateHook.js
+++ b/packages/rettangoli-fe/src/web/componentUpdateHook.js
@@ -1,22 +1,155 @@
 import { scheduleFrame } from "./scheduler.js";
 
+export const RETTANGOLI_COMPONENT_MARKER = Symbol.for(
+  "@rettangoli/fe/component",
+);
+
+const propsSnapshots = new WeakMap();
+
+const createReferenceSnapshot = (value) => ({
+  value,
+  hasStructuralSnapshot: false,
+});
+
+const createPropSnapshot = (value) => {
+  if (value === null || typeof value !== "object") {
+    return createReferenceSnapshot(value);
+  }
+
+  try {
+    // Keep the live value for identity and a separate old value only for
+    // detecting and reporting same-reference JSON-data mutations.
+    const serialized = JSON.stringify(value);
+    if (serialized === undefined || typeof structuredClone !== "function") {
+      return createReferenceSnapshot(value);
+    }
+    return {
+      value,
+      hasStructuralSnapshot: true,
+      serialized,
+      oldValue: structuredClone(value),
+    };
+  } catch {
+    return createReferenceSnapshot(value);
+  }
+};
+
+const createPropsSnapshot = (props = {}) => {
+  const entries = new Map();
+  Object.keys(props).forEach((key) => {
+    entries.set(key, createPropSnapshot(props[key]));
+  });
+  return entries;
+};
+
+const propChanged = (previousEntry, nextEntry) => {
+  if (!previousEntry || !nextEntry) return true;
+  if (previousEntry.hasStructuralSnapshot !== nextEntry.hasStructuralSnapshot) {
+    return true;
+  }
+  if (previousEntry.hasStructuralSnapshot) {
+    return previousEntry.serialized !== nextEntry.serialized;
+  }
+  return !Object.is(previousEntry.value, nextEntry.value);
+};
+
+const getChangedPropKeys = (previousSnapshot, nextSnapshot) => {
+  const keys = new Set([...previousSnapshot.keys(), ...nextSnapshot.keys()]);
+  return [...keys].filter((key) =>
+    propChanged(previousSnapshot.get(key), nextSnapshot.get(key)),
+  );
+};
+
+const defineProp = (target, key, value) => {
+  Object.defineProperty(target, key, {
+    configurable: true,
+    enumerable: true,
+    value,
+    writable: true,
+  });
+};
+
+const hasDriftedFromSnapshot = (entry) => {
+  if (!entry.hasStructuralSnapshot) return false;
+  try {
+    return JSON.stringify(entry.value) !== entry.serialized;
+  } catch {
+    return true;
+  }
+};
+
+const createOldProps = (previousSnapshot) => {
+  const oldProps = {};
+  previousSnapshot.forEach((entry, key) => {
+    defineProp(
+      oldProps,
+      key,
+      hasDriftedFromSnapshot(entry) ? entry.oldValue : entry.value,
+    );
+  });
+  return oldProps;
+};
+
+const isRettangoliComponent = (element) => {
+  try {
+    if (element?.[RETTANGOLI_COMPONENT_MARKER] === true) {
+      return true;
+    }
+
+    // Compatibility for separately bundled components built before the brand
+    // existed. These relationships are installed together by the FE runtime.
+    return (
+      typeof element?.elementName === "string" &&
+      typeof element.render === "function" &&
+      typeof element.patch === "function" &&
+      typeof element._snabbdomH === "function" &&
+      element.deps?.render === element.render &&
+      element.deps?.store === element.store &&
+      element.deps?.props === element.props
+    );
+  } catch {
+    return false;
+  }
+};
+
+const storePropsSnapshot = (element, props = {}) => {
+  const snapshot = createPropsSnapshot(props);
+  propsSnapshots.set(element, snapshot);
+  return snapshot;
+};
+
 export const createWebComponentUpdateHook = ({
   scheduleFrameFn = scheduleFrame,
 } = {}) => {
   return {
+    insert: (vnode) => {
+      const element = vnode.elm;
+      if (!isRettangoliComponent(element)) return;
+      storePropsSnapshot(element, vnode.data?.props || {});
+    },
     update: (oldVnode, vnode) => {
+      const element = vnode.elm;
+      if (
+        !isRettangoliComponent(element) ||
+        typeof element.render !== "function"
+      ) {
+        return;
+      }
+
       const oldProps = oldVnode.data?.props || {};
       const newProps = vnode.data?.props || {};
-
-      const propsChanged = JSON.stringify(oldProps) !== JSON.stringify(newProps);
-      if (!propsChanged) {
+      const previousSnapshot =
+        propsSnapshots.get(element) || createPropsSnapshot(oldProps);
+      const nextSnapshot = storePropsSnapshot(element, newProps);
+      const changedPropKeys = getChangedPropKeys(
+        previousSnapshot,
+        nextSnapshot,
+      );
+      if (changedPropKeys.length === 0) {
         return;
       }
 
-      const element = vnode.elm;
-      if (!element || typeof element.render !== "function") {
-        return;
-      }
+      const previousProps = createOldProps(previousSnapshot);
 
       element.setAttribute("isDirty", "true");
       scheduleFrameFn(() => {
@@ -25,7 +158,7 @@ export const createWebComponentUpdateHook = ({
 
         if (element.handlers && element.handlers.handleOnUpdate) {
           const deps = {
-            ...(element.deps),
+            ...element.deps,
             store: element.store,
             render: element.render.bind(element),
             handlers: element.handlers,
@@ -33,7 +166,7 @@ export const createWebComponentUpdateHook = ({
             refs: element.refIds || {},
           };
           element.handlers.handleOnUpdate(deps, {
-            oldProps,
+            oldProps: previousProps,
             newProps,
           });
         }

--- a/packages/rettangoli-fe/src/web/componentUpdateHook.js
+++ b/packages/rettangoli-fe/src/web/componentUpdateHook.js
@@ -220,9 +220,8 @@ const runPendingUpdate = (element, pendingUpdate) => {
   // Prop values remain live references between the parent render and this
   // frame. Refresh the latest snapshot so the stored baseline matches the
   // value the child is about to render.
-  pendingUpdate.nextSnapshot = createPropsSnapshot(pendingUpdate.newProps);
-  propsSnapshots.set(element, pendingUpdate.nextSnapshot);
-  const nextSnapshot = pendingUpdate.nextSnapshot;
+  const nextSnapshot = createPropsSnapshot(pendingUpdate.newProps);
+  propsSnapshots.set(element, nextSnapshot);
   const changedPropKeys = getChangedPropKeys(
     pendingUpdate.previousSnapshot,
     nextSnapshot,
@@ -278,7 +277,6 @@ export const createWebComponentUpdateHook = ({
 
       if (pendingUpdate) {
         pendingUpdate.newProps = newProps;
-        pendingUpdate.nextSnapshot = createPropsSnapshot(newProps);
         return;
       }
 
@@ -297,7 +295,6 @@ export const createWebComponentUpdateHook = ({
       const nextPendingUpdate = {
         previousSnapshot,
         newProps,
-        nextSnapshot,
       };
       pendingUpdates.set(element, nextPendingUpdate);
 

--- a/packages/rettangoli-fe/src/web/createWebComponentClass.js
+++ b/packages/rettangoli-fe/src/web/createWebComponentClass.js
@@ -15,7 +15,10 @@ import {
   buildObservedAttributes,
 } from "../core/runtime/componentRuntime.js";
 import { initializeComponentDom } from "./componentDom.js";
-import { createWebComponentUpdateHook } from "./componentUpdateHook.js";
+import {
+  createWebComponentUpdateHook,
+  RETTANGOLI_COMPONENT_MARKER,
+} from "./componentUpdateHook.js";
 import { scheduleFrame } from "./scheduler.js";
 
 export const createWebComponentClass = ({
@@ -34,6 +37,7 @@ export const createWebComponentClass = ({
   deps,
 }) => {
   class BaseComponent extends HTMLElement {
+    [RETTANGOLI_COMPONENT_MARKER] = true;
     elementName;
     styles;
     _snabbdomH;

--- a/packages/rettangoli-fe/test/cli/vite-runtime.integration.test.js
+++ b/packages/rettangoli-fe/test/cli/vite-runtime.integration.test.js
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { Writable } from "node:stream";
 import { fileURLToPath } from "node:url";
 import {
   existsSync,
@@ -80,27 +81,40 @@ const createFixtureProject = ({
 const requestFromMiddleware = async (server, url) =>
   await new Promise((resolve, reject) => {
     const headers = new Map();
+    const chunks = [];
     const req = {
       url,
       originalUrl: url,
       method: "GET",
       headers: {},
     };
-    const res = {
-      statusCode: 200,
-      getHeader(name) {
-        return headers.get(String(name).toLowerCase());
+    const res = new Writable({
+      write(chunk, _encoding, callback) {
+        chunks.push(Buffer.from(chunk));
+        callback();
       },
-      setHeader(name, value) {
-        headers.set(String(name).toLowerCase(), value);
-      },
-      end(body = "") {
+      final(callback) {
+        const rawBody = Buffer.concat(chunks);
         resolve({
-          statusCode: this.statusCode,
+          statusCode: res.statusCode,
           headers,
-          body: String(body),
+          body: String(rawBody),
+          rawBody,
         });
+        callback();
       },
+    });
+    res.statusCode = 200;
+    res.getHeader = (name) => headers.get(String(name).toLowerCase());
+    res.setHeader = (name, value) => {
+      headers.set(String(name).toLowerCase(), value);
+    };
+    res.writeHead = (statusCode, responseHeaders = {}) => {
+      res.statusCode = statusCode;
+      Object.entries(responseHeaders).forEach(([name, value]) => {
+        res.setHeader(name, value);
+      });
+      return res;
     };
 
     server.middlewares.handle(req, res, (error) => {
@@ -113,6 +127,7 @@ const requestFromMiddleware = async (server, url) =>
         statusCode: res.statusCode,
         headers,
         body: "",
+        rawBody: Buffer.alloc(0),
       });
     });
   });
@@ -251,6 +266,41 @@ describe("vite runtime integration", () => {
     expect(response.body).toContain("x-counter");
     expect(response.body).toContain("customElements.define");
     expect(response.body).not.toContain("__STALE_FE_BUNDLE__");
+  });
+
+  it("serves extensionless files from the configured public directory without transforming them", async () => {
+    const rootDir = createFixtureProject();
+    createdDirs.push(rootDir);
+
+    const publicFilePath = path.join(
+      rootDir,
+      "static",
+      "templates",
+      "default",
+      "files",
+      "font-file-id",
+    );
+    const publicFileBytes = Buffer.from([0, 1, 0, 0, 255]);
+    mkdirSync(path.dirname(publicFilePath), { recursive: true });
+    writeFileSync(publicFilePath, publicFileBytes);
+
+    const server = await createWatchServer({
+      cwd: rootDir,
+      dirs: ["components"],
+      setup: "setup.js",
+      outfile: "vt/static/public/main.js",
+      publicDir: "static",
+    });
+    servers.push(server);
+
+    const response = await requestFromMiddleware(
+      server,
+      "/templates/default/files/font-file-id",
+    );
+
+    expect(response.statusCode).toBe(200);
+    expect(response.rawBody).toEqual(publicFileBytes);
+    expect(response.body).not.toContain("export default");
   });
 
   it("refreshes the generated entry when an outside-root YAML source changes", async () => {

--- a/packages/rettangoli-fe/test/cli/vite-runtime.integration.test.js
+++ b/packages/rettangoli-fe/test/cli/vite-runtime.integration.test.js
@@ -303,6 +303,33 @@ describe("vite runtime integration", () => {
     expect(response.body).not.toContain("export default");
   });
 
+  it.each([
+    ["an empty string", ""],
+    ["false", false],
+  ])("keeps public serving disabled for %s", async (_label, publicDir) => {
+    const rootDir = createFixtureProject();
+    createdDirs.push(rootDir);
+
+    const privateFilePath = path.join(rootDir, ".git", "config");
+    mkdirSync(path.dirname(privateFilePath), { recursive: true });
+    writeFileSync(privateFilePath, "PRIVATE_PROJECT_CONFIGURATION\n");
+
+    const server = await createWatchServer({
+      cwd: rootDir,
+      dirs: ["components"],
+      setup: "setup.js",
+      outfile: "vt/static/public/main.js",
+      publicDir,
+    });
+    servers.push(server);
+
+    const response = await requestFromMiddleware(server, "/.git/config");
+
+    expect(server.config.publicDir).toBe("");
+    expect(response.statusCode).toBe(404);
+    expect(response.body).not.toContain("PRIVATE_PROJECT_CONFIGURATION");
+  });
+
   it("refreshes the generated entry when an outside-root YAML source changes", async () => {
     const rootDir = createFixtureProject();
     createdDirs.push(rootDir);

--- a/packages/rettangoli-fe/test/runtime/component-update-hook.test.js
+++ b/packages/rettangoli-fe/test/runtime/component-update-hook.test.js
@@ -135,6 +135,119 @@ describe("createWebComponentUpdateHook", () => {
     expect(payload.newProps.options).toHaveLength(4);
   });
 
+  it("coalesces queued mutations using the earliest old and latest new props", () => {
+    const callbacks = [];
+    const scheduleFrame = vi.fn((callback) => callbacks.push(callback));
+    const updateHook = createWebComponentUpdateHook({
+      scheduleFrameFn: scheduleFrame,
+    });
+    const element = createManagedElement();
+    const options = [{ value: "one" }];
+    const firstVnode = {
+      data: { props: { options, phase: "initial" } },
+      elm: element,
+    };
+    updateHook.insert(firstVnode);
+
+    options.push({ value: "two" });
+    const secondVnode = {
+      data: { props: { options, phase: "middle" } },
+      elm: element,
+    };
+    updateHook.update(firstVnode, secondVnode);
+
+    options.push({ value: "three" });
+    const thirdVnode = {
+      data: { props: { options, phase: "latest" } },
+      elm: element,
+    };
+    updateHook.update(secondVnode, thirdVnode);
+
+    expect(scheduleFrame).toHaveBeenCalledTimes(1);
+    expect(element.render).not.toHaveBeenCalled();
+    expect(element.handlers.handleOnUpdate).not.toHaveBeenCalled();
+
+    callbacks.shift()();
+
+    expect(element.render).toHaveBeenCalledTimes(1);
+    expect(element.handlers.handleOnUpdate).toHaveBeenCalledTimes(1);
+    const firstPayload = element.handlers.handleOnUpdate.mock.calls[0][1];
+    expect(firstPayload.oldProps.options).toEqual([{ value: "one" }]);
+    expect(firstPayload.oldProps.phase).toBe("initial");
+    expect(firstPayload.newProps).toBe(thirdVnode.data.props);
+    expect(firstPayload.newProps.options).toEqual([
+      { value: "one" },
+      { value: "two" },
+      { value: "three" },
+    ]);
+    expect(firstPayload.newProps.phase).toBe("latest");
+
+    options.push({ value: "four" });
+    const fourthVnode = {
+      data: { props: { options, phase: "latest" } },
+      elm: element,
+    };
+    updateHook.update(thirdVnode, fourthVnode);
+    callbacks.shift()();
+
+    expect(scheduleFrame).toHaveBeenCalledTimes(2);
+    expect(element.render).toHaveBeenCalledTimes(2);
+    expect(element.handlers.handleOnUpdate).toHaveBeenCalledTimes(2);
+    const secondPayload = element.handlers.handleOnUpdate.mock.calls[1][1];
+    expect(secondPayload.oldProps.options).toEqual([
+      { value: "one" },
+      { value: "two" },
+      { value: "three" },
+    ]);
+    expect(secondPayload.newProps.options).toHaveLength(4);
+  });
+
+  it("refreshes the rendered baseline from live props when the frame runs", () => {
+    const callbacks = [];
+    const scheduleFrame = vi.fn((callback) => callbacks.push(callback));
+    const updateHook = createWebComponentUpdateHook({
+      scheduleFrameFn: scheduleFrame,
+    });
+    const element = createManagedElement();
+    const options = [{ value: "one" }];
+    const firstVnode = {
+      data: { props: { options } },
+      elm: element,
+    };
+    updateHook.insert(firstVnode);
+
+    options.push({ value: "two" });
+    const secondVnode = {
+      data: { props: { options } },
+      elm: element,
+    };
+    updateHook.update(firstVnode, secondVnode);
+
+    // This mutation happens after the final parent hook but before its frame.
+    options.push({ value: "three" });
+    callbacks.shift()();
+
+    expect(
+      element.handlers.handleOnUpdate.mock.calls[0][1].newProps.options,
+    ).toHaveLength(3);
+
+    options.push({ value: "four" });
+    const thirdVnode = {
+      data: { props: { options } },
+      elm: element,
+    };
+    updateHook.update(secondVnode, thirdVnode);
+    callbacks.shift()();
+
+    expect(
+      element.handlers.handleOnUpdate.mock.calls[1][1].oldProps.options,
+    ).toEqual([
+      { value: "one" },
+      { value: "two" },
+      { value: "three" },
+    ]);
+  });
+
   it("preserves references for props unchanged by an in-place mutation", () => {
     const scheduleFrame = vi.fn((callback) => callback());
     const updateHook = createWebComponentUpdateHook({
@@ -295,6 +408,184 @@ describe("createWebComponentUpdateHook", () => {
     expect(payload.newProps.context).toBe(context);
     expect(payload.oldProps.disabled).toBe(false);
     expect(payload.newProps.disabled).toBe(true);
+  });
+
+  it("bounds stateful Proxy prototype walks and treats cycles as opaque", () => {
+    let prototypeReads = 0;
+    let context;
+    context = new Proxy(
+      {},
+      {
+        getPrototypeOf() {
+          prototypeReads += 1;
+          if (prototypeReads > 2) {
+            throw new Error("prototype walk was not bounded");
+          }
+          return prototypeReads === 1 ? Object.prototype : context;
+        },
+      },
+    );
+
+    const callbacks = [];
+    const scheduleFrame = vi.fn((callback) => callbacks.push(callback));
+    const updateHook = createWebComponentUpdateHook({
+      scheduleFrameFn: scheduleFrame,
+    });
+    const element = createManagedElement();
+    const oldVnode = {
+      data: { props: { context, disabled: false } },
+      elm: element,
+    };
+
+    updateHook.insert(oldVnode);
+    expect(prototypeReads).toBe(2);
+
+    prototypeReads = 0;
+    updateHook.update(oldVnode, {
+      data: { props: { context, disabled: true } },
+      elm: element,
+    });
+
+    expect(prototypeReads).toBe(2);
+
+    prototypeReads = 0;
+    callbacks.shift()();
+    expect(prototypeReads).toBe(2);
+
+    const payload = element.handlers.handleOnUpdate.mock.calls[0][1];
+    expect(payload.oldProps.context).toBe(context);
+    expect(payload.newProps.context).toBe(context);
+  });
+
+  it("compares Map props by reference", () => {
+    const scheduleFrame = vi.fn((callback) => callback());
+    const updateHook = createWebComponentUpdateHook({
+      scheduleFrameFn: scheduleFrame,
+    });
+    const element = createManagedElement();
+    const oldContext = new Map([["projectId", "project-1"]]);
+    const newContext = new Map([["projectId", "project-1"]]);
+    const oldVnode = {
+      data: { props: { context: oldContext } },
+      elm: element,
+    };
+    updateHook.insert(oldVnode);
+
+    updateHook.update(oldVnode, {
+      data: { props: { context: newContext } },
+      elm: element,
+    });
+
+    expect(scheduleFrame).toHaveBeenCalledTimes(1);
+    const payload = element.handlers.handleOnUpdate.mock.calls[0][1];
+    expect(payload.oldProps.context).toBe(oldContext);
+    expect(payload.newProps.context).toBe(newContext);
+    expect(payload.oldProps.context).toBeInstanceOf(Map);
+    expect(payload.newProps.context).toBeInstanceOf(Map);
+  });
+
+  it("preserves custom class instances and their prototypes", () => {
+    class Context {
+      constructor(projectId) {
+        this.projectId = projectId;
+      }
+
+      readProjectId() {
+        return this.projectId;
+      }
+    }
+
+    const scheduleFrame = vi.fn((callback) => callback());
+    const updateHook = createWebComponentUpdateHook({
+      scheduleFrameFn: scheduleFrame,
+    });
+    const element = createManagedElement();
+    const oldContext = new Context("project-1");
+    const newContext = new Context("project-1");
+    const oldVnode = {
+      data: { props: { context: oldContext } },
+      elm: element,
+    };
+    updateHook.insert(oldVnode);
+
+    updateHook.update(oldVnode, {
+      data: { props: { context: newContext } },
+      elm: element,
+    });
+
+    const payload = element.handlers.handleOnUpdate.mock.calls[0][1];
+    expect(payload.oldProps.context).toBe(oldContext);
+    expect(payload.newProps.context).toBe(newContext);
+    expect(payload.oldProps.context).toBeInstanceOf(Context);
+    expect(payload.oldProps.context.readProjectId()).toBe("project-1");
+  });
+
+  it("does not clone a same-reference class instance after it mutates", () => {
+    class Context {
+      constructor(projectId) {
+        this.projectId = projectId;
+      }
+
+      readProjectId() {
+        return this.projectId;
+      }
+    }
+
+    const scheduleFrame = vi.fn((callback) => callback());
+    const updateHook = createWebComponentUpdateHook({
+      scheduleFrameFn: scheduleFrame,
+    });
+    const element = createManagedElement();
+    const context = new Context("project-1");
+    const oldVnode = {
+      data: { props: { context, disabled: false } },
+      elm: element,
+    };
+    updateHook.insert(oldVnode);
+
+    context.projectId = "project-2";
+    updateHook.update(oldVnode, {
+      data: { props: { context, disabled: true } },
+      elm: element,
+    });
+
+    const payload = element.handlers.handleOnUpdate.mock.calls[0][1];
+    expect(payload.oldProps.context).toBe(context);
+    expect(payload.newProps.context).toBe(context);
+    expect(payload.oldProps.context).toBeInstanceOf(Context);
+    expect(payload.oldProps.context.readProjectId()).toBe("project-2");
+  });
+
+  it("treats a plain record containing an opaque value as reference data", () => {
+    class Model {
+      constructor(value) {
+        this.value = value;
+      }
+    }
+
+    const scheduleFrame = vi.fn((callback) => callback());
+    const updateHook = createWebComponentUpdateHook({
+      scheduleFrameFn: scheduleFrame,
+    });
+    const element = createManagedElement();
+    const oldContext = { model: new Model("same") };
+    const newContext = { model: new Model("same") };
+    const oldVnode = {
+      data: { props: { context: oldContext } },
+      elm: element,
+    };
+    updateHook.insert(oldVnode);
+
+    updateHook.update(oldVnode, {
+      data: { props: { context: newContext } },
+      elm: element,
+    });
+
+    expect(scheduleFrame).toHaveBeenCalledTimes(1);
+    const payload = element.handlers.handleOnUpdate.mock.calls[0][1];
+    expect(payload.oldProps.context).toBe(oldContext);
+    expect(payload.newProps.context).toBe(newContext);
+    expect(payload.oldProps.context.model).toBeInstanceOf(Model);
   });
 
   it("preserves opaque prop identities when another prop changes", () => {

--- a/packages/rettangoli-fe/test/runtime/component-update-hook.test.js
+++ b/packages/rettangoli-fe/test/runtime/component-update-hook.test.js
@@ -1,26 +1,71 @@
 import { describe, expect, it, vi } from "vitest";
-import { createWebComponentUpdateHook } from "../../src/web/componentUpdateHook.js";
+import {
+  createWebComponentUpdateHook,
+  RETTANGOLI_COMPONENT_MARKER,
+} from "../../src/web/componentUpdateHook.js";
+
+const createManagedElement = (overrides = {}) => ({
+  [RETTANGOLI_COMPONENT_MARKER]: true,
+  deps: { marker: "ok" },
+  store: { getState: () => ({}) },
+  refIds: { submitButton: {} },
+  handlers: { handleOnUpdate: vi.fn() },
+  render: vi.fn(),
+  setAttribute: vi.fn(),
+  removeAttribute: vi.fn(),
+  dispatchEvent: vi.fn(),
+  ...overrides,
+});
 
 describe("createWebComponentUpdateHook", () => {
+  it("uses a stable cross-bundle component marker", () => {
+    expect(RETTANGOLI_COMPONENT_MARKER).toBe(
+      Symbol.for("@rettangoli/fe/component"),
+    );
+  });
+
+  it("recognizes pre-brand components built by an older FE bundle", () => {
+    const scheduleFrame = vi.fn((callback) => callback());
+    const updateHook = createWebComponentUpdateHook({
+      scheduleFrameFn: scheduleFrame,
+    });
+    const element = createManagedElement();
+    delete element[RETTANGOLI_COMPONENT_MARKER];
+    element.elementName = "rtgl-select";
+    element.patch = vi.fn();
+    element._snabbdomH = vi.fn();
+    element.props = {};
+    element.deps = {
+      render: element.render,
+      store: element.store,
+      props: element.props,
+    };
+    const options = [{ value: "old" }];
+    const oldVnode = {
+      data: { props: { options } },
+      elm: element,
+    };
+    updateHook.insert(oldVnode);
+
+    options.push({ value: "new" });
+    updateHook.update(oldVnode, {
+      data: { props: { options } },
+      elm: element,
+    });
+
+    expect(scheduleFrame).toHaveBeenCalledTimes(1);
+    expect(element.render).toHaveBeenCalledTimes(1);
+    expect(
+      element.handlers.handleOnUpdate.mock.calls[0][1].oldProps.options,
+    ).toEqual([{ value: "old" }]);
+  });
+
   it("schedules re-render and handleOnUpdate when props changed", () => {
     const scheduleFrame = vi.fn((callback) => callback());
-    const updateHook = createWebComponentUpdateHook({ scheduleFrameFn: scheduleFrame });
-
-    const render = vi.fn();
-    const handleOnUpdate = vi.fn();
-    const setAttribute = vi.fn();
-    const removeAttribute = vi.fn();
-    const dispatchEvent = vi.fn();
-    const element = {
-      deps: { marker: "ok" },
-      store: { getState: () => ({}) },
-      refIds: { submitButton: {} },
-      handlers: { handleOnUpdate },
-      render,
-      setAttribute,
-      removeAttribute,
-      dispatchEvent,
-    };
+    const updateHook = createWebComponentUpdateHook({
+      scheduleFrameFn: scheduleFrame,
+    });
+    const element = createManagedElement();
 
     updateHook.update(
       { data: { props: { value: "a" } } },
@@ -28,11 +73,11 @@ describe("createWebComponentUpdateHook", () => {
     );
 
     expect(scheduleFrame).toHaveBeenCalledTimes(1);
-    expect(setAttribute).toHaveBeenCalledWith("isDirty", "true");
-    expect(render).toHaveBeenCalledTimes(1);
-    expect(removeAttribute).toHaveBeenCalledWith("isDirty");
-    expect(handleOnUpdate).toHaveBeenCalledTimes(1);
-    expect(handleOnUpdate.mock.calls[0][1]).toEqual({
+    expect(element.setAttribute).toHaveBeenCalledWith("isDirty", "true");
+    expect(element.render).toHaveBeenCalledTimes(1);
+    expect(element.removeAttribute).toHaveBeenCalledWith("isDirty");
+    expect(element.handlers.handleOnUpdate).toHaveBeenCalledTimes(1);
+    expect(element.handlers.handleOnUpdate.mock.calls[0][1]).toEqual({
       oldProps: { value: "a" },
       newProps: { value: "b" },
     });
@@ -40,14 +85,263 @@ describe("createWebComponentUpdateHook", () => {
 
   it("does nothing when props are unchanged", () => {
     const scheduleFrame = vi.fn();
-    const updateHook = createWebComponentUpdateHook({ scheduleFrameFn: scheduleFrame });
-    const render = vi.fn();
+    const updateHook = createWebComponentUpdateHook({
+      scheduleFrameFn: scheduleFrame,
+    });
+    const element = createManagedElement();
 
     updateHook.update(
       { data: { props: { value: "a" } } },
-      { data: { props: { value: "a" } }, elm: { render } },
+      { data: { props: { value: "a" } }, elm: element },
     );
 
+    expect(scheduleFrame).not.toHaveBeenCalled();
+    expect(element.render).not.toHaveBeenCalled();
+  });
+
+  it("detects in-place mutations to JSON-data props", () => {
+    const scheduleFrame = vi.fn((callback) => callback());
+    const updateHook = createWebComponentUpdateHook({
+      scheduleFrameFn: scheduleFrame,
+    });
+    const element = createManagedElement();
+    const options = [
+      { value: "one", label: "One" },
+      { value: "two", label: "Two" },
+    ];
+    const oldVnode = {
+      data: { props: { options } },
+      elm: element,
+    };
+    updateHook.insert(oldVnode);
+
+    options.push(
+      { value: "three", label: "Three" },
+      { value: "four", label: "Four" },
+    );
+    updateHook.update(oldVnode, {
+      data: { props: { options } },
+      elm: element,
+    });
+
+    expect(scheduleFrame).toHaveBeenCalledTimes(1);
+    const payload = element.handlers.handleOnUpdate.mock.calls[0][1];
+    expect(payload.oldProps.options).toEqual([
+      { value: "one", label: "One" },
+      { value: "two", label: "Two" },
+    ]);
+    expect(payload.oldProps.options).not.toBe(options);
+    expect(payload.newProps.options).toBe(options);
+    expect(payload.newProps.options).toHaveLength(4);
+  });
+
+  it("preserves references for props unchanged by an in-place mutation", () => {
+    const scheduleFrame = vi.fn((callback) => callback());
+    const updateHook = createWebComponentUpdateHook({
+      scheduleFrameFn: scheduleFrame,
+    });
+    const element = createManagedElement();
+    const options = [{ value: "bug", label: "Bug" }];
+    const selectedValues = ["bug"];
+    const context = { projectId: "project-1" };
+    context.self = context;
+    const oldVnode = {
+      data: { props: { options, selectedValues, context } },
+      elm: element,
+    };
+    updateHook.insert(oldVnode);
+
+    options.push({ value: "platform", label: "Platform" });
+    updateHook.update(oldVnode, {
+      data: { props: { options, selectedValues, context } },
+      elm: element,
+    });
+
+    const payload = element.handlers.handleOnUpdate.mock.calls[0][1];
+    expect(payload.oldProps.selectedValues).toBe(selectedValues);
+    expect(payload.newProps.selectedValues).toBe(selectedValues);
+    expect(payload.oldProps.context).toBe(context);
+    expect(payload.newProps.context).toBe(context);
+  });
+
+  it("refreshes the baseline after a structurally equal replacement", () => {
+    const scheduleFrame = vi.fn((callback) => callback());
+    const updateHook = createWebComponentUpdateHook({
+      scheduleFrameFn: scheduleFrame,
+    });
+    const element = createManagedElement();
+    const firstOptions = [{ value: "one" }];
+    const firstVnode = {
+      data: { props: { options: firstOptions } },
+      elm: element,
+    };
+    updateHook.insert(firstVnode);
+
+    const nextOptions = [{ value: "one" }];
+    const nextVnode = {
+      data: { props: { options: nextOptions } },
+      elm: element,
+    };
+    updateHook.update(firstVnode, nextVnode);
+    expect(scheduleFrame).not.toHaveBeenCalled();
+
+    nextOptions.push({ value: "two" });
+    updateHook.update(nextVnode, {
+      data: { props: { options: nextOptions } },
+      elm: element,
+    });
+
+    expect(scheduleFrame).toHaveBeenCalledTimes(1);
+    expect(
+      element.handlers.handleOnUpdate.mock.calls[0][1].oldProps.options,
+    ).toEqual([{ value: "one" }]);
+  });
+
+  it("retains exact old and new references for a deep-equal replacement", () => {
+    const scheduleFrame = vi.fn((callback) => callback());
+    const updateHook = createWebComponentUpdateHook({
+      scheduleFrameFn: scheduleFrame,
+    });
+    const element = createManagedElement();
+    const oldOptions = [{ value: "one" }];
+    const newOptions = [{ value: "one" }];
+    const oldVnode = {
+      data: { props: { options: oldOptions, disabled: false } },
+      elm: element,
+    };
+    updateHook.insert(oldVnode);
+
+    updateHook.update(oldVnode, {
+      data: { props: { options: newOptions, disabled: true } },
+      elm: element,
+    });
+
+    const payload = element.handlers.handleOnUpdate.mock.calls[0][1];
+    expect(payload.oldProps.options).toBe(oldOptions);
+    expect(payload.newProps.options).toBe(newOptions);
+  });
+
+  it("reports the rendered value when a prop is mutated and then replaced", () => {
+    const scheduleFrame = vi.fn((callback) => callback());
+    const updateHook = createWebComponentUpdateHook({
+      scheduleFrameFn: scheduleFrame,
+    });
+    const element = createManagedElement();
+    const oldOptions = [{ value: "rendered" }];
+    const oldVnode = {
+      data: { props: { options: oldOptions } },
+      elm: element,
+    };
+    updateHook.insert(oldVnode);
+
+    oldOptions.push({ value: "never-rendered" });
+    const newOptions = [{ value: "replacement" }];
+    updateHook.update(oldVnode, {
+      data: { props: { options: newOptions } },
+      elm: element,
+    });
+
+    const payload = element.handlers.handleOnUpdate.mock.calls[0][1];
+    expect(payload.oldProps.options).toEqual([{ value: "rendered" }]);
+    expect(payload.oldProps.options).not.toBe(oldOptions);
+    expect(payload.newProps.options).toBe(newOptions);
+  });
+
+  it("supports BigInt props during insertion and updates", () => {
+    const scheduleFrame = vi.fn((callback) => callback());
+    const updateHook = createWebComponentUpdateHook({
+      scheduleFrameFn: scheduleFrame,
+    });
+    const element = createManagedElement();
+    const oldVnode = {
+      data: { props: { selectedValue: 1n } },
+      elm: element,
+    };
+
+    expect(() => updateHook.insert(oldVnode)).not.toThrow();
+    updateHook.update(oldVnode, {
+      data: { props: { selectedValue: 2n } },
+      elm: element,
+    });
+
+    expect(scheduleFrame).toHaveBeenCalledTimes(1);
+    expect(element.handlers.handleOnUpdate.mock.calls[0][1]).toEqual({
+      oldProps: { selectedValue: 1n },
+      newProps: { selectedValue: 2n },
+    });
+  });
+
+  it("supports circular props and preserves their identity", () => {
+    const scheduleFrame = vi.fn((callback) => callback());
+    const updateHook = createWebComponentUpdateHook({
+      scheduleFrameFn: scheduleFrame,
+    });
+    const element = createManagedElement();
+    const context = { projectId: "project-1" };
+    context.self = context;
+    const oldVnode = {
+      data: { props: { context, disabled: false } },
+      elm: element,
+    };
+
+    expect(() => updateHook.insert(oldVnode)).not.toThrow();
+    updateHook.update(oldVnode, {
+      data: { props: { context, disabled: true } },
+      elm: element,
+    });
+
+    const payload = element.handlers.handleOnUpdate.mock.calls[0][1];
+    expect(payload.oldProps.context).toBe(context);
+    expect(payload.newProps.context).toBe(context);
+    expect(payload.oldProps.disabled).toBe(false);
+    expect(payload.newProps.disabled).toBe(true);
+  });
+
+  it("preserves opaque prop identities when another prop changes", () => {
+    const scheduleFrame = vi.fn((callback) => callback());
+    const updateHook = createWebComponentUpdateHook({
+      scheduleFrameFn: scheduleFrame,
+    });
+    const element = createManagedElement();
+    const callback = () => {};
+    const createdAt = new Date("2026-07-18T00:00:00.000Z");
+    const oldVnode = {
+      data: { props: { callback, createdAt, value: "old" } },
+      elm: element,
+    };
+    updateHook.insert(oldVnode);
+
+    updateHook.update(oldVnode, {
+      data: { props: { callback, createdAt, value: "new" } },
+      elm: element,
+    });
+
+    const payload = element.handlers.handleOnUpdate.mock.calls[0][1];
+    expect(payload.oldProps.callback).toBe(callback);
+    expect(payload.newProps.callback).toBe(callback);
+    expect(payload.oldProps.createdAt).toBe(createdAt);
+    expect(payload.newProps.createdAt).toBe(createdAt);
+  });
+
+  it("does not inspect or update unrelated custom elements", () => {
+    const scheduleFrame = vi.fn();
+    const updateHook = createWebComponentUpdateHook({
+      scheduleFrameFn: scheduleFrame,
+    });
+    const render = vi.fn();
+    const props = new Proxy(
+      {},
+      {
+        ownKeys() {
+          throw new Error("foreign props were inspected");
+        },
+      },
+    );
+    const oldVnode = { data: { props }, elm: { render } };
+    const nextVnode = { data: { props }, elm: oldVnode.elm };
+
+    expect(() => updateHook.insert(oldVnode)).not.toThrow();
+    expect(() => updateHook.update(oldVnode, nextVnode)).not.toThrow();
     expect(scheduleFrame).not.toHaveBeenCalled();
     expect(render).not.toHaveBeenCalled();
   });

--- a/packages/rettangoli-fe/test/runtime/component-update-hook.test.js
+++ b/packages/rettangoli-fe/test/runtime/component-update-hook.test.js
@@ -202,6 +202,52 @@ describe("createWebComponentUpdateHook", () => {
     expect(secondPayload.newProps.options).toHaveLength(4);
   });
 
+  it("defers snapshotting queued props until the scheduled frame", () => {
+    const callbacks = [];
+    const scheduleFrame = vi.fn((callback) => callbacks.push(callback));
+    const updateHook = createWebComponentUpdateHook({
+      scheduleFrameFn: scheduleFrame,
+    });
+    const element = createManagedElement();
+    const firstVnode = {
+      data: { props: { phase: "initial" } },
+      elm: element,
+    };
+    updateHook.insert(firstVnode);
+
+    const secondVnode = {
+      data: { props: { phase: "middle" } },
+      elm: element,
+    };
+    updateHook.update(firstVnode, secondVnode);
+
+    let prototypeReads = 0;
+    const latestContext = new Proxy(
+      { projectId: "project-1" },
+      {
+        getPrototypeOf(target) {
+          prototypeReads += 1;
+          return Reflect.getPrototypeOf(target);
+        },
+      },
+    );
+    const latestVnode = {
+      data: { props: { context: latestContext, phase: "latest" } },
+      elm: element,
+    };
+    updateHook.update(secondVnode, latestVnode);
+
+    expect(scheduleFrame).toHaveBeenCalledTimes(1);
+    expect(prototypeReads).toBe(0);
+
+    callbacks.shift()();
+
+    expect(prototypeReads).toBeGreaterThan(0);
+    expect(element.handlers.handleOnUpdate.mock.calls[0][1].newProps).toBe(
+      latestVnode.data.props,
+    );
+  });
+
   it("refreshes the rendered baseline from live props when the frame runs", () => {
     const callbacks = [];
     const scheduleFrame = vi.fn((callback) => callbacks.push(callback));

--- a/packages/rettangoli-fe/test/runtime/create-component.contract.test.js
+++ b/packages/rettangoli-fe/test/runtime/create-component.contract.test.js
@@ -1,5 +1,6 @@
 import { parse } from "jempl";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { RETTANGOLI_COMPONENT_MARKER } from "../../src/web/componentUpdateHook.js";
 
 let createComponent;
 let createI18nRuntime;
@@ -258,6 +259,12 @@ afterAll(() => {
 });
 
 describe("createComponent runtime contracts", () => {
+  it("brands instances for framework-owned child update hooks", () => {
+    const TestComponent = createComponentClass();
+
+    expect(new TestComponent()[RETTANGOLI_COMPONENT_MARKER]).toBe(true);
+  });
+
   it("binds named methods with payload defaulting to object", () => {
     const TestComponent = createComponentClass({
       methods: {

--- a/packages/rettangoli-ui/DEVELOPMENT.md
+++ b/packages/rettangoli-ui/DEVELOPMENT.md
@@ -232,6 +232,15 @@ Canonical `inputType` values are kebab-case only:
 - `read-only-text`
 - `slot`
 
+### Form field paths
+
+- every data field name must be a non-empty string
+- dotted field paths are supported for nested values (`user.email`)
+- path traversal uses own properties only
+- bracket notation is not supported
+- `__proto__`, `constructor`, and `prototype` are reserved and rejected in any path segment
+- legacy flat dotted defaults are normalized to nested values when written
+
 ## Events: Naming and Payloads
 
 ### Naming rules

--- a/packages/rettangoli-ui/docs/changelog.md
+++ b/packages/rettangoli-ui/docs/changelog.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Improvements
+- `rtgl-form`: rejects unsafe, bracket-style, and reserved field paths without mutating prototypes; preserves invalid-path errors during reactive validation; and keeps conditional value pruning safe with frozen store state.
 - `rtgl-dialog`: added `bare` mode for consumer-owned modal visuals while preserving native modality, focus containment, and close requests.
 - `rtgl-dialog`: keeps sequential keyboard focus inside the modal across slotted and open-shadow content instead of allowing focus to fall back to the page body at a tab boundary.
 - `rtgl-dialog`: fixed the open animation so adaptive centering is applied before the first paint, preventing the dialog from jumping from a top-biased position into the centered final state.

--- a/packages/rettangoli-ui/package.json
+++ b/packages/rettangoli-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rettangoli/ui",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "A UI component library for building web interfaces.",
   "main": "dist/rettangoli-esm.min.js",
   "type": "module",

--- a/packages/rettangoli-ui/spec/form.handlers.spec.js
+++ b/packages/rettangoli-ui/spec/form.handlers.spec.js
@@ -1,21 +1,17 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { handleOnUpdate } from "../src/components/form/form.handlers.js";
+import { bindStore } from "../../rettangoli-fe/src/core/runtime/store.js";
 import {
-  createInitialState,
-  resetFormValues,
-} from "../src/components/form/form.store.js";
+  handleOnUpdate,
+  handleValueChange,
+  handleValueInput,
+} from "../src/components/form/form.handlers.js";
+import * as formStore from "../src/components/form/form.store.js";
 
-const createStore = (overrides = {}) => {
-  const state = {
-    ...structuredClone(createInitialState()),
-    ...overrides,
-  };
-
-  return {
-    getState: () => state,
-    resetFormValues: (payload) => resetFormValues({ state }, payload),
-  };
+const createStore = ({ props, formValues = {} }) => {
+  const store = bindStore(formStore, props, {});
+  store.resetFormValues({ defaultValues: formValues });
+  return store;
 };
 
 const createRef = () => ({
@@ -23,7 +19,7 @@ const createRef = () => ({
   removeAttribute: vi.fn(),
 });
 
-describe("rtgl-form handleOnUpdate", () => {
+describe("rtgl-form handlers", () => {
   const form = {
     fields: [
       {
@@ -40,48 +36,65 @@ describe("rtgl-form handleOnUpdate", () => {
   };
 
   it("re-seeds form values when the form key changes", () => {
-    const store = createStore({
-      formValues: {
+    const oldProps = {
+      key: "section-form-1",
+      form,
+      defaultValues: {
         inheritPresentationFromSelectedLine: false,
       },
+    };
+    const newProps = {
+      key: "section-form-2",
+      form,
+      defaultValues: {
+        inheritPresentationFromSelectedLine: true,
+      },
+    };
+    const store = createStore({
+      props: newProps,
+      formValues: oldProps.defaultValues,
     });
+    const render = vi.fn();
 
     handleOnUpdate(
       {
         store,
-        render: vi.fn(),
+        render,
         refs: {
           field0: createRef(),
         },
       },
       {
-        oldProps: {
-          key: "section-form-1",
-          form,
-          defaultValues: {
-            inheritPresentationFromSelectedLine: false,
-          },
-        },
-        newProps: {
-          key: "section-form-2",
-          form,
-          defaultValues: {
-            inheritPresentationFromSelectedLine: true,
-          },
-        },
+        oldProps,
+        newProps,
       },
     );
 
     expect(store.getState().formValues).toEqual({
       inheritPresentationFromSelectedLine: true,
     });
+    expect(Object.isFrozen(store.getState().formValues)).toBe(true);
+    expect(render).toHaveBeenCalledTimes(1);
   });
 
   it("does not re-seed form values when only defaultValues changes", () => {
-    const store = createStore({
-      formValues: {
+    const oldProps = {
+      key: "section-form-1",
+      form,
+      defaultValues: {
         inheritPresentationFromSelectedLine: false,
       },
+    };
+    const newProps = {
+      key: "section-form-1",
+      form,
+      defaultValues: {
+        inheritPresentationFromSelectedLine: true,
+      },
+    };
+    const store = createStore({
+      props: newProps,
+      formValues: oldProps.defaultValues,
     });
 
     handleOnUpdate(
@@ -93,20 +106,8 @@ describe("rtgl-form handleOnUpdate", () => {
         },
       },
       {
-        oldProps: {
-          key: "section-form-1",
-          form,
-          defaultValues: {
-            inheritPresentationFromSelectedLine: false,
-          },
-        },
-        newProps: {
-          key: "section-form-1",
-          form,
-          defaultValues: {
-            inheritPresentationFromSelectedLine: true,
-          },
-        },
+        oldProps,
+        newProps,
       },
     );
 
@@ -114,4 +115,195 @@ describe("rtgl-form handleOnUpdate", () => {
       inheritPresentationFromSelectedLine: false,
     });
   });
+
+  it("prunes newly hidden fields through the live bound props", () => {
+    const oldForm = {
+      fields: [
+        { name: "visible", type: "input-text" },
+        { name: "removed", type: "input-text" },
+      ],
+    };
+    const newForm = {
+      fields: [{ name: "visible", type: "input-text" }],
+    };
+    const liveProps = {
+      key: "stable-key",
+      form: oldForm,
+    };
+    const store = createStore({
+      props: liveProps,
+      formValues: {
+        visible: "keep",
+        removed: "prune",
+      },
+    });
+    const before = store.getState();
+    const render = vi.fn();
+
+    liveProps.form = newForm;
+    handleOnUpdate(
+      {
+        store,
+        render,
+        refs: {
+          field0: createRef(),
+        },
+      },
+      {
+        oldProps: { key: "stable-key", form: oldForm },
+        newProps: { key: "stable-key", form: newForm },
+      },
+    );
+
+    expect(before.formValues).toEqual({
+      visible: "keep",
+      removed: "prune",
+    });
+    expect(store.getState().formValues).toEqual({ visible: "keep" });
+    expect(Object.isFrozen(store.getState().formValues)).toBe(true);
+    expect(render).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    ["input", handleValueInput, "form-input"],
+    ["change", handleValueChange, "form-change"],
+  ])(
+    "updates and prunes atomically on value %s",
+    (_label, handler, eventName) => {
+      const props = {
+        form: {
+          fields: [
+            {
+              name: "mode",
+              type: "select",
+              options: [
+                { label: "Basic", value: "basic" },
+                { label: "Advanced", value: "advanced" },
+              ],
+            },
+            {
+              name: "secret",
+              type: "input-text",
+              $when: 'formValues.mode == "advanced"',
+            },
+          ],
+        },
+      };
+      const store = createStore({
+        props,
+        formValues: {
+          mode: "advanced",
+          secret: "remove",
+        },
+      });
+      const before = store.getState();
+      const render = vi.fn();
+      const dispatchEvent = vi.fn();
+      const currentTarget = {
+        dataset: { fieldName: "mode" },
+        removeAttribute: vi.fn(),
+        setAttribute: vi.fn(),
+      };
+
+      handler(
+        {
+          store,
+          dispatchEvent,
+          render,
+          props,
+        },
+        {
+          _event: {
+            currentTarget,
+            detail: { value: "basic" },
+          },
+        },
+      );
+
+      expect(before.formValues).toEqual({
+        mode: "advanced",
+        secret: "remove",
+      });
+      expect(store.getState().formValues).toEqual({ mode: "basic" });
+      expect(Object.isFrozen(store.getState().formValues)).toBe(true);
+      expect(render).toHaveBeenCalledTimes(1);
+      expect(dispatchEvent).toHaveBeenCalledTimes(1);
+      const dispatchedEvent = dispatchEvent.mock.calls[0][0];
+      expect(dispatchedEvent.type).toBe(eventName);
+      expect(dispatchedEvent.detail).toEqual({
+        name: "mode",
+        value: "basic",
+        values: { mode: "basic" },
+      });
+    },
+  );
+
+  it.each([
+    ["input", handleValueInput, "form-input"],
+    ["change", handleValueChange, "form-change"],
+  ])(
+    "preserves invalid-path errors during reactive %s validation",
+    (_label, handler, eventName) => {
+      const fieldName = "profile[0].name";
+      const props = {
+        form: {
+          fields: [
+            {
+              name: fieldName,
+              type: "input-text",
+              required: true,
+            },
+          ],
+        },
+      };
+      const store = createStore({ props });
+      const initialValidation = formStore.validateForm(
+        props.form.fields,
+        store.getState().formValues,
+      );
+      store.setErrors({ errors: initialValidation.errors });
+      store.setReactiveMode();
+      const render = vi.fn();
+      const dispatchEvent = vi.fn();
+
+      handler(
+        {
+          store,
+          dispatchEvent,
+          render,
+          props,
+        },
+        {
+          _event: {
+            currentTarget: {
+              dataset: { fieldName },
+              removeAttribute: vi.fn(),
+              setAttribute: vi.fn(),
+            },
+            detail: { value: "updated" },
+          },
+        },
+      );
+
+      expect(
+        Object.prototype.hasOwnProperty.call(
+          store.getState().errors,
+          fieldName,
+        ),
+      ).toBe(true);
+      expect(store.getState().errors[fieldName]).toBe(
+        "Invalid form field path",
+      );
+      expect(store.getState().formValues).toEqual({});
+      expect(render).toHaveBeenCalledTimes(1);
+      expect(dispatchEvent).toHaveBeenCalledTimes(1);
+      const dispatchedEvent = dispatchEvent.mock.calls[0][0];
+      expect(dispatchedEvent.type).toBe(eventName);
+      expect(dispatchedEvent.detail).toEqual({
+        name: fieldName,
+        value: "updated",
+        values: {},
+      });
+    },
+  );
 });

--- a/packages/rettangoli-ui/spec/form.store.integration.spec.js
+++ b/packages/rettangoli-ui/spec/form.store.integration.spec.js
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+
+import { bindStore } from "../../rettangoli-fe/src/core/runtime/store.js";
+import * as formStore from "../src/components/form/form.store.js";
+
+const createConditionalFormProps = () => ({
+  form: {
+    fields: [
+      {
+        name: "mode",
+        type: "select",
+        options: [
+          { label: "Basic", value: "basic" },
+          { label: "Advanced", value: "advanced" },
+        ],
+      },
+      {
+        name: "secret",
+        type: "input-text",
+        $when: 'formValues.mode == "advanced"',
+      },
+    ],
+  },
+});
+
+describe("rtgl-form bound store integration", () => {
+  it("rejects unsafe paths through bound form write actions", () => {
+    const pollutionKey = "__rtglBoundFormPollutionProbe";
+    const props = {
+      form: {
+        fields: [{ name: "safe", type: "input-text" }],
+      },
+    };
+    const store = bindStore(formStore, props, {});
+
+    try {
+      store.setFormValues({
+        values: {
+          safe: "kept",
+          [`__proto__.${pollutionKey}`]: "polluted",
+          [`items.__proto__.${pollutionKey}`]: "polluted",
+        },
+      });
+      store.setFormFieldValue({
+        name: `constructor.prototype.${pollutionKey}`,
+        value: "polluted",
+      });
+
+      expect(store.getState().formValues).toEqual({ safe: "kept" });
+      expect(Object.prototype[pollutionKey]).toBeUndefined();
+      expect(Array.prototype[pollutionKey]).toBeUndefined();
+    } finally {
+      delete Object.prototype[pollutionKey];
+      delete Array.prototype[pollutionKey];
+    }
+  });
+
+  it("sets and prunes a conditional value atomically", () => {
+    const props = createConditionalFormProps();
+    const store = bindStore(formStore, props, {});
+    store.resetFormValues({
+      defaultValues: {
+        mode: "advanced",
+        secret: "keep",
+      },
+    });
+    const before = store.getState();
+
+    store.setFormFieldValue({ name: "mode", value: "basic" });
+
+    const after = store.getState();
+    expect(after).not.toBe(before);
+    expect(before.formValues).toEqual({
+      mode: "advanced",
+      secret: "keep",
+    });
+    expect(after.formValues).toEqual({ mode: "basic" });
+    expect(Object.isFrozen(before)).toBe(true);
+    expect(Object.isFrozen(before.formValues)).toBe(true);
+    expect(Object.isFrozen(after)).toBe(true);
+    expect(Object.isFrozen(after.formValues)).toBe(true);
+  });
+
+  it("prunes an already frozen state through the bound action", () => {
+    const props = createConditionalFormProps();
+    const store = bindStore(formStore, props, {});
+    store.resetFormValues({
+      defaultValues: {
+        mode: "basic",
+        secret: "stale",
+      },
+    });
+
+    expect(Object.isFrozen(store.getState().formValues)).toBe(true);
+    expect(() => store.pruneHiddenValues()).not.toThrow();
+    expect(store.getState().formValues).toEqual({ mode: "basic" });
+  });
+
+  it("stores and clears an own __proto__ validation error safely", () => {
+    const props = {
+      form: {
+        fields: [{ name: "__proto__", type: "input-text" }],
+      },
+    };
+    const store = bindStore(formStore, props, {});
+    const errors = JSON.parse('{"__proto__":"Invalid form field path"}');
+
+    store.setErrors({ errors });
+
+    expect(store.selectViewData().flatFields[0]._error).toBe(
+      "Invalid form field path",
+    );
+    expect(
+      Object.prototype.hasOwnProperty.call(
+        store.getState().errors,
+        "__proto__",
+      ),
+    ).toBe(true);
+
+    store.clearFieldError({ name: "__proto__" });
+
+    expect(store.selectViewData().flatFields[0]._error).toBeNull();
+    expect(
+      Object.prototype.hasOwnProperty.call(
+        store.getState().errors,
+        "__proto__",
+      ),
+    ).toBe(false);
+  });
+});

--- a/packages/rettangoli-ui/spec/form.store.security.spec.js
+++ b/packages/rettangoli-ui/spec/form.store.security.spec.js
@@ -1,0 +1,262 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  get,
+  selectFormValues,
+  set,
+  validateForm,
+} from "../src/components/form/form.store.js";
+
+const pollutionKey = "__rtglFormPollutionProbe";
+
+const clearPollutionProbe = () => {
+  delete Object.prototype[pollutionKey];
+  delete Array.prototype[pollutionKey];
+};
+
+afterEach(() => {
+  clearPollutionProbe();
+});
+
+describe("rtgl-form safe field paths", () => {
+  it.each([
+    ["terminal __proto__", () => ({}), "__proto__"],
+    ["root __proto__", () => ({}), `__proto__.${pollutionKey}`],
+    ["nested terminal __proto__", () => ({ profile: {} }), "profile.__proto__"],
+    [
+      "nested __proto__",
+      () => ({ profile: {} }),
+      `profile.__proto__.${pollutionKey}`,
+    ],
+    [
+      "array __proto__",
+      () => ({ items: [] }),
+      `items.__proto__.${pollutionKey}`,
+    ],
+    [
+      "constructor prototype",
+      () => ({}),
+      `constructor.prototype.${pollutionKey}`,
+    ],
+    ["terminal constructor", () => ({}), "constructor"],
+    [
+      "nested constructor",
+      () => ({ profile: {} }),
+      `profile.constructor.${pollutionKey}`,
+    ],
+    ["terminal prototype", () => ({}), "prototype"],
+    ["root prototype", () => ({}), `prototype.${pollutionKey}`],
+    [
+      "nested prototype",
+      () => ({ profile: {} }),
+      `profile.prototype.${pollutionKey}`,
+    ],
+  ])(
+    "rejects %s paths without mutating the target",
+    (_label, createTarget, path) => {
+      const target = createTarget();
+      const expected = structuredClone(target);
+      const prototypeSnapshots = [target, ...Object.values(target)]
+        .filter((value) => value !== null && typeof value === "object")
+        .map((value) => [value, Object.getPrototypeOf(value)]);
+
+      try {
+        expect(set(target, path, { [pollutionKey]: "polluted" })).toBe(target);
+        expect(Object.prototype[pollutionKey]).toBeUndefined();
+        expect(Array.prototype[pollutionKey]).toBeUndefined();
+        prototypeSnapshots.forEach(([value, prototype]) => {
+          expect(Object.getPrototypeOf(value)).toBe(prototype);
+        });
+        expect(target).toEqual(expected);
+        expect(get(target, path, "fallback")).toBe("fallback");
+      } finally {
+        clearPollutionProbe();
+      }
+    },
+  );
+
+  it("does not read or mutate inherited branches", () => {
+    const inherited = {
+      user: {
+        name: "Inherited",
+      },
+    };
+    const target = Object.create(inherited);
+
+    expect(get(target, "user.name", "fallback")).toBe("fallback");
+
+    set(target, "user.name", "Owned");
+
+    expect(Object.prototype.hasOwnProperty.call(target, "user")).toBe(true);
+    expect(target.user).toEqual({ name: "Owned" });
+    expect(inherited.user).toEqual({ name: "Inherited" });
+  });
+
+  it("does not invoke inherited setters while creating own branches", () => {
+    let setterCalls = 0;
+    const prototype = {};
+    Object.defineProperty(prototype, "user", {
+      configurable: true,
+      set() {
+        setterCalls++;
+      },
+    });
+    const target = Object.create(prototype);
+
+    set(target, "user.name", "Owned");
+
+    expect(setterCalls).toBe(0);
+    expect(Object.prototype.hasOwnProperty.call(target, "user")).toBe(true);
+    expect(target.user).toEqual({ name: "Owned" });
+  });
+
+  it("returns the fallback for primitive and null intermediates", () => {
+    expect(get({ user: "text" }, "user.name", "fallback")).toBe("fallback");
+    expect(get({ user: null }, "user.name", "fallback")).toBe("fallback");
+  });
+
+  it("preserves safe dotted-path normalization", () => {
+    const target = {
+      "user.email": "old@example.com",
+      sibling: true,
+    };
+
+    expect(set(target, "user.email", "new@example.com")).toBe(target);
+    expect(target).toEqual({
+      user: {
+        email: "new@example.com",
+      },
+      sibling: true,
+    });
+    expect(get(target, "user.email")).toBe("new@example.com");
+  });
+
+  it("preserves nested-over-flat reads and own array traversal", () => {
+    const target = {
+      "user.email": "flat@example.com",
+      user: {
+        email: "nested@example.com",
+      },
+      items: [{ name: "First" }],
+    };
+
+    expect(get(target, "user.email")).toBe("nested@example.com");
+    expect(get(target, "items.0.name")).toBe("First");
+  });
+
+  it("selects own falsy values and omits missing values", () => {
+    const fields = [
+      { name: "enabled", type: "checkbox" },
+      { name: "count", type: "input-number" },
+      { name: "label", type: "input-text" },
+      { name: "choice", type: "select" },
+      { name: "missing", type: "input-text" },
+    ];
+
+    expect(
+      selectFormValues({
+        state: {
+          formValues: {
+            enabled: false,
+            count: 0,
+            label: "",
+            choice: null,
+          },
+        },
+        props: { form: { fields } },
+      }),
+    ).toEqual({
+      enabled: false,
+      count: 0,
+      label: "",
+      choice: null,
+    });
+  });
+
+  it("does not expose values inherited from Object.prototype", () => {
+    Object.prototype[pollutionKey] = "inherited";
+
+    try {
+      const values = selectFormValues({
+        state: { formValues: {} },
+        props: {
+          form: {
+            fields: [{ name: pollutionKey, type: "input-text" }],
+          },
+        },
+      });
+
+      expect(values).toEqual({});
+    } finally {
+      clearPollutionProbe();
+    }
+  });
+
+  it("does not copy a JSON-owned __proto__ path into the output prototype", () => {
+    const formValues = JSON.parse(
+      `{"__proto__":{"${pollutionKey}":"polluted"}}`,
+    );
+
+    try {
+      const values = selectFormValues({
+        state: { formValues },
+        props: {
+          form: {
+            fields: [
+              {
+                name: `__proto__.${pollutionKey}`,
+                type: "input-text",
+              },
+            ],
+          },
+        },
+      });
+
+      expect(values).toEqual({});
+      expect(Object.prototype[pollutionKey]).toBeUndefined();
+    } finally {
+      clearPollutionProbe();
+    }
+  });
+
+  it.each([
+    "__proto__",
+    `profile.__proto__.${pollutionKey}`,
+    `constructor.prototype.${pollutionKey}`,
+    `profile.prototype.${pollutionKey}`,
+  ])("reports an invalid form configuration for reserved path %s", (path) => {
+    const result = validateForm(
+      [{ name: path, type: "input-text", required: true }],
+      {},
+    );
+
+    expect(result.valid).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(result.errors, path)).toBe(
+      true,
+    );
+    expect(result.errors[path]).toBe("Invalid form field path");
+    expect(Object.prototype[pollutionKey]).toBeUndefined();
+  });
+
+  it.each([
+    ["symbol", Symbol("field")],
+    ["number", 42],
+    ["empty string", ""],
+    ["missing", undefined],
+  ])(
+    "reports an invalid form configuration for a %s field name",
+    (_label, name) => {
+      const result = validateForm(
+        [{ name, type: "input-text", required: true }],
+        {},
+      );
+
+      expect(result).toEqual({
+        valid: false,
+        errors: {
+          "$invalidFieldPath:0": "Invalid form field path",
+        },
+      });
+    },
+  );
+});

--- a/packages/rettangoli-ui/spec/tagSelect.handlers.spec.js
+++ b/packages/rettangoli-ui/spec/tagSelect.handlers.spec.js
@@ -121,6 +121,46 @@ describe("rtgl-tag-select handlers", () => {
     expect(render).toHaveBeenCalledTimes(1);
   });
 
+  it("preserves an uncontrolled draft when only options changed", () => {
+    const selectedValues = ["bug"];
+    const options = [
+      { value: "bug", label: "Bug" },
+      { value: "platform", label: "Platform" },
+    ];
+    const store = createStore({
+      isOpen: true,
+      hasSelectedValues: true,
+      selectedValues: ["bug"],
+      draftSelectedValues: ["bug", "platform"],
+    });
+    const render = vi.fn();
+
+    handleOnUpdate(
+      {
+        store,
+        render,
+        refs: {},
+      },
+      {
+        oldProps: {
+          options: [{ value: "bug", label: "Bug" }],
+          selectedValues,
+        },
+        newProps: {
+          options,
+          selectedValues,
+        },
+      },
+    );
+
+    expect(store.getState().selectedValues).toEqual(["bug"]);
+    expect(store.getState().draftSelectedValues).toEqual([
+      "bug",
+      "platform",
+    ]);
+    expect(render).toHaveBeenCalledTimes(1);
+  });
+
   it("emits open-change when an open tag select becomes disabled", () => {
     const store = createStore({
       isOpen: true,

--- a/packages/rettangoli-ui/src/components/form/form.handlers.js
+++ b/packages/rettangoli-ui/src/components/form/form.handlers.js
@@ -5,8 +5,6 @@ import {
   selectFormValues,
   collectAllDataFields,
   getDefaultValue,
-  pruneHiddenValues,
-  validateField,
   validateForm,
 } from "./form.store.js";
 
@@ -160,8 +158,8 @@ export const handleOnUpdate = (deps, payload) => {
     initFormValues(store, newProps);
   }
 
+  store.pruneHiddenValues();
   const state = store.getState();
-  pruneHiddenValues({ state, props: newProps });
   const form = selectForm({ state, props: newProps });
   updateFieldAttributes({
     form,
@@ -184,7 +182,6 @@ export const handleValueInput = (deps, payload) => {
   store.setFormFieldValue({ name, value });
 
   const state = store.getState();
-  pruneHiddenValues({ state, props });
   const form = selectForm({ state, props });
   const dataFields = collectAllDataFields(form.fields || []);
   const field = dataFields.find((f) => f.name === name);
@@ -198,7 +195,10 @@ export const handleValueInput = (deps, payload) => {
   // Reactive validation
   if (state.reactiveMode) {
     if (field) {
-      const error = validateField(field, value);
+      const { errors } = validateForm([field], state.formValues);
+      const error = Object.prototype.hasOwnProperty.call(errors, name)
+        ? errors[name]
+        : null;
       if (error) {
         store.setErrors({ errors: { ...state.errors, [name]: error } });
       } else {
@@ -234,7 +234,6 @@ export const handleValueChange = (deps, payload) => {
   store.setFormFieldValue({ name, value });
 
   const state = store.getState();
-  pruneHiddenValues({ state, props });
   const form = selectForm({ state, props });
   const dataFields = collectAllDataFields(form.fields || []);
   const field = dataFields.find((f) => f.name === name);
@@ -248,7 +247,10 @@ export const handleValueChange = (deps, payload) => {
   // Reactive validation
   if (state.reactiveMode) {
     if (field) {
-      const error = validateField(field, value);
+      const { errors } = validateForm([field], state.formValues);
+      const error = Object.prototype.hasOwnProperty.call(errors, name)
+        ? errors[name]
+        : null;
       if (error) {
         store.setErrors({ errors: { ...state.errors, [name]: error } });
       } else {

--- a/packages/rettangoli-ui/src/components/form/form.store.js
+++ b/packages/rettangoli-ui/src/components/form/form.store.js
@@ -21,6 +21,63 @@ const isObjectLike = (value) => value !== null && typeof value === "object";
 const isPlainObject = (value) => isObjectLike(value) && !Array.isArray(value);
 const isPathLike = (path) => typeof path === "string" && path.includes(".");
 const hasBracketPathToken = (path) => typeof path === "string" && /[\[\]]/.test(path);
+const unsafePathSegments = new Set(["__proto__", "constructor", "prototype"]);
+const hasOwn = (obj, key) => Object.prototype.hasOwnProperty.call(obj, key);
+
+const parseSafePath = (path) => {
+  if (
+    typeof path !== "string" ||
+    path.length === 0 ||
+    hasBracketPathToken(path)
+  ) {
+    return null;
+  }
+
+  const keys = path.split(".").filter((key) => key !== "");
+  if (keys.length === 0 || keys.some((key) => unsafePathSegments.has(key))) {
+    return null;
+  }
+
+  return keys;
+};
+
+const defineOwnValue = (obj, key, value) => {
+  Object.defineProperty(obj, key, {
+    configurable: true,
+    enumerable: true,
+    value,
+    writable: true,
+  });
+};
+
+const findInheritedDescriptor = (obj, key) => {
+  let prototype = Object.getPrototypeOf(obj);
+  while (prototype) {
+    const descriptor = Object.getOwnPropertyDescriptor(prototype, key);
+    if (descriptor) return descriptor;
+    prototype = Object.getPrototypeOf(prototype);
+  }
+  return null;
+};
+
+const setOwnValue = (obj, key, value) => {
+  const ownDescriptor = Object.getOwnPropertyDescriptor(obj, key);
+  const inheritedDescriptor = ownDescriptor
+    ? null
+    : findInheritedDescriptor(obj, key);
+  const descriptor = ownDescriptor || inheritedDescriptor;
+  const assignmentCouldBeIntercepted =
+    descriptor &&
+    (!Object.prototype.hasOwnProperty.call(descriptor, "value") ||
+      descriptor.writable === false);
+
+  if (assignmentCouldBeIntercepted) {
+    defineOwnValue(obj, key, value);
+    return;
+  }
+
+  obj[key] = value;
+};
 
 function pickByPaths(obj, paths) {
   const result = {};
@@ -73,14 +130,14 @@ function normalizeWhenDirectives(form) {
 
 // Nested property access utilities
 export const get = (obj, path, defaultValue = undefined) => {
-  if (!path) return defaultValue;
   if (!isObjectLike(obj)) return defaultValue;
-  if (hasBracketPathToken(path)) return defaultValue;
-  const keys = path.split(".").filter((key) => key !== "");
+  const keys = parseSafePath(path);
+  if (!keys) return defaultValue;
+
   let current = obj;
   for (const key of keys) {
-    if (current === null || current === undefined || !(key in current)) {
-      if (Object.prototype.hasOwnProperty.call(obj, path)) {
+    if (!isObjectLike(current) || !hasOwn(current, key)) {
+      if (hasOwn(obj, path)) {
         return obj[path];
       }
       return defaultValue;
@@ -91,32 +148,26 @@ export const get = (obj, path, defaultValue = undefined) => {
 };
 
 export const set = (obj, path, value) => {
-  if (!isObjectLike(obj) || typeof path !== "string" || path.length === 0) {
+  if (!isObjectLike(obj)) {
     return obj;
   }
-  if (hasBracketPathToken(path)) {
-    return obj;
-  }
-  const keys = path.split(".").filter((key) => key !== "");
-  if (keys.length === 0) {
-    return obj;
-  }
-  if (isPathLike(path) && Object.prototype.hasOwnProperty.call(obj, path)) {
+
+  const keys = parseSafePath(path);
+  if (!keys) return obj;
+
+  if (isPathLike(path) && hasOwn(obj, path)) {
     delete obj[path];
   }
+
   let current = obj;
   for (let i = 0; i < keys.length - 1; i++) {
     const key = keys[i];
-    if (
-      !(key in current) ||
-      typeof current[key] !== "object" ||
-      current[key] === null
-    ) {
-      current[key] = {};
+    if (!hasOwn(current, key) || !isObjectLike(current[key])) {
+      setOwnValue(current, key, {});
     }
     current = current[key];
   }
-  current[keys[keys.length - 1]] = value;
+  setOwnValue(current, keys[keys.length - 1], value);
   return obj;
 };
 
@@ -357,11 +408,20 @@ export const validateForm = (fields, formValues) => {
   const errors = {};
   const dataFields = collectAllDataFields(fields);
 
-  for (const field of dataFields) {
+  for (const [index, field] of dataFields.entries()) {
+    if (!parseSafePath(field.name)) {
+      const errorKey =
+        typeof field.name === "string" && field.name.length > 0
+          ? field.name
+          : `$invalidFieldPath:${index}`;
+      defineOwnValue(errors, errorKey, "Invalid form field path");
+      continue;
+    }
+
     const value = get(formValues, field.name);
     const error = validateField(field, value);
     if (error) {
-      errors[field.name] = error;
+      defineOwnValue(errors, field.name, error);
     }
   }
 
@@ -502,7 +562,9 @@ export const selectViewData = ({ state, props }) => {
     field._disabled = formDisabled || !!field.disabled;
 
     if (isData && field.name) {
-      field._error = state.errors[field.name] || null;
+      field._error = hasOwn(state.errors, field.name)
+        ? state.errors[field.name]
+        : null;
     }
 
     // Type-specific computed props
@@ -619,12 +681,13 @@ export const resetFormValues = ({ state }, payload = {}) => {
 };
 
 export const setErrors = ({ state }, payload = {}) => {
-  state.errors = payload.errors || {};
+  const errors = isPlainObject(payload.errors) ? payload.errors : {};
+  state.errors = Object.fromEntries(Object.entries(errors));
 };
 
 export const clearFieldError = ({ state }, payload = {}) => {
   const { name } = payload;
-  if (name && state.errors[name]) {
+  if (name && hasOwn(state.errors, name)) {
     delete state.errors[name];
   }
 };


### PR DESCRIPTION
## Summary

This PR consolidates #437, #438, and #439 into one frontend release candidate.

### FE watch and CLI

- serve the configured public directory during FE watch mode
- document the public-directory behavior
- cover public assets in the Vite watch integration suite

### FE component update semantics

- detect supported in-place prop mutations without requiring JSON-only values
- preserve original identity for unchanged props in `handleOnUpdate` payloads
- retain supported non-JSON values and tolerate circular data
- scope update snapshots to Rettangoli components
- preserve explicit component `render()` behavior; rendering is not automated

### UI form correctness and security

- reject bracket-style and reserved field paths that could traverse prototypes
- use own-property-safe nested reads, writes, selected values, and validation errors
- make conditional-field pruning atomic through the bound Immer store
- preserve invalid-path configuration errors during reactive input/change validation
- keep each handler's existing explicit single-render behavior

### Release metadata

- `@rettangoli/fe`: 1.2.2
- `@rettangoli/ui`: 1.10.1
- `rtgl`: 2.0.2
- CLI exact FE dependency: 1.2.2
- root lockfile and UI changelog updated

## Suggested review order

1. FE watch behavior and CLI wiring
2. FE component update snapshots and prop identity semantics
3. UI form path safety and reactive validation
4. Tests, documentation, and release metadata

## Verification

- frozen root install: no lockfile changes
- FE: 203 tests passed across 16 files
- UI: 179 tests passed across 18 files
- FE generation, UI development bundle, and CSS copy completed
- visual capture: 313/313 succeeded
- visual report: 0 mismatches across 350 images
- `git diff --check` passed

## Known existing gate

`bun run check:contracts` still reports the existing UI checker backlog: 8 legacy component-directory naming diagnostics and 231 unknown custom-element registry diagnostics. These changes do not add contract diagnostics.

Supersedes #437, #438, and #439.
