### PR TITLE
Fix Check npm provenance and release 0.1.4

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -27,7 +27,7 @@
     },
     "packages/rettangoli-check": {
       "name": "@rettangoli/check",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "bin": {
         "rtgl-check": "./src/cli/bin.js",
       },
@@ -47,7 +47,7 @@
       },
       "dependencies": {
         "@rettangoli/be": "2.0.0",
-        "@rettangoli/check": "0.1.3",
+        "@rettangoli/check": "0.1.4",
         "@rettangoli/fe": "1.2.3",
         "@rettangoli/sites": "1.2.0",
         "@rettangoli/ui": "1.11.0",

--- a/packages/rettangoli-check/package.json
+++ b/packages/rettangoli-check/package.json
@@ -1,8 +1,13 @@
 {
   "name": "@rettangoli/check",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Static contract checker for Rettangoli projects",
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/yuusoft-org/rettangoli",
+    "directory": "packages/rettangoli-check"
+  },
   "main": "./src/index.js",
   "exports": {
     ".": "./src/index.js",

--- a/packages/rettangoli-check/scripts/package-smoke-test.js
+++ b/packages/rettangoli-check/scripts/package-smoke-test.js
@@ -4,6 +4,7 @@ import {
   existsSync,
   mkdirSync,
   mkdtempSync,
+  readdirSync,
   readFileSync,
   rmSync,
   writeFileSync,
@@ -47,14 +48,23 @@ function run(command, args, options = {}) {
 }
 
 function packPackage(directory) {
-  const output = run(
+  const existingTarballs = new Set(
+    readdirSync(temporaryDirectory).filter((entry) => entry.endsWith(".tgz")),
+  );
+  run(
     npmCommand,
     ["pack", "--silent", "--pack-destination", temporaryDirectory],
     { cwd: directory },
   );
-  const match = output.match(/(?:^|\r?\n)([^\r\n]+\.tgz)\s*$/);
-  assert.ok(match, `npm pack did not report a tarball:\n${output}`);
-  return path.join(temporaryDirectory, match[1]);
+  const newTarballs = readdirSync(temporaryDirectory).filter(
+    (entry) => entry.endsWith(".tgz") && !existingTarballs.has(entry),
+  );
+  assert.equal(
+    newTarballs.length,
+    1,
+    `npm pack did not create exactly one tarball for ${directory}`,
+  );
+  return path.join(temporaryDirectory, newTarballs[0]);
 }
 
 try {

--- a/packages/rettangoli-check/scripts/package-smoke-test.js
+++ b/packages/rettangoli-check/scripts/package-smoke-test.js
@@ -96,6 +96,15 @@ try {
       "utf8",
     ),
   );
+  assert.deepEqual(
+    installedPackageJson.repository,
+    {
+      type: "git",
+      url: "https://github.com/yuusoft-org/rettangoli",
+      directory: "packages/rettangoli-check",
+    },
+    "the published package must declare repository metadata for npm provenance",
+  );
   assert.ok(
     existsSync(path.join(installedPackageDirectory, "LICENSE")),
     "the published package must include its license",

--- a/packages/rettangoli-cli/package.json
+++ b/packages/rettangoli-cli/package.json
@@ -49,7 +49,7 @@
   "dependencies": {
     "commander": "^14.0.0",
     "js-yaml": "^4.1.0",
-    "@rettangoli/check": "0.1.3",
+    "@rettangoli/check": "0.1.4",
     "@rettangoli/be": "2.0.0",
     "@rettangoli/fe": "1.2.3",
     "@rettangoli/sites": "1.2.0",


### PR DESCRIPTION
## Summary

- add repository metadata required by npm provenance verification
- release Check as 0.1.4 without moving the failed 0.1.3 tag
- keep CLI at 2.0.3 and update it to depend on Check 0.1.4
- assert repository metadata in the packed-package smoke test
- make tarball detection work with npm versions that suppress silent pack output

## Verification

- bun install --frozen-lockfile
- Check tests and packed-package smoke passed in the tag workflow before npm rejected only the missing repository metadata
- packed-package smoke passes locally after the tarball detection fix

After merge, release order is check-v0.1.4 followed by cli-v2.0.3.