### PR TITLE
feat(fe): make the package renderable outside a browser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ CLAUDE.md
 .codex-runs/
 **/.codex-journal.md
 **/.codex-compiler-journal.md
+
+# vitest temp dirs created by fe cli integration tests
+**/.tmp-tests/

--- a/bun.lock
+++ b/bun.lock
@@ -27,12 +27,12 @@
     },
     "packages/rettangoli-check": {
       "name": "@rettangoli/check",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "bin": {
         "rtgl-check": "./src/cli/bin.js",
       },
       "dependencies": {
-        "@rettangoli/ui": "1.15.0",
+        "@rettangoli/ui": "1.15.1",
         "jempl": "0.3.2-rc2",
         "js-yaml": "^4.1.0",
         "oxc-parser": "^0.112.0",
@@ -41,16 +41,16 @@
     },
     "packages/rettangoli-cli": {
       "name": "rtgl",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "bin": {
         "rtgl": "cli.js",
       },
       "dependencies": {
         "@rettangoli/be": "2.0.0",
-        "@rettangoli/check": "0.1.5",
-        "@rettangoli/fe": "1.3.0",
+        "@rettangoli/check": "0.1.6",
+        "@rettangoli/fe": "1.4.0",
         "@rettangoli/sites": "1.3.0",
-        "@rettangoli/ui": "1.15.0",
+        "@rettangoli/ui": "1.15.1",
         "@rettangoli/vt": "1.1.0",
         "commander": "^14.0.0",
         "js-yaml": "^4.1.0",
@@ -58,7 +58,7 @@
     },
     "packages/rettangoli-fe": {
       "name": "@rettangoli/fe",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "dependencies": {
         "immer": "^10.1.1",
         "jempl": "1.0.1",
@@ -115,9 +115,9 @@
     },
     "packages/rettangoli-ui": {
       "name": "@rettangoli/ui",
-      "version": "1.15.0",
+      "version": "1.15.1",
       "dependencies": {
-        "@rettangoli/fe": "1.3.0",
+        "@rettangoli/fe": "1.4.0",
         "jempl": "1.0.1",
       },
       "devDependencies": {

--- a/packages/rettangoli-check/package.json
+++ b/packages/rettangoli-check/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rettangoli/check",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Static contract checker for Rettangoli projects",
   "type": "module",
   "repository": {
@@ -47,7 +47,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@rettangoli/ui": "1.15.0",
+    "@rettangoli/ui": "1.15.1",
     "jempl": "0.3.2-rc2",
     "js-yaml": "^4.1.0",
     "oxc-parser": "^0.112.0",

--- a/packages/rettangoli-cli/package.json
+++ b/packages/rettangoli-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rtgl",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "CLI tool for Rettangoli - A frontend framework and development toolkit",
   "type": "module",
   "bin": {
@@ -49,11 +49,11 @@
   "dependencies": {
     "commander": "^14.0.0",
     "js-yaml": "^4.1.0",
-    "@rettangoli/check": "0.1.5",
+    "@rettangoli/check": "0.1.6",
     "@rettangoli/be": "2.0.0",
-    "@rettangoli/fe": "1.3.0",
+    "@rettangoli/fe": "1.4.0",
     "@rettangoli/sites": "1.3.0",
     "@rettangoli/vt": "1.1.0",
-    "@rettangoli/ui": "1.15.0"
+    "@rettangoli/ui": "1.15.1"
   }
 }

--- a/packages/rettangoli-fe/docs/ssr-plan.md
+++ b/packages/rettangoli-fe/docs/ssr-plan.md
@@ -53,10 +53,22 @@ Two decisions from §10.0 were resolved during implementation:
   Only 2 of 113 lines touch `window`.
 - **§5.6 template normalization → do not change the code.** The reviewed claim
   that the pass is not idempotent is correct, but the build inlines the *raw*
-  AST and normalization runs once per template object at runtime, so there is no
-  live bug. Relaxing the validator would loosen authoring semantics for no gain.
-  The constraint is now captured in `test/runtime/template-normalization.test.js`
-  so nobody attempts the build-time move.
+  AST and normalization runs once per template object at runtime, so there is
+  no live bug.
+
+  Two fixes were attempted and both rejected on evidence. Relaxing the
+  validator to accept the normalized form would loosen authoring semantics.
+  And a friendlier "this template is already normalized" error turns out to be
+  impossible: `:value=title` is simultaneously what the normalizer produces
+  **and** legitimate legacy author syntax that the framework deliberately
+  rejects (`loop-property-binding.test.js`, "rejects legacy property-form
+  source syntax"). The two are byte-identical, so any special-casing would
+  mislead the far more common case. That attempt broke an existing test, which
+  is how it was caught.
+
+  The constraint is captured in `test/runtime/template-normalization.test.js`,
+  including a test asserting the two cases produce the *same* message, so the
+  reason it cannot be improved is recorded rather than rediscovered.
 
 **Decision B (`rtgl-popover`) remains open** and only blocks Part B stage B4.
 

--- a/packages/rettangoli-fe/docs/ssr-plan.md
+++ b/packages/rettangoli-fe/docs/ssr-plan.md
@@ -565,7 +565,10 @@ violate is worth more than a contract with more slots.
 
 ### 5.6 [A] Exports, tooling, and three latent bugs — small
 
-- `"./server"` and `"./parser"` entries in the exports map. This also removes a
+- A `"./server"` entry in the exports map. (Shipped as `./server` only: a
+  separate `./parser` entry was dropped, because `renderView` supplies snabbdom's
+  `h` and jempl's parser itself and callers no longer need the raw `parseView`.)
+  This also removes a
   live hazard: `tests/support/renderView.js` reaches into
   `node_modules/@rettangoli/fe/node_modules/jempl` by path, binding a
   different jempl version than the app hoists — the test helper can compile

--- a/packages/rettangoli-fe/docs/ssr-plan.md
+++ b/packages/rettangoli-fe/docs/ssr-plan.md
@@ -1,0 +1,945 @@
+# SSR for @rettangoli/fe — implementation plan
+
+Status: proposal, backed by a working prototype.
+Scope: framework-level (`@rettangoli/fe`).
+
+The prototype and its test suite live outside this repo, in the app used to
+validate the design:
+
+    RouteVN/routevn-creator-client/ssr-poc/
+
+Every measurement below comes from that prototype running against a real
+consumer app (108 views, 75 components, 33 pages). Paths of the form
+`rvn-app` / `rvn-projects` are that app's components, cited as evidence rather
+than as part of the design.
+
+---
+
+## 0. Status
+
+**Part A is implemented and merged into `packages/rettangoli-fe`.** Part B is
+unstarted and remains a separate decision.
+
+What shipped:
+
+| | |
+|---|---|
+| `src/web/vendor/snabbdomStyleModule.js` | vendored from snabbdom 3.6.2; two lines changed so `raf` resolves lazily |
+| `src/core/component/resolveComponentDefinition.js` | moved out of `createComponent.js`, off the patch's import graph |
+| `src/core/server/serializeVNode.js` | vnode → HTML, ~190 lines |
+| `src/server/index.js` | the Node-safe entry |
+| `src/web/componentDom.js` | render-target adoption hardened; inline styles no longer clobbered |
+| `package.json` | `./server` and `./parser` exports |
+
+Verification: **302 tests** in `@rettangoli/fe` (up from 237), **8/8** browser
+checks against real Chromium, package smoke test (pack → install → import), and
+`@rettangoli/ui` builds and passes its 260 tests against the modified
+framework. Full monorepo run matches the pre-change baseline exactly — the same
+four pre-existing failures in `rettangoli-be` / `rettangoli-tui` /
+`rettangoli-cli`, none touched by this work.
+
+The headline result:
+
+```
+$ node -e "import('@rettangoli/fe')"
+# before: ReferenceError: window is not defined
+# after:  resolves
+```
+
+Two decisions from §10.0 were resolved during implementation:
+
+- **Decision A → vendor the style module.** Confirmed the reviewed diagnosis:
+  the throw is at *module evaluation*, so no amount of lazy instantiation helps.
+  Only 2 of 113 lines touch `window`.
+- **§5.6 template normalization → do not change the code.** The reviewed claim
+  that the pass is not idempotent is correct, but the build inlines the *raw*
+  AST and normalization runs once per template object at runtime, so there is no
+  live bug. Relaxing the validator would loosen authoring semantics for no gain.
+  The constraint is now captured in `test/runtime/template-normalization.test.js`
+  so nobody attempts the build-time move.
+
+**Decision B (`rtgl-popover`) remains open** and only blocks Part B stage B4.
+
+---
+
+## 1. Summary
+
+### 1.1 This is two projects, not one
+
+Read the rest of this document with that split in mind. Conflating them is what
+makes the scope look larger and riskier than it is.
+
+**Project A — make the framework renderable outside a browser.**
+Finish the core/binding separation the framework already started, and add a
+vnode→HTML serializer. Small, low-risk, and **commits you to nothing about
+SSR**. Worth shipping on its own merits: it makes the package importable in
+Node, gives the project HTML golden tests it currently has none of, and fixes
+three latent bugs.
+
+**Project B — SSR itself.**
+Recursive renderer, hydration, registration order, telemetry, parity gates.
+Larger, and a genuine product bet with an ongoing maintenance cost, because
+hydration mismatches fail silently rather than loudly.
+
+**Recommendation: do A now, decide B separately.** A is finishing something
+already in progress — `src/core/**` is already pure and all DOM already lives
+in `src/web/`; the separation is simply unfinished, undone by one module-scope
+line. If B never happens, none of A is wasted. If B does happen, A is what
+makes it assembly rather than invention.
+
+**The trap to avoid** is doing B first. Writing the server renderer as a second
+copy of the component construction sequence, before extracting the shared core,
+makes the framework harder to maintain rather than better. Order matters more
+than scope here.
+
+Sections below are tagged **[A]** or **[B]** accordingly.
+
+### 1.2 What B delivers, if you do it
+
+Server-render `@rettangoli/fe` components to HTML, paint that HTML before any
+application JavaScript runs, then have the client **adopt** it rather than
+rebuild it.
+
+A prototype of the full path exists and works. Measured in Chromium at 4× CPU
+throttle:
+
+| | first contentful paint | pre-JS UI | hydration |
+|---|---|---|---|
+| today | ~1600 ms | blank | — |
+| prototype | **~120 ms** | fully styled, correct layout | `hydrated=5 mismatched=0` |
+
+The prototype renders the app shell and route page in bare Node with no DOM
+shim, no headless browser, and no prop serialization. Server output is 7.7 KB
+against a 596-byte shell today — roughly 1.5 KB gzipped, ~0.1% of the bundle.
+
+**What this buys:** the page looks correct almost immediately instead of being
+black for ~1.6 s.
+
+**What it does not buy:** time-to-interactive is unchanged, and data the server
+cannot see still arrives when it arrives. This is a perceived-quality change,
+not a performance one. That distinction should survive into how it is
+described internally.
+
+---
+
+## 2. How it works
+
+### 2.1 Rendering
+
+The render path is already environment-agnostic. `parseView` takes `h` by
+injection and never inspects its return value, so the server calls the same
+parser the browser does and serializes the resulting vnode tree:
+
+```
+createInitialState → selectViewData → parseView → serializeVNode → HTML
+```
+
+Handlers are never invoked server-side. The output is the component's initial
+state — chrome, empty states, loading states.
+
+Because components are wired by **tag name** rather than by import, the
+renderer must resolve tags itself and recurse. Without recursion the entire
+app shell serializes to 688 bytes of empty custom elements; with it, 6.5 KB of
+real UI.
+
+### 2.2 Markup shape
+
+Every component gets its **own** declarative shadow root:
+
+```html
+<rvn-app data-rtgl-hydrate="true">
+  <template shadowrootmode="open">
+    <div data-rtgl-render-target style="display: contents">
+      <rtgl-view d="h" w="f" h="f">
+        <rvn-projects data-rtgl-hydrate="">
+          <template shadowrootmode="open">
+            <div data-rtgl-render-target style="display: contents">
+              …
+```
+
+Nesting matters. Each component attaches its own shadow root on upgrade, so a
+child whose subtree was written into its *light* DOM has that subtree
+unslotted and discarded the moment it upgrades. Per-component shadow roots are
+what let each one adopt its own output.
+
+The only SSR-specific markup is `data-rtgl-hydrate` on component hosts. No
+per-node keys, no comment separators, no JSON payloads.
+
+### 2.3 Why it paints before the app bundle
+
+The UI primitive bundle is a **blocking** `<script>` in `<head>`, so all
+`rtgl-*` elements are defined before `<body>` is parsed. Server-emitted
+`rtgl-view`/`rtgl-text` therefore upgrade at their start tag and paint fully
+styled, with no application JavaScript involved.
+
+> **Do not add `defer` to the UI bundle.** Measured: blocking gives FCP ~120 ms
+> with a correct full-viewport layout; deferred gives a faster FCP number but
+> paints a 130×22 px blob at top-left that then reflows. The blocking script is
+> what makes prerendering free.
+
+One CSS rule is required, or the host is an unknown element (`display: inline`)
+and the tree collapses to a ~14 px strip:
+
+```css
+rvn-app { display: block; height: var(--rvn-app-viewport-height, 100vh); min-height: 0; }
+```
+
+This rule already ships in `static/ios/index.html`; it is simply absent from
+the web shell.
+
+### 2.4 Hydration
+
+The client's first patch must diff against the server DOM, not append beside
+it. Snabbdom's `patch(element, vnode)` calls `emptyNodeAt()`, which synthesises
+an old vnode with `children: []` — so `updateChildren` only ever calls
+`addVnodes` and the server tree survives untouched *next to* a second copy.
+This was reproduced: it is visibly corrupt, not subtle.
+
+The fix is a structural zip: walk the freshly computed vDom and the live DOM in
+parallel, mirror the client's own `sel`/`key` onto the old vnode, and point
+`elm` at the real node. Leave `data` empty so every snabbdom module treats each
+node as new — attributes re-applied idempotently, props assigned, and
+`eventListeners` sees `oldOn === undefined` and binds every listener to the
+**server's** elements.
+
+Snabbdom's shipped `toVNode` cannot be used: it builds `sel` as
+`tag#id.class` while the parser emits a bare tag, and never restores
+`data.key`. Both make `sameVnode` fail.
+
+On any structural divergence the zip returns `null` and that subtree falls back
+to a normal client render.
+
+> **CORRECTION (review, 26 Jul).** An earlier draft claimed "mismatches cost
+> the benefit, never correctness". **That was false as implemented.**
+> `initializeComponentDom` adopts an existing `[data-rtgl-render-target]` and
+> never clears it, so the fallback `patch(renderTarget, vDom)` runs
+> `emptyNodeAt` → `children: []` → `addVnodes` and **stacks the client tree
+> beside the surviving server tree** — precisely the corruption this document
+> holds up as the cautionary case. Reproduced in Chromium: the prototype's
+> `/project/variables` run showed 4 render-target roots against a baseline of 2.
+>
+> The fix is one line and is now **required work in §5.3**: on an SSR-marked
+> host, `renderTarget.replaceChildren()` before any non-hydrating first patch.
+> Verified: 4 roots → 2. The same reset is needed on the throw path, where
+> `componentOrchestrator.js` returns `instance._oldVNode || null` and can leave
+> a partially-patched DOM.
+>
+> With that reset in place the property holds. Without it, it does not — and the
+> incremental-adoption argument depends on it, so it must land with §5.3 rather
+> than after.
+
+Three further divergence classes the zip currently accepts and reports as clean
+(all verified, all must be closed in §5.3):
+
+1. **The zero-children branch never reads the DOM.** A server-rendered populated
+   list under a client-rendered empty state survives forever at
+   `mismatched=0`. Require `domChildren.length === 0` or bail.
+2. **`data: {}` never removes anything.** snabbdom's attributes module only
+   deletes keys present in the *old* data, so any attribute the server emitted
+   and the client does not is permanent. Build the old vnode's
+   `attrs`/`class`/`style` from the real element, keeping `props` and `on`
+   empty so props and listeners still bind.
+3. **The zip is positional, not keyed.** A reordered keyed list zips
+   "successfully" against the wrong nodes. Verify the key against a serialized
+   attribute, or state explicitly that keyed lists are not hydrated.
+
+**`data.hook` is also unhandled.** `parser.js` attaches
+`createComponentUpdateHook` as `data.hook` on every web-component vnode.
+Adopted elements are patched, never created, so `insert` — which seeds the
+props snapshot — never runs, and `update` sees `oldProps = {}`, reports every
+prop changed, stamps `isDirty` and forces a redundant re-render of every
+already-correct child. The fix is to seed the hook's snapshot for adopted hosts
+at zip time, which needs a small export from `componentUpdateHook.js` and is
+**not** inside §5.3's stated line budget.
+
+---
+
+## 3. Props — no serialization required
+
+This was the main open question and the answer is that there is nothing to
+build.
+
+Property-form bindings (`:items=${obj}`) land only in `data.props`. The
+serializer ignores `data.props` entirely, so they contribute **zero bytes**:
+
+```yaml
+- demo-child :user=${user} :tags=${tags} :onPick=${onPick} label=static: null
+```
+
+```html
+<demo-child label="static" data-rtgl-hydrate="">…</demo-child>
+```
+
+Yet the rendered output contains `Ada Lovelace`, three `<li>` tags from the
+array, `memberSince=1843` (requiring a live `Date`) and `fnResult=picked:t2`
+(requiring a live **function**). The server passed the real object graph in
+memory; the HTML is a picture of the output, never a container for the inputs.
+
+The client obtains the same values by re-running the parent's render.
+`propsModule` assigns `elm.items = [...]` as a plain JS property while the
+child's tag is still undefined; `installReactiveProps` (`props.js:107-120`)
+captures pre-set own properties on upgrade and preserves them.
+
+**Therefore:** no JSON island, no escaping hazard, no type restriction. Objects,
+arrays, `Date`s, `Map`s and functions all survive because nothing is stringified.
+
+### The catch: registration order
+
+This only holds if the parent renders before the child upgrades.
+`frontendEntrySource.js:196` sorts categories alphabetically, so `components`
+register before `pages` — and in the validating app the pages are the parents. Children
+were upgrading and running their first render with **no props assigned**.
+
+That single ordering bug was the prototype's only hydration mismatch. Fixing it
+took the result from `hydrated=4 mismatched=1` to `hydrated=5 mismatched=0`,
+with zero markup changes.
+
+The real fix is a **topological sort** of the tag-reference graph, which the
+codegen can derive since it already parses every view. Cycles fall back to
+`defer-hydration` (§5.4).
+
+---
+
+## 4. The contract
+
+> **The client's first render must be a pure function of the same inputs the
+> server used.**
+
+Three things satisfy it:
+
+| | how |
+|---|---|
+| same props | registration order — element properties survive upgrade |
+| same store logic | free, it is the same code |
+| **same inputs to that logic** | the part you must maintain |
+
+### 4.1 The four inputs — no new ones
+
+The contract needs **no additions to the framework**. Every input already
+exists:
+
+```js
+// store   (store.js:11-17)                  // handler  (lifecycle.js:1-13)
+{ state, props, constants, i18n, locale }    { ...deps, refs, dispatchEvent, store, render }
+```
+
+| input | origin |
+|---|---|
+| `props` | the parent |
+| `constants` | the component's `.constants.yaml` |
+| `state` | the component itself |
+| `locale` / `i18n` | the framework's i18n runtime |
+
+Stores get **values**; handlers get **services**. That separation is already
+enforced by the framework — a store cannot reach `deps` even if it wants to.
+
+**The rule: the first render must never depend on `deps`.**
+
+Every bug found during prototyping is a violation of this rule, not a gap in
+it:
+
+- `platform: "tauri"` hardcoded, then corrected from `appService` in a handler
+  — a fifth, undeclared input
+- `globalThis.window?.innerWidth ?? FALLBACK` in a selector — a sixth
+
+#### A fifth input was considered and rejected
+
+An earlier draft proposed a render-scoped ambient bag (`env` / `renderContext`)
+to carry platform, theme and route into stores. It was dropped after checking
+what would actually use it:
+
+| candidate | verdict |
+|---|---|
+| `platform` | **per-build, not per-render.** The server only ever renders for web; the client's platform is fixed by which `setup.<target>.js` was bundled. Resolve it at build time. |
+| viewport / pointer type | **the server cannot know it.** No channel helps; this is the CSS-or-post-hydration tradeoff in §9. |
+| route | **already in app state.** A store reading `window.location` is a bug independent of SSR — pass it as a prop. |
+| theme | not per-request today; it is a `<body>` class. |
+| locale | already owned by the i18n runtime. |
+
+Nothing left. Adding an input would have legalised the violations rather than
+fixing them, and would have grown the contract from four inputs to five for no
+consumer that needs it.
+
+Note also that `resolveConstants` currently merges `deps.constants` from setup
+with the component's `.constants.yaml`. Two invisible origins under one name is
+the same class of ambiguity; `setupConstants` should be deprecated so
+`constants` means the YAML file and nothing else.
+
+### 4.2 No `isSsr` flag — anywhere
+
+Handlers are not invoked server-side at all. It is non-execution, not
+branching, so no guard is needed.
+
+If a handler seeds state that affects the first render, move it into the store
+rather than guarding it:
+
+```js
+// before
+createInitialState: () => ({ platform: "tauri" })          // a lie on web
+handleAfterMount: () => store.setPlatform(appService.getPlatform())
+
+// after — platform resolved at build time, no service call, no new input
+createInitialState: () => ({ platform: PLATFORM })
+// handler line deleted
+```
+
+The handler gets *smaller*, and the client stops rendering once with the wrong
+value and correcting itself.
+
+`if (deps.isSsr)` should not be reachable. Every other failure mode in this
+system is caught by a test; a branch is caught by nothing, because both sides
+are individually "correct" and quietly different. Recommendation: **do not
+expose the flag at all.**
+
+Components that genuinely cannot render server-side (canvas, Lexical, WebGL)
+opt out **declaratively**, not imperatively:
+
+```yaml
+componentName: rvn-scene-editor-lexical
+ssr: false
+```
+
+The renderer emits a bare host with no shadow root and no hydrate flag; the
+client mounts it exactly as today.
+
+---
+
+## 5. Framework changes (`yuusoft/rettangoli`)
+
+All additive. Nothing changes for existing consumers who do not opt in.
+
+### 5.0 [A] Separate the component core from its DOM binding — **required, first**
+
+SSR adds a second binding of the same component construction sequence. If that
+sequence is written independently for the server, it will drift from the web
+one — and drift in the parser's key generation is a *silent hydration bug*, not
+a visible one: the tree simply stops adopting and falls back to CSR with no
+error.
+
+The entanglement is already causing a concrete failure today, with no SSR
+involved:
+
+```
+$ node -e "import('@rettangoli/fe')"
+ReferenceError: window is not defined
+```
+
+`createComponent.js:7` instantiates `createWebPatch()` at module scope, and
+snabbdom's style module dereferences a bare `window` at import time. That single
+line blocks every Node-side tool — including the HTML golden tests in §6, which
+the framework currently has none of.
+
+Most of the seams already exist and are simply unused:
+
+- `resolveComponentDefinition` (`createComponent.js:9-46`) is already pure and
+  already exported — it just lives in a module that pulls in the patch.
+- `componentDom.js:66-68` accepts `createStyleSheet` and `createElement`
+  factories, but both production call sites
+  (`createWebComponentClass.js:178, :265`) ignore them and fall back to globals.
+- snabbdom's `init(modules, domApi)` accepts a custom DOM API;
+  `createWebPatch.js` hardcodes the default.
+
+Work:
+
+1. Move `resolveComponentDefinition` into `core/`, off any graph that imports
+   `createWebPatch`.
+2. Make the package importable in Node. **See the correction below — the
+   obvious fix does not work.**
+3. Extract the construction sequence — store binding, props, constants,
+   lifecycle wiring — into `core/`, so the web and server bindings share it
+   rather than each owning a copy.
+4. Thread the existing `componentDom.js` factories through from the call sites.
+
+> **CORRECTION (review, 26 Jul).** An earlier draft prescribed "make the patch
+> lazy (`patch ??= createWebPatch()`)". **That does not work**, verified three
+> times independently. The `ReferenceError` is thrown while *evaluating*
+> `snabbdom/build/modules/style.js`, whose line 2 dereferences a bare `window`
+> at module scope — not while *calling* `createWebPatch()`. The blocking edge is
+> the static `import` in `createComponent.js`, and `web/hotComponentRegistry.js`
+> sits downstream of the same import rather than being a second edge.
+>
+> **OPEN DECISION — pick one before starting A1:**
+>
+> **(a) Vendor snabbdom's style module.** It is 113 lines, of which exactly
+> **two** touch `window`. Guarding them (`globalThis.window?.…`) makes it import
+> cleanly in Node — verified. Keeps `createComponent` synchronous, keeps the
+> exit criterion as `import('@rettangoli/fe')`. Cost: maintaining a copy of a
+> snabbdom internal.
+>
+> **(b) Keep `.` browser-only.** Expose the Node surface solely through the new
+> `./server` and `./parser` entries. No vendoring, but the main entry stays
+> un-importable in Node and the exit criterion weakens to
+> `import('@rettangoli/fe/parser')`.
+>
+> **(c) Make `createComponent` async.** Rejected: `frontendEntrySource.js` emits
+> `customElements.define(elementName, createComponent(...))` inline, so this is a
+> breaking change for every consumer's generated entry.
+
+**Scope correction.** This section was sized against `@rettangoli/fe` 1.2.3. The
+repo is 1.3.0, and HMR landed in `e9d482cd`: `createWebComponentClass.js` grew
+195 → 376 lines and `store.js` 50 → 149. The construction sequence now exists
+**twice** — the cold constructor and the hot-update path — and both must move to
+`core/` together or `rtgl fe watch` regresses. A1 is real work, not a
+half-day. Name `test/runtime/create-component.contract.test.js` and
+`hot-component-registry.test.js` as the regression net and an A1 exit criterion.
+
+Exit criteria: the Node-import decision above is implemented and its criterion
+met; the cold and hot construction paths both live in `core/`; the existing
+runtime contract tests still pass.
+
+Doing this **before** §5.1–5.4 is materially cheaper than retrofitting it after
+a second binding exists.
+
+### 5.1 [A] A vnode → HTML serializer — **required**
+
+`snabbdom-to-html@7.1.0` is not usable: last published 2022, CI targeting
+Node 4/5/6, and it stringifies `data.props` into lowercased attributes. On this
+app's own tree it emits both `h-bc="ac"` and `hbc="ac"` on the same element,
+plus `[object Object]` for object props. Those names are in `observedAttributes`,
+so `attributeChangedCallback` would overwrite real props with garbage on
+upgrade.
+
+Requirements, each verified by test:
+
+- never emit `data.props`
+- **preserve empty-string attributes** — rettangoli's boolean encoding
+  (`attrs[name] = ""`); `snabbdom-to-html` drops them
+- merge `data.class` and `data.style` into single attributes
+- validate attribute names
+- HTML5 void-element table
+- **`<style>` and `<script>` are raw text**: emit verbatim, never escape.
+  Escaping turns `.a > .b` into `.a &gt; .b`, which is not a selector. Since
+  raw text cannot be escaped, refuse content containing `</style` or
+  `</script` rather than emitting an injection.
+- `<textarea>` and `<title>` are *escapable* raw text and stay on the normal
+  escaping path. Getting this backwards is a classic bug.
+
+### 5.2 [B] A recursive server renderer — **required**
+
+Resolves tag → component, runs the store, calls `parseView`, recurses into
+child components, emits per-component declarative shadow roots.
+
+### 5.3 [B] A hydrating first patch — **required**
+
+Four things, not one. The line budget below covers the first only.
+
+`buildHydrationVNode({ vDom, rootElm })`, ~90 lines, plus ~15 lines in
+`componentOrchestrator.js` gated on the host attribute — inert for non-SSR
+pages.
+
+### 5.4 [B] Topological registration — **required**
+
+Emit `customElements.define` calls parents-first, derived from the
+tag-reference graph. `defer-hydration` covers cycles and any future
+lazy/partial hydration: the server marks hosts, `connectedCallback` skips the
+first render, the parent removes the attribute after its patch.
+
+### 5.5 [B] Contract enforcement — **required**
+
+No new store input (see §4.1). What is required instead is making the existing
+four-input contract checkable, because a violation is silent by construction:
+
+- **`rettangoli-check` rules** — no browser globals and no `Math.random` /
+  `Date.now` inside `createInitialState` or `selectViewData`. The checker
+  already parses every store and view, so this is a rule addition rather than
+  new machinery. `ssr-poc/tests/ssr-hazards.test.js` is a working prototype of
+  the analysis, including the literal-stripping needed to avoid flagging
+  `` `document-${id}` ``.
+- **`__rtglSsr = { hydrated, mismatched, reasons }`** exposed by the runtime,
+  so consumers can gate CI on `mismatched === 0`.
+
+This is the highest-value long-term item in the plan. A contract nobody can
+violate is worth more than a contract with more slots.
+
+### 5.6 [A] Exports, tooling, and three latent bugs — small
+
+- `"./server"` and `"./parser"` entries in the exports map. This also removes a
+  live hazard: `tests/support/renderView.js` reaches into
+  `node_modules/@rettangoli/fe/node_modules/jempl` by path, binding a
+  different jempl version than the app hoists — the test helper can compile
+  templates with a different AST than the browser.
+- `ssr: false` honoured from `.schema.yaml`.
+
+Three small correctness fixes surfaced by validation, each a latent bug today
+rather than an SSR-only concern:
+
+- **`componentDom.js:50`** — `querySelector('[data-rtgl-render-target]') ??
+  shadow.firstElementChild` will stamp a `<style>` as the render target in any
+  shadow root that contains one. snabbdom then replaces it, leaving
+  `instance.renderTarget` dangling. Restrict the fallback or drop it. Note the
+  existing test at `component-dom.test.js:182` depends on the current
+  behaviour.
+- **`componentDom.js:90,94`** — clobbers `renderTarget.style.cssText` wholesale
+  instead of setting `display` conditionally, wiping any inline style already
+  on the element.
+- **`parseView` template normalization.** *Re-scoped after review.* Two claims
+  in the earlier draft were wrong. The concurrency justification does not hold —
+  Node is single-threaded and the mutation cannot be observed mid-flight, so
+  drop that reasoning. And the pass is **not idempotent**: it rewrites
+  `:value=${title}` → `:value=title`, which
+  `getPropertyBindingViolationForKey` then **rejects** — verified to throw when
+  re-run on a clone of its own output. The `WeakSet` is therefore a correctness
+  guard, not a memo, and a build-time-serialized AST arrives with a fresh object
+  identity and re-enters the validator.
+
+  So "normalize at build time" as written would break every property-binding
+  view. Do the smaller, genuinely useful fix instead: make the validator accept
+  the normalized forms so the pass becomes truly idempotent. Worth doing on its
+  own merits.
+- `javaScriptEnabled` threaded through `@rettangoli/vt` so the pre-JS render
+  can be regression-tested at all.
+
+### 5.7 Explicitly not needed
+
+No `command: "server"` codegen arm (the parameter is binary at 21 call sites).
+No change to `handleBeforeMount`'s synchronous contract. No prop serialization.
+No `__INITIAL_STATE__`.
+
+**Nothing in `@rettangoli/ui` for Part A.** Part B is a different matter, and an
+earlier draft contradicted itself here: §9.1 makes an `@rettangoli/ui` change a
+prerequisite for full hydration coverage. **OPEN DECISION — fix `rtgl-popover`,
+or accept CSR fallback on subtrees containing one?**
+
+The fix (move the content wrapper into shadow DOM around the slot) is verified
+safe: it does not break `::part(content)` — that selector cannot match slotted
+light DOM and nothing in the repo uses it — nor the ResizeObserver, nor the
+`content-*` attribute mapping. But it touches a shipped component with five
+internal consumers (tooltip, select, dropdown-menu, tag-select, popover-input)
+that pass unnamed, variable-count children, while the published docs pass a
+single `slot=`-named child. That fork is the real compat surface.
+
+Accepting CSR fallback is legitimate: those subtrees render correctly, they just
+get no SSR benefit. `rtgl-popover` appears in 13+ views.
+
+**No new store input.** No `env`, no `renderContext`, no ambient bag, and no
+new merging into `constants`. §4.1 records why: every candidate value turned
+out to be per-build, already available, or unknowable to a server. The
+framework's contract stays at four inputs.
+
+---
+
+## 6. Testing
+
+Consistency here is not testable by inspection: a hydration mismatch is not an
+error. It re-renders and looks correct. The suite has to be the gate.
+
+Existing in the prototype's `ssr-poc/tests/` — 37 unit tests (1.4 s) plus 8
+browser checks. These should move into this package as the framework work
+lands:
+
+**`serialize.test.js` (20)** — escaping, raw-text elements, boolean attributes,
+props never emitted, class/style merging, void elements, injection cases.
+
+**`invariants.test.js` (12)** — byte-identical output across repeated renders
+and under a shifted `Date.now`; every store imports and runs in bare Node; no
+`Math.random`/`Date.now` in any `selectViewData`; unique component names; zero
+render failures; one render target per shadow root; no `[object Object]`;
+balanced tags.
+
+**`ssr-hazards.test.js` (5)** — static scan for browser globals in the
+first-render path, with an allowlist so it fails on *new* offenders.
+
+This catches what execution tests cannot. `globalThis.window?.innerWidth ?? FALLBACK`
+does not throw in Node — it silently returns a different value than the client.
+**Guarded browser access is more dangerous than unguarded**, because unguarded
+fails loudly. Two real offenders found: `vnPreview`, `mobileSidebar`.
+
+> **CORRECTION (review, 26 Jul).** The prototype's parity gate **cannot observe
+> the failures it exists to catch**, so the "8/8 passed" result must not be
+> cited until it is rebuilt. Two defects, both verified in Chromium:
+>
+> - It stamps `data-server-node` inside a `DOMContentLoaded` listener, but the
+>   app is a `<script type="module">`, which executes **before** that fires. A
+>   reviewer proved it reports success on a page that deliberately replaced
+>   everything.
+> - Its "server DOM was adopted" check passed while the tree was **duplicated** —
+>   the server nodes survived precisely because they were stacked, not adopted.
+>   After the §2.4 reset fix, the same check correctly flips to failing.
+>
+> A usable gate must: tag synchronously via `addInitScript` and hold node
+> identity in a `WeakSet` (or a `MutationObserver` asserting zero removals of
+> tagged nodes); walk shadow roots recursively; assert
+> `hydrated === expected component count` from the server's own stats rather
+> than `hydrated > 0`; and replace the `targetRoots <= 2` heuristic with a
+> comparison against a known-good baseline.
+
+**`hydration-parity.mjs` (8)** — the CI gate. Boots the real client over
+server-rendered HTML and asserts the server markup paints with `main.js`
+blocked, the shell fills the viewport, `mismatched === 0`, server DOM adopted
+rather than replaced, no stray templates, no console errors.
+
+Ship `globalThis.__rtglSsr = { hydrated, mismatched, reasons }` and gate CI on
+`mismatched === 0`. Without it SSR silently stops paying for itself: you keep
+shipping the bytes and lose the benefit, with no symptom.
+
+---
+
+## 7. Backend usage
+
+The entire application integration:
+
+```js
+import { renderComponent, renderDocument } from "@rettangoli/fe/server";
+
+const handler = async (req, res) => {
+  const url = new URL(req.url, `http://${req.headers.host}`);
+  const env = {
+    platform: "web",
+    locale: url.searchParams.get("locale") ?? "en",
+    theme: "dark",
+    route: url.pathname,
+    query: Object.fromEntries(url.searchParams),
+  };
+
+  const { html, head } = await renderComponent({ component: "rvn-app", props: {}, env });
+
+  res.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+  res.end(renderDocument({ html, head, env, title: "Projects" }));
+};
+```
+
+No jsdom, no DOM shim, no headless browser, no per-request global state — safe
+to call concurrently. Measured: **~12 ms warm** (min 10.3, max 17.3 over 8
+requests), 7.7 KB out.
+
+`env` here is a **transport shape for the request**, not a new store input —
+§5.7 still forbids an ambient bag reaching stores. Its values land as follows:
+
+- `locale` — the one value the framework already threads into the store context
+- `platform`, `theme` — build-time constants, not per-request
+- `route`, `query` — passed to the **root component as props**, per §4.1
+
+Whatever the server passes here, the client must be given the same values.
+
+The same `renderComponent` call serves build-time prerendering, so "static now,
+server later" stays one code path. A render failure should fall back to the
+plain `<rvn-app></rvn-app>` shell — degrading to what ships today, never taking
+the page down.
+
+---
+
+## 8. Rollout
+
+Each stage ships alone and is independently valuable.
+
+### Part A — framework hygiene (do this regardless)
+
+**Stage A1 — core/binding split (§5.0).** Move `resolveComponentDefinition`
+into `core/`, make the patch lazy, extract the construction sequence, thread
+the existing `componentDom` factories through. Plus the three latent bugs in
+§5.6.
+
+Exit: `node -e "import('@rettangoli/fe')"` succeeds. That one result unblocks
+every Node-side tool.
+
+**Stage A2 — serializer + exports (§5.1, §5.6).** Ship the vnode→HTML
+serializer with its unit suite, and add the `./server` / `./parser` export
+entries.
+
+Exit: components render to HTML in bare Node, and the project has **HTML golden
+tests** — against 1,301 `.webp` pixel references and zero `.html` goldens
+today. Ships as a minor version bump of `@rettangoli/fe`, republished through
+`rtgl`.
+
+**Stop here if SSR is not wanted.** Nothing above is wasted, no consumer
+changes, no ongoing maintenance commitment.
+
+### Part B — SSR (a separate decision)
+
+**Stage B1 — recursive renderer (§5.2).** Resolve tag → component, run the
+store, recurse, emit nested declarative shadow roots. Still no consumer
+changes; the output is testable on its own.
+
+**Stage B2 — hydration + ordering (§5.3–5.5).** Hydrating patch, topological
+registration, `defer-hydration`, `__rtglSsr` telemetry, parity gate in CI. This
+is where the ongoing maintenance commitment begins: mismatches degrade silently,
+so the gate is not optional.
+
+**Stage B3 — app adoption, shell only.** Prerender the app shell at build time.
+Add the `rvn-app` CSS rule. Keep the UI bundle blocking. Low risk: the shell
+depends on almost nothing.
+
+**Stage B4 — full route depth.** Render the entire component tree for the
+requested route, not just the shell. This is where the store cleanup lands
+(§4.1): resolve `platform` at build time, and pass the route to
+`mobileSidebar` as a prop instead of reading `window.location`.
+
+Depth has now been measured (§9.1) and it does change the risk profile. All 14
+routes render server-side, but hydration coverage drops on dense ones:
+`/projects` (5 components) hydrates 5/5 with zero mismatches, while
+`/project/variables` (9 components) hydrates 3/9. Stage 4 is achievable, but
+the popover fix in §9.1 is a prerequisite for full coverage rather than an
+optimisation.
+
+Prerequisite for stages B3–B4: guard the prerender step on the web target only.
+Tauri/Android/iOS share `_site`, and prerendered content in a desktop or mobile
+shell may be wrong.
+
+---
+
+## 9. Limits and tradeoffs
+
+**Time-to-interactive does not change — accepted, and out of scope.** The
+bundle still parses and the boot sequence still runs, so users see a
+correct-looking page that is not yet clickable. Improving TTI is deferred to
+separate work (bundle size, boot sequencing); it is explicitly not what this
+project delivers.
+
+Mitigation while that remains true: prerender the **loading state**, not a
+fake-ready state. It sets correct expectations and still moves FCP, because
+only text is contentful — a shimmer or skeleton box moves it 0 ms.
+
+**Data the server cannot see still arrives late.** Not fixable by rendering
+work.
+
+**Touch/viewport-dependent layout — decided: CSS.** `isTouchMode` currently
+changes which elements exist (sidebar vs bottom tab bar, shell direction), not
+just their styling. The resolution is to express those in CSS so both sides
+emit identical markup and the browser decides layout.
+
+Two consequences to plan for. Rendering both variants and hiding one means
+hidden interactive elements must be kept out of the tab order —
+`inert`/`display:none`, not `visibility:hidden`. And User-Agent sniffing, if
+used as a secondary hint, is a heuristic: tablets and touch-capable laptops
+will be guessed wrong, producing a hydration mismatch and a CSR fallback for
+those visitors. That degrades correctly, but it is a real cost and should be
+visible in the `mismatched` counter rather than assumed away.
+
+### 9.1 Light-DOM restructuring blocks hydration — measured
+
+The densest routes surfaced a problem class the shallow prototype did not.
+
+`rtgl-popover` moves all of its children into a synthesized `rtgl-view`
+wrapper on upgrade (`popover.js:407-427`). Because the UI bundle is a blocking
+script, that happens at **parse time — before hydration runs**. The client's
+vdom describes the template's children; the live DOM has already been
+restructured. They cannot match.
+
+Measured on `/project/variables` (9 components):
+
+```
+hydrated=3  mismatched=4
+  <rtgl-popover> child count 4 != 3
+  <rtgl-popover> child count 2 != 1
+  <rvn-resizable-panel> child count 0 != 1     ← deps-seeded state (§4.1)
+  <rtgl-view> child count 2 != 1               ← knock-on
+```
+
+Emitting the wrapper server-side **does not fix it** — tested. The numbers move
+(`4 != 3` becomes `2 != 3`) but never converge, because the client's vdom
+describes the *unwrapped* children and always will: the template has no
+knowledge of the wrapper.
+
+The real fix is in `@rettangoli/ui`: put the content wrapper in the popover's
+**shadow** DOM, around the slot, rather than moving light-DOM children. Then
+the template's children stay where the template put them and the zip succeeds.
+
+Scope is bounded — `rtgl-popover` is the **only** structural offender among the
+19 primitives. The others set attributes, which the hydrating patch re-applies
+idempotently. But it appears in 13+ views, so components containing one fall
+back to CSR until it is fixed: correct output, no SSR benefit for that subtree.
+
+**The general rule this establishes:** a component that restructures its own
+light DOM cannot be hydrated through. Either it adopts the structure the server
+emitted, or it owns that structure in its shadow DOM.
+
+A second finding from the same run: `rvn-whiteboard` cannot be imported in
+Node at all (`src/internal/whiteboard/arrowUtils.js:1` imports an extensionless
+`.ts` file that only Vite's resolver can find). That route degrades to an empty
+mount point. It is a real app bug independent of SSR.
+
+**Some components can never server-render.** Canvas, WebGL, Lexical. They opt
+out declaratively and render as empty mount points — acceptable, since they sit
+below the fold of first paint.
+
+**Store cleanup is per-component work with no shortcut.** The cost is audit
+breadth, not risk: every change also removes a wrong-then-corrected render from
+the client.
+
+---
+
+## 10. Decisions
+
+### 10.0 Still open — blocking the start of work
+
+Surfaced by the 26 Jul review. Everything else in this document is settled.
+
+**A. How to make the package importable in Node** (§5.0). Vendor snabbdom's
+style module — 113 lines, 2 of which touch `window`, verified working and keeps
+the API synchronous — or keep `.` browser-only and expose Node solely via
+`./server` / `./parser`. Blocks stage A1.
+
+**B. `rtgl-popover`** (§5.7, §9.1). Fix it in `@rettangoli/ui`, or accept CSR
+fallback on the 13+ views containing one. Blocks stage B4, not earlier.
+
+**C. Accept that Part A is larger than first stated** (§5.0). HMR landed after
+the plan's evidence was gathered; the construction sequence now exists twice and
+both paths must move together. A is still worth doing — it is no longer
+"small".
+
+### 10.1 Settled
+
+Recorded so they are not relitigated.
+
+**0. Project A ships regardless; Project B is a separate decision.** See §1.1.
+A is finishing a separation the framework already began and is justified by
+Node-importability and HTML golden tests alone. B is a product bet with an
+ongoing maintenance cost. Do A first — writing the server renderer before
+extracting the core is the one sequencing mistake that makes the framework
+worse rather than better.
+
+**1. Time-to-interactive is out of scope.** This project delivers a correct
+first paint, not a faster boot. TTI work (bundle size, boot sequencing,
+deferring heavy dependencies) is separate and may happen later. Anyone
+describing this as a performance improvement is overselling it.
+
+**2. Touch/viewport → CSS.** Layout that varies by pointer type or viewport is
+expressed in CSS, not in the vdom, so both sides emit identical markup.
+User-Agent sniffing is acceptable as a secondary hint, with the caveat in §9
+that it will guess wrong for tablets and touch laptops and cost those visitors
+a CSR fallback.
+
+**3. Render the full route.** Not shell-only — the entire component tree for
+the requested route. This puts the store cleanup in §4.1 in scope, and means a
+dense route should be measured before stage 4 is called done (§8).
+
+**4. Framework changes ship as version bumps.** A minor bump of
+`@rettangoli/fe` republished through `rtgl`, rather than vendoring or patching
+`node_modules`. Slower per iteration, but the alternative leaves consumers on a
+copy that does not exist upstream.
+
+**5. Local testing only for now.** No deploy target is required. Acceptance is
+a local server plus the parity gate in §6. Note this makes now the cheapest
+moment to change document structure — there is no production traffic to
+regress, and that stops being true the day a public URL exists.
+
+---
+
+## Appendix — prototype
+
+`RouteVN/routevn-creator-client/ssr-poc/`, with run instructions in its
+`README.md`. It imports this package's `parser.js` and `store.js` directly, so
+it exercises the real runtime rather than a copy.
+
+Five variants were built and measured; the winner is `e_nested_dsd`
+(per-component declarative shadow roots + hydrating patch + topological
+registration). Variant `c_dsd` — declarative shadow DOM *without* hydration —
+is retained deliberately as the cautionary case: it is visibly corrupt, with
+the server and client trees stacked.
+
+`node_modules` patches used to prove the framework changes are applied and
+reverted by `ssr-poc/hydration/apply.js`; the tree is left clean.
+
+**What the prototype actually ran.** It loads each component's `.handlers.js`
+and calls `handleBeforeMount` against a hand-built stub service bag, and runs a
+`syncFromProps` action by name convention. That is a **compatibility shim for
+the validating app**, whose render-relevant state is seeded from injected
+services — it is *not* the architecture §2.1/§4.2 propose, which never invokes
+handlers server-side.
+
+This was challenged in review as invalidating the headline number. It does not:
+the run was independently repeated with `serverDeps: null`, no route seeding and
+no sync actions, and still produced `hydrated=5 mismatched=0` — the server HTML
+differed by one character. The shim affects *content* accuracy for that app, not
+hydration parity. But the prototype should not be described as demonstrating the
+handler-free design, because it does not.

--- a/packages/rettangoli-fe/package.json
+++ b/packages/rettangoli-fe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rettangoli/fe",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Frontend framework for building reactive web components",
   "type": "module",
   "main": "./src/index.js",
@@ -29,8 +29,7 @@
     ".": "./src/index.js",
     "./cli": "./src/cli/index.js",
     "./contracts": "./src/contracts/index.js",
-    "./server": "./src/server/index.js",
-    "./parser": "./src/parser.js"
+    "./server": "./src/server/index.js"
   },
   "devDependencies": {
     "puty": "^0.1.1",

--- a/packages/rettangoli-fe/package.json
+++ b/packages/rettangoli-fe/package.json
@@ -28,7 +28,9 @@
   "exports": {
     ".": "./src/index.js",
     "./cli": "./src/cli/index.js",
-    "./contracts": "./src/contracts/index.js"
+    "./contracts": "./src/contracts/index.js",
+    "./server": "./src/server/index.js",
+    "./parser": "./src/parser.js"
   },
   "devDependencies": {
     "puty": "^0.1.1",
@@ -46,6 +48,7 @@
     "test": "vitest run --reporter=verbose",
     "test:package": "node test/package-smoke-test.js",
     "test:puty": "vitest run puty.spec.js --reporter=verbose",
-    "test:vitest": "vitest run test/**/*.test.js --reporter=verbose"
+    "test:vitest": "vitest run test/**/*.test.js --reporter=verbose",
+    "test:browser": "node test/web/style-module.browser.mjs"
   }
 }

--- a/packages/rettangoli-fe/src/core/component/resolveComponentDefinition.js
+++ b/packages/rettangoli-fe/src/core/component/resolveComponentDefinition.js
@@ -1,0 +1,56 @@
+/**
+ * Turns the four-file component config (.view.yaml / .store.js / .handlers.js /
+ * .schema.yaml) into a plain, target-agnostic definition object.
+ *
+ * This lives in `core/` deliberately. It is pure — no DOM, no patch, no
+ * rendering — so any binding (browser, server, tooling) can resolve a component
+ * without pulling in a render target. Keeping it in `createComponent.js` meant
+ * every consumer of the definition also transitively imported the snabbdom
+ * patch, which is what made the package unimportable outside a browser.
+ *
+ * Re-exported from `../../createComponent.js` for backwards compatibility.
+ */
+
+import { toCamelCase } from "../runtime/props.js";
+import { validateSchemaContract } from "../schema/validateSchemaContract.js";
+
+export const resolveComponentDefinition = (
+  { handlers, methods, constants, schema, view, store },
+) => {
+  if (!view) {
+    throw new Error("view is not defined");
+  }
+
+  if (!schema || typeof schema !== "object" || Array.isArray(schema)) {
+    throw new Error("schema is required. Define component metadata in .schema.yaml.");
+  }
+
+  const resolvedSchema = schema;
+  const { template, refs, styles } = view;
+
+  validateSchemaContract({
+    schema: resolvedSchema,
+    methodExports: Object.keys(methods || {}),
+  });
+
+  const elementName = resolvedSchema.componentName;
+  const propsSchema = resolvedSchema.propsSchema;
+  const propsSchemaKeys = propsSchema?.properties
+    ? [...new Set(Object.keys(propsSchema.properties).map((propKey) => toCamelCase(propKey)))]
+    : [];
+
+  return {
+    elementName,
+    propsSchema,
+    propsSchemaKeys,
+    template,
+    refs,
+    styles,
+    handlers,
+    methods,
+    constants,
+    store,
+  };
+};
+
+export default resolveComponentDefinition;

--- a/packages/rettangoli-fe/src/core/component/resolveComponentDefinition.js
+++ b/packages/rettangoli-fe/src/core/component/resolveComponentDefinition.js
@@ -52,5 +52,3 @@ export const resolveComponentDefinition = (
     store,
   };
 };
-
-export default resolveComponentDefinition;

--- a/packages/rettangoli-fe/src/core/server/serializeVNode.js
+++ b/packages/rettangoli-fe/src/core/server/serializeVNode.js
@@ -1,0 +1,193 @@
+/**
+ * Serializes a snabbdom vnode tree — the exact tree `parseView` produces — to
+ * an HTML string. Pure, synchronous, no DOM.
+ *
+ * WHY NOT `snabbdom-to-html`
+ *
+ * It is unusable for this dialect, not merely suboptimal:
+ *
+ *  - It stringifies `data.props` into lowercased attributes. Because the parser
+ *    mirrors attribute-form bindings into BOTH `attrs` and `props`, a node with
+ *    `h-bc="ac"` emits `h-bc="ac" hbc="ac"`, and object props emit
+ *    `[object Object]`. Those invented names are in `observedAttributes`, so
+ *    `attributeChangedCallback` would overwrite real props with garbage.
+ *  - It drops empty-string attributes (`if (value && value !== '')`), which is
+ *    exactly how rettangoli encodes boolean attributes (`attrs[name] = ""`).
+ *
+ * WHAT IS DELIBERATELY DROPPED
+ *
+ *  - `data.props`  — property-form (`:prop=${expr}`) bindings have no HTML
+ *    representation and need none: the client recomputes them by re-running the
+ *    parent's render, and `installReactiveProps` preserves properties assigned
+ *    before upgrade. Serializing them would be lossy (functions, Dates, Maps)
+ *    and duplicate the payload.
+ *  - `data.on`, `data.hook` — live closures.
+ */
+
+const VOID_ELEMENTS = new Set([
+  "area", "base", "br", "col", "embed", "hr", "img", "input",
+  "link", "meta", "param", "source", "track", "wbr",
+]);
+
+/**
+ * RAW TEXT elements. The HTML parser resolves no character references inside
+ * these — content runs literally until the closing tag. Escaping `<` to `&lt;`
+ * here produces corrupt CSS/JS (`.a &gt; .b` is not a selector).
+ *
+ * `textarea` and `title` are ESCAPABLE raw text: they DO process character
+ * references, so they stay on the normal escaping path and are deliberately
+ * absent from this set.
+ */
+const RAW_TEXT_ELEMENTS = new Set(["script", "style"]);
+
+/** Mirrors the framework's own attribute-name validation. */
+const ATTRIBUTE_NAME = /^[a-zA-Z_:][-a-zA-Z0-9_:.]*$/;
+
+const escapeText = (value) =>
+  String(value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+
+const escapeAttribute = (value) =>
+  String(value)
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+
+const toKebab = (key) =>
+  key.startsWith("--") ? key : key.replace(/[A-Z]/g, (c) => `-${c.toLowerCase()}`);
+
+/**
+ * Raw text cannot be escaped, so the only defence against content closing its
+ * own element is to refuse it. Anything producing `</style` or `</script` here
+ * is either a bug or an injection attempt.
+ */
+const rawTextOrThrow = (tag, content) => {
+  const text = String(content ?? "");
+  if (new RegExp(`</\\s*${tag}`, "i").test(text)) {
+    throw new Error(
+      `[serializeVNode] <${tag}> content contains a closing "</${tag}" sequence and cannot be safely serialized.`,
+    );
+  }
+  return text;
+};
+
+/**
+ * Comments are also raw: `--` cannot appear inside, and a comment may not end
+ * with `-`. Rather than silently mangle, refuse — a comment is never
+ * user-facing content in this dialect, so an offending one is a bug.
+ */
+const commentOrThrow = (content) => {
+  const text = String(content ?? "");
+  if (text.includes("--") || text.endsWith("-")) {
+    throw new Error(
+      "[serializeVNode] comment content may not contain `--` or end with `-`.",
+    );
+  }
+  return text;
+};
+
+const styleObjectToString = (style) => {
+  if (!style || typeof style !== "object") return "";
+  return Object.entries(style)
+    // snabbdom reserves these sub-objects for transition hooks; they are
+    // behaviour, not declarations.
+    .filter(([key]) => key !== "delayed" && key !== "remove" && key !== "destroy")
+    .filter(([, value]) => value !== undefined && value !== null && value !== "")
+    .map(([key, value]) => `${toKebab(key)}: ${value}`)
+    .join("; ");
+};
+
+const classObjectToString = (klass) => {
+  if (!klass || typeof klass !== "object") return "";
+  return Object.keys(klass).filter((key) => klass[key]).join(" ");
+};
+
+/** parseView emits bare tags; tolerate snabbdom's `tag#id.cls` form defensively. */
+const tagFromSel = (sel) => String(sel).split(/[.#]/)[0] || "div";
+
+const buildAttributes = (data = {}) => {
+  const out = [];
+  const attrs = { ...(data.attrs || {}) };
+
+  // data.class (selector-derived) and an authored class attribute can both be
+  // present; emitting two `class=` attributes would have the parser silently
+  // drop one.
+  const selectorClasses = classObjectToString(data.class);
+  if (selectorClasses) {
+    attrs.class = attrs.class ? `${attrs.class} ${selectorClasses}` : selectorClasses;
+  }
+
+  // data.style is an object; attrs.style is already a string.
+  const styleFromObject = styleObjectToString(data.style);
+  if (styleFromObject) {
+    attrs.style = attrs.style
+      ? `${String(attrs.style).replace(/;\s*$/, "")}; ${styleFromObject}`
+      : styleFromObject;
+  }
+
+  for (const [name, value] of Object.entries(attrs)) {
+    if (value === false || value === null || value === undefined) continue;
+    if (!ATTRIBUTE_NAME.test(name)) continue;
+    // `true` and `""` are both the boolean form.
+    if (value === true || value === "") {
+      out.push(` ${name}=""`);
+      continue;
+    }
+    out.push(` ${name}="${escapeAttribute(value)}"`);
+  }
+
+  return out.join("");
+};
+
+/**
+ * @param {object} vnode  a vnode as produced by `parseView`
+ * @param {object} [options]
+ * @param {(vnode: object) => string|null} [options.renderChildren]
+ *   Called for each element vnode. Return an HTML string to substitute for that
+ *   element's children — used by a recursive renderer to descend into a
+ *   component — or `null`/`undefined` to serialize normally.
+ * @returns {string}
+ */
+export const serializeVNode = (vnode, options = {}) => {
+  if (vnode === null || vnode === undefined) return "";
+
+  // Text vnode: snabbdom leaves `sel` undefined and puts the string in `text`.
+  if (vnode.sel === undefined) {
+    return escapeText(vnode.text ?? "");
+  }
+
+  if (vnode.sel === "!") {
+    return `<!--${commentOrThrow(vnode.text)}-->`;
+  }
+
+  const tag = tagFromSel(vnode.sel);
+  const attributes = buildAttributes(vnode.data);
+
+  if (VOID_ELEMENTS.has(tag)) {
+    return `<${tag}${attributes}>`;
+  }
+
+  const substituted = options.renderChildren ? options.renderChildren(vnode) : null;
+
+  let inner = "";
+  if (substituted !== null && substituted !== undefined) {
+    inner = substituted;
+  } else if (RAW_TEXT_ELEMENTS.has(tag)) {
+    const raw = Array.isArray(vnode.children) && vnode.children.length > 0
+      ? vnode.children.map((child) => child?.text ?? "").join("")
+      : (vnode.text ?? "");
+    inner = rawTextOrThrow(tag, raw);
+  } else if (Array.isArray(vnode.children) && vnode.children.length > 0) {
+    inner = vnode.children.map((child) => serializeVNode(child, options)).join("");
+  } else if (vnode.text !== undefined && vnode.text !== null) {
+    // h(tag, data, "string") puts the text on the element vnode itself.
+    inner = escapeText(vnode.text);
+  }
+
+  return `<${tag}${attributes}>${inner}</${tag}>`;
+};
+
+export default serializeVNode;

--- a/packages/rettangoli-fe/src/core/server/serializeVNode.js
+++ b/packages/rettangoli-fe/src/core/server/serializeVNode.js
@@ -97,6 +97,21 @@ const childIsForeign = (rawTag, isForeign, data) => {
 /** Mirrors the framework's own attribute-name validation. */
 const ATTRIBUTE_NAME = /^[a-zA-Z_:][-a-zA-Z0-9_:.]*$/;
 
+/**
+ * Tag names are grammar, not data, and were the one thing here emitted without
+ * validation — attribute names, raw text and comments are all already checked.
+ *
+ * It is reachable: an interpolated element key (`{ "${tag}": ... }`) puts view
+ * data straight into the sel, and `parseView` yields e.g. `sel: "div><img"`,
+ * which breaks out of the tag and injects live markup.
+ *
+ * The browser has always been safe here by accident — `document.createElement`
+ * rejects the same string with InvalidCharacterError — so without this the
+ * server path would be strictly weaker than the client it mirrors. Throwing
+ * keeps the two in agreement.
+ */
+const TAG_NAME = /^[a-zA-Z][a-zA-Z0-9:-]*$/;
+
 const escapeText = (value) =>
   String(value)
     .replace(/&/g, "&amp;")
@@ -254,6 +269,12 @@ const serializeNode = (vnode, options, isForeign) => {
   }
 
   const tag = tagFromSel(vnode.sel);
+  if (!TAG_NAME.test(tag)) {
+    throw new Error(
+      `[serializeVNode] refusing to emit invalid tag name ${JSON.stringify(tag)} ` +
+        "— it would break out of the tag and inject markup.",
+    );
+  }
   const attributes = buildAttributes(vnode.data);
 
   if (VOID_ELEMENTS.has(tag.toLowerCase())) {

--- a/packages/rettangoli-fe/src/core/server/serializeVNode.js
+++ b/packages/rettangoli-fe/src/core/server/serializeVNode.js
@@ -38,9 +38,12 @@ const VOID_ELEMENTS = new Set([
  * references, so they stay on the normal escaping path and are deliberately
  * absent from this set.
  *
- * CRITICAL: this applies only in the HTML namespace. See FOREIGN_ROOTS.
+ * CRITICAL: this applies only in the HTML namespace. See namespace tracking
+ * below.
  */
-const RAW_TEXT_ELEMENTS = new Set(["script", "style"]);
+const RAW_TEXT_ELEMENTS = new Set([
+  "iframe", "noembed", "noframes", "script", "style", "xmp",
+]);
 
 /**
  * Foreign content changes what "raw text" means, and getting this wrong is an
@@ -59,39 +62,85 @@ const RAW_TEXT_ELEMENTS = new Set(["script", "style"]);
  * `data.ns` for sels starting with `svg`, so MathML carries nothing. It has to
  * be tracked structurally as we descend.
  */
-const FOREIGN_ROOTS = new Set(["svg", "math"]);
+const HTML_NAMESPACE = "html";
+const SVG_NAMESPACE = "svg";
+const MATHML_NAMESPACE = "mathml";
 
 /**
- * Points where foreign content switches back to the HTML namespace, so
- * `svg > foreignObject > style` correctly regains raw-text semantics.
- *
- * MathML's `annotation-xml` is also an integration point, but only when its
- * `encoding` is text/html or application/xhtml+xml — handled below.
+ * SVG and MathML have different HTML integration points. Combining these sets
+ * is unsafe: for example, `title` is an integration point in SVG but not in
+ * MathML, while `mi` is one in MathML but not SVG.
  */
-const HTML_INTEGRATION_POINTS = new Set([
-  // SVG
-  "foreignobject", "desc", "title",
-  // MathML text integration points
-  "mi", "mo", "mn", "ms", "mtext",
-]);
+const SVG_HTML_INTEGRATION_POINTS = new Set(["foreignobject", "desc", "title"]);
+const MATHML_TEXT_INTEGRATION_POINTS = new Set(["mi", "mo", "mn", "ms", "mtext"]);
+const MATHML_TEXT_INTEGRATION_EXCEPTIONS = new Set(["mglyph", "malignmark"]);
 
 const HTML_ENCODINGS = new Set(["text/html", "application/xhtml+xml"]);
 
 /**
- * Given the current namespace state and a tag, what namespace do children sit in?
+ * Resolves an element token processed in the HTML namespace. HTML parsing
+ * enters foreign content only for SVG and MathML roots.
+ */
+const namespaceFromHtml = (rawTag) => {
+  const tag = rawTag.toLowerCase();
+  if (tag === "svg") return SVG_NAMESPACE;
+  if (tag === "math") return MATHML_NAMESPACE;
+  return HTML_NAMESPACE;
+};
+
+const getAttribute = (data, expectedName) => {
+  const entry = Object.entries(data?.attrs || {}).find(
+    ([name]) => name.toLowerCase() === expectedName,
+  );
+  return entry?.[1];
+};
+
+/**
+ * Resolves one child at a time because MathML text integration points keep
+ * immediate `mglyph` and `malignmark` children in MathML while processing
+ * their other children as HTML.
  *
  * Tags are lowercased for lookup only — the emitted tag keeps its original case,
  * which matters for SVG's camelCase elements (`foreignObject`, `clipPath`).
  */
-const childIsForeign = (rawTag, isForeign, data) => {
-  const tag = rawTag.toLowerCase();
-  if (!isForeign) return FOREIGN_ROOTS.has(tag);
-  if (HTML_INTEGRATION_POINTS.has(tag)) return false;
-  if (tag === "annotation-xml") {
-    const encoding = String(data?.attrs?.encoding ?? "").toLowerCase();
-    return !HTML_ENCODINGS.has(encoding);
+const namespaceForChild = ({
+  parentNamespace,
+  parentTag: rawParentTag,
+  parentData,
+  childTag: rawChildTag,
+}) => {
+  const parentTag = rawParentTag.toLowerCase();
+  const childTag = rawChildTag.toLowerCase();
+
+  if (parentNamespace === HTML_NAMESPACE) {
+    return namespaceFromHtml(childTag);
   }
-  return true;
+
+  if (parentNamespace === SVG_NAMESPACE) {
+    return SVG_HTML_INTEGRATION_POINTS.has(parentTag)
+      ? namespaceFromHtml(childTag)
+      : SVG_NAMESPACE;
+  }
+
+  if (MATHML_TEXT_INTEGRATION_POINTS.has(parentTag)) {
+    return MATHML_TEXT_INTEGRATION_EXCEPTIONS.has(childTag)
+      ? MATHML_NAMESPACE
+      : namespaceFromHtml(childTag);
+  }
+
+  if (parentTag === "annotation-xml") {
+    // The HTML parser handles this start tag as SVG even when annotation-xml
+    // is not an HTML integration point (that is, regardless of encoding).
+    if (childTag === "svg") {
+      return SVG_NAMESPACE;
+    }
+    const encoding = String(getAttribute(parentData, "encoding") ?? "").toLowerCase();
+    if (HTML_ENCODINGS.has(encoding)) {
+      return namespaceFromHtml(childTag);
+    }
+  }
+
+  return MATHML_NAMESPACE;
 };
 
 /** Mirrors the framework's own attribute-name validation. */
@@ -195,27 +244,60 @@ const styleObjectToString = (style) => {
     .join("; ");
 };
 
-const classObjectToString = (klass) => {
-  if (!klass || typeof klass !== "object") return "";
-  return Object.keys(klass).filter((key) => klass[key]).join(" ");
+/**
+ * Mirrors snabbdom's selector parsing in `createElm`. `parseView` emits bare
+ * tags, but `serializeVNode` is public and also accepts standard
+ * `tag#id.class` vnodes.
+ */
+const parseSelector = (rawSelector) => {
+  const selector = String(rawSelector);
+  const hashIndex = selector.indexOf("#");
+  const dotIndex = selector.indexOf(".", hashIndex);
+  const hash = hashIndex > 0 ? hashIndex : selector.length;
+  const dot = dotIndex > 0 ? dotIndex : selector.length;
+  const tag = hashIndex !== -1 || dotIndex !== -1
+    ? selector.slice(0, Math.min(hash, dot))
+    : selector;
+
+  return {
+    tag: tag || "div",
+    id: hash < dot ? selector.slice(hash + 1, dot) : null,
+    classes: dotIndex > 0
+      ? selector.slice(dot + 1).split(".").filter(Boolean)
+      : [],
+  };
 };
 
-/** parseView emits bare tags; tolerate snabbdom's `tag#id.cls` form defensively. */
-const tagFromSel = (sel) => String(sel).split(/[.#]/)[0] || "div";
-
-const buildAttributes = (rawData) => {
+const buildAttributes = (rawData, selector) => {
   // A default parameter only applies to `undefined`, so an explicit `data: null`
   // would crash here with an unattributable TypeError.
   const data = rawData || {};
   const out = [];
   const attrs = { ...(data.attrs || {}) };
 
-  // data.class (selector-derived) and an authored class attribute can both be
-  // present; emitting two `class=` attributes would have the parser silently
-  // drop one.
-  const selectorClasses = classObjectToString(data.class);
-  if (selectorClasses) {
-    attrs.class = attrs.class ? `${attrs.class} ${selectorClasses}` : selectorClasses;
+  if (
+    selector.id !== null
+    && !Object.prototype.hasOwnProperty.call(attrs, "id")
+  ) {
+    attrs.id = selector.id;
+  }
+
+  // Snabbdom creates selector classes first, runs classModule, then runs
+  // attributesModule. Consequently an authored attrs.class replaces every
+  // selector/module class rather than merging with it.
+  if (!Object.prototype.hasOwnProperty.call(attrs, "class")) {
+    const classes = new Set(selector.classes);
+    for (const [name, enabled] of Object.entries(data.class || {})) {
+      if (enabled) {
+        classes.add(name);
+      } else {
+        classes.delete(name);
+      }
+    }
+    const classValue = [...classes].join(" ");
+    if (classValue) {
+      attrs.class = classValue;
+    }
   }
 
   // data.style is an object; attrs.style is already a string.
@@ -250,13 +332,18 @@ const buildAttributes = (rawData) => {
  * @returns {string}
  */
 export const serializeVNode = (vnode, options = {}) =>
-  serializeNode(vnode, options, false);
+  serializeNode(
+    vnode,
+    options,
+    vnode?.sel !== undefined && vnode.sel !== "!"
+      ? namespaceFromHtml(parseSelector(vnode.sel).tag)
+      : HTML_NAMESPACE,
+  );
 
 /**
- * @param {boolean} isForeign  true when this node sits inside <svg>/<math>,
- *   where <style>/<script> are NOT raw text.
+ * @param {"html"|"svg"|"mathml"} namespace  the namespace of this element.
  */
-const serializeNode = (vnode, options, isForeign) => {
+const serializeNode = (vnode, options, namespace) => {
   if (vnode === null || vnode === undefined) return "";
 
   // Text vnode: snabbdom leaves `sel` undefined and puts the string in `text`.
@@ -268,24 +355,30 @@ const serializeNode = (vnode, options, isForeign) => {
     return `<!--${commentOrThrow(vnode.text)}-->`;
   }
 
-  const tag = tagFromSel(vnode.sel);
+  const selector = parseSelector(vnode.sel);
+  const tag = selector.tag;
   if (!TAG_NAME.test(tag)) {
     throw new Error(
       `[serializeVNode] refusing to emit invalid tag name ${JSON.stringify(tag)} ` +
         "— it would break out of the tag and inject markup.",
     );
   }
-  const attributes = buildAttributes(vnode.data);
+  const lowerTag = tag.toLowerCase();
+  if (namespace === HTML_NAMESPACE && lowerTag === "plaintext") {
+    throw new Error(
+      "[serializeVNode] refusing to emit <plaintext> in the HTML namespace " +
+        "because the HTML tokenizer never recognizes its closing tag.",
+    );
+  }
+  const attributes = buildAttributes(vnode.data, selector);
 
-  if (VOID_ELEMENTS.has(tag.toLowerCase())) {
+  if (VOID_ELEMENTS.has(lowerTag)) {
     return `<${tag}${attributes}>`;
   }
 
-  const lowerTag = tag.toLowerCase();
-  const childForeign = childIsForeign(tag, isForeign, vnode.data);
   // Raw text only applies in the HTML namespace. In foreign content the parser
   // reads <style>/<script> content as markup, so it must be escaped instead.
-  const isRawText = RAW_TEXT_ELEMENTS.has(lowerTag) && !isForeign;
+  const isRawText = RAW_TEXT_ELEMENTS.has(lowerTag) && namespace === HTML_NAMESPACE;
 
   const substituted = options.renderChildren ? options.renderChildren(vnode) : null;
 
@@ -299,7 +392,17 @@ const serializeNode = (vnode, options, isForeign) => {
     inner = rawTextOrThrow(lowerTag, raw);
   } else if (Array.isArray(vnode.children) && vnode.children.length > 0) {
     inner = vnode.children
-      .map((child) => serializeNode(child, options, childForeign))
+      .map((child) => {
+        const childNamespace = child?.sel !== undefined && child.sel !== "!"
+          ? namespaceForChild({
+            parentNamespace: namespace,
+            parentTag: tag,
+            parentData: vnode.data,
+            childTag: parseSelector(child.sel).tag,
+          })
+          : namespace;
+        return serializeNode(child, options, childNamespace);
+      })
       .join("");
   } else if (vnode.text !== undefined && vnode.text !== null) {
     // h(tag, data, "string") puts the text on the element vnode itself.

--- a/packages/rettangoli-fe/src/core/server/serializeVNode.js
+++ b/packages/rettangoli-fe/src/core/server/serializeVNode.js
@@ -37,8 +37,62 @@ const VOID_ELEMENTS = new Set([
  * `textarea` and `title` are ESCAPABLE raw text: they DO process character
  * references, so they stay on the normal escaping path and are deliberately
  * absent from this set.
+ *
+ * CRITICAL: this applies only in the HTML namespace. See FOREIGN_ROOTS.
  */
 const RAW_TEXT_ELEMENTS = new Set(["script", "style"]);
+
+/**
+ * Foreign content changes what "raw text" means, and getting this wrong is an
+ * XSS.
+ *
+ * `<style>` and `<script>` are RAWTEXT *only* in the HTML namespace. Inside
+ * `<svg>` or `<math>` the tokenizer stays in data state, so emitting content
+ * verbatim there injects live markup:
+ *
+ *   <svg><style>a::after{content:'<img src=x onerror=…>'}</style></svg>
+ *
+ * re-parses with a real <img> hoisted out of the svg, and the handler runs.
+ * Verified in Chromium.
+ *
+ * Namespace cannot be read off the vnode: snabbdom's `addNS` only stamps
+ * `data.ns` for sels starting with `svg`, so MathML carries nothing. It has to
+ * be tracked structurally as we descend.
+ */
+const FOREIGN_ROOTS = new Set(["svg", "math"]);
+
+/**
+ * Points where foreign content switches back to the HTML namespace, so
+ * `svg > foreignObject > style` correctly regains raw-text semantics.
+ *
+ * MathML's `annotation-xml` is also an integration point, but only when its
+ * `encoding` is text/html or application/xhtml+xml — handled below.
+ */
+const HTML_INTEGRATION_POINTS = new Set([
+  // SVG
+  "foreignobject", "desc", "title",
+  // MathML text integration points
+  "mi", "mo", "mn", "ms", "mtext",
+]);
+
+const HTML_ENCODINGS = new Set(["text/html", "application/xhtml+xml"]);
+
+/**
+ * Given the current namespace state and a tag, what namespace do children sit in?
+ *
+ * Tags are lowercased for lookup only — the emitted tag keeps its original case,
+ * which matters for SVG's camelCase elements (`foreignObject`, `clipPath`).
+ */
+const childIsForeign = (rawTag, isForeign, data) => {
+  const tag = rawTag.toLowerCase();
+  if (!isForeign) return FOREIGN_ROOTS.has(tag);
+  if (HTML_INTEGRATION_POINTS.has(tag)) return false;
+  if (tag === "annotation-xml") {
+    const encoding = String(data?.attrs?.encoding ?? "").toLowerCase();
+    return !HTML_ENCODINGS.has(encoding);
+  }
+  return true;
+};
 
 /** Mirrors the framework's own attribute-name validation. */
 const ATTRIBUTE_NAME = /^[a-zA-Z_:][-a-zA-Z0-9_:.]*$/;
@@ -71,19 +125,45 @@ const rawTextOrThrow = (tag, content) => {
       `[serializeVNode] <${tag}> content contains a closing "</${tag}" sequence and cannot be safely serialized.`,
     );
   }
+  // `<!--` inside a <script> moves the tokenizer into script-data-escaped
+  // state, where a later `</script>` no longer closes the element — the rest
+  // of the document is silently swallowed as script text. Not code execution,
+  // but total content loss, and invisible until someone views the page.
+  if (tag === "script" && text.includes("<!--")) {
+    throw new Error(
+      '[serializeVNode] <script> content contains "<!--", which changes the tokenizer state ' +
+        "so the element no longer closes at </script>. Refusing to serialize.",
+    );
+  }
   return text;
 };
 
 /**
- * Comments are also raw: `--` cannot appear inside, and a comment may not end
- * with `-`. Rather than silently mangle, refuse — a comment is never
- * user-facing content in this dialect, so an offending one is a bug.
+ * Comment text is raw and cannot be escaped, so anything that could terminate
+ * the comment early must be refused.
+ *
+ * Per the HTML spec the text must not start with `>` or `->`, must not contain
+ * `--` or `<!--`, and must not end with `-`. The `>` cases are the dangerous
+ * ones and are easy to miss: `<!-->x-->` parses as an EMPTY comment followed by
+ * `x-->` as live markup — verified in Chromium, where a payload of
+ * `><img src=x onerror=...>` creates a real element and runs the handler.
+ *
+ * Refusing rather than sanitizing is deliberate: a comment is never
+ * user-facing content in this dialect, so an offending one is a bug worth
+ * surfacing.
  */
 const commentOrThrow = (content) => {
   const text = String(content ?? "");
-  if (text.includes("--") || text.endsWith("-")) {
+  const invalid =
+    text.startsWith(">") ||
+    text.startsWith("->") ||
+    text.includes("--") ||
+    text.includes("<!") ||
+    text.endsWith("-");
+  if (invalid) {
     throw new Error(
-      "[serializeVNode] comment content may not contain `--` or end with `-`.",
+      "[serializeVNode] comment content may not start with `>` or `->`, " +
+        "contain `--` or `<!`, or end with `-` — any of these terminate the comment early.",
     );
   }
   return text;
@@ -108,7 +188,10 @@ const classObjectToString = (klass) => {
 /** parseView emits bare tags; tolerate snabbdom's `tag#id.cls` form defensively. */
 const tagFromSel = (sel) => String(sel).split(/[.#]/)[0] || "div";
 
-const buildAttributes = (data = {}) => {
+const buildAttributes = (rawData) => {
+  // A default parameter only applies to `undefined`, so an explicit `data: null`
+  // would crash here with an unattributable TypeError.
+  const data = rawData || {};
   const out = [];
   const attrs = { ...(data.attrs || {}) };
 
@@ -151,7 +234,14 @@ const buildAttributes = (data = {}) => {
  *   component — or `null`/`undefined` to serialize normally.
  * @returns {string}
  */
-export const serializeVNode = (vnode, options = {}) => {
+export const serializeVNode = (vnode, options = {}) =>
+  serializeNode(vnode, options, false);
+
+/**
+ * @param {boolean} isForeign  true when this node sits inside <svg>/<math>,
+ *   where <style>/<script> are NOT raw text.
+ */
+const serializeNode = (vnode, options, isForeign) => {
   if (vnode === null || vnode === undefined) return "";
 
   // Text vnode: snabbdom leaves `sel` undefined and puts the string in `text`.
@@ -166,22 +256,30 @@ export const serializeVNode = (vnode, options = {}) => {
   const tag = tagFromSel(vnode.sel);
   const attributes = buildAttributes(vnode.data);
 
-  if (VOID_ELEMENTS.has(tag)) {
+  if (VOID_ELEMENTS.has(tag.toLowerCase())) {
     return `<${tag}${attributes}>`;
   }
+
+  const lowerTag = tag.toLowerCase();
+  const childForeign = childIsForeign(tag, isForeign, vnode.data);
+  // Raw text only applies in the HTML namespace. In foreign content the parser
+  // reads <style>/<script> content as markup, so it must be escaped instead.
+  const isRawText = RAW_TEXT_ELEMENTS.has(lowerTag) && !isForeign;
 
   const substituted = options.renderChildren ? options.renderChildren(vnode) : null;
 
   let inner = "";
   if (substituted !== null && substituted !== undefined) {
     inner = substituted;
-  } else if (RAW_TEXT_ELEMENTS.has(tag)) {
+  } else if (isRawText) {
     const raw = Array.isArray(vnode.children) && vnode.children.length > 0
       ? vnode.children.map((child) => child?.text ?? "").join("")
       : (vnode.text ?? "");
-    inner = rawTextOrThrow(tag, raw);
+    inner = rawTextOrThrow(lowerTag, raw);
   } else if (Array.isArray(vnode.children) && vnode.children.length > 0) {
-    inner = vnode.children.map((child) => serializeVNode(child, options)).join("");
+    inner = vnode.children
+      .map((child) => serializeNode(child, options, childForeign))
+      .join("");
   } else if (vnode.text !== undefined && vnode.text !== null) {
     // h(tag, data, "string") puts the text on the element vnode itself.
     inner = escapeText(vnode.text);
@@ -189,5 +287,3 @@ export const serializeVNode = (vnode, options = {}) => {
 
   return `<${tag}${attributes}>${inner}</${tag}>`;
 };
-
-export default serializeVNode;

--- a/packages/rettangoli-fe/src/core/server/serializeVNode.js
+++ b/packages/rettangoli-fe/src/core/server/serializeVNode.js
@@ -24,6 +24,12 @@
  *  - `data.on`, `data.hook` — live closures.
  */
 
+import {
+  HTML_NAMESPACE,
+  namespaceFromHtml,
+  namespaceForChild,
+} from "../view/namespaces.js";
+
 const VOID_ELEMENTS = new Set([
   "area", "base", "br", "col", "embed", "hr", "img", "input",
   "link", "meta", "param", "source", "track", "wbr",
@@ -58,91 +64,10 @@ const RAW_TEXT_ELEMENTS = new Set([
  * re-parses with a real <img> hoisted out of the svg, and the handler runs.
  * Verified in Chromium.
  *
- * Namespace cannot be read off the vnode: snabbdom's `addNS` only stamps
- * `data.ns` for sels starting with `svg`, so MathML carries nothing. It has to
- * be tracked structurally as we descend.
+ * Public callers can supply vnodes that have not gone through rettangoli's
+ * namespace normalization, so serialization still tracks namespace
+ * structurally rather than trusting `data.ns`.
  */
-const HTML_NAMESPACE = "html";
-const SVG_NAMESPACE = "svg";
-const MATHML_NAMESPACE = "mathml";
-
-/**
- * SVG and MathML have different HTML integration points. Combining these sets
- * is unsafe: for example, `title` is an integration point in SVG but not in
- * MathML, while `mi` is one in MathML but not SVG.
- */
-const SVG_HTML_INTEGRATION_POINTS = new Set(["foreignobject", "desc", "title"]);
-const MATHML_TEXT_INTEGRATION_POINTS = new Set(["mi", "mo", "mn", "ms", "mtext"]);
-const MATHML_TEXT_INTEGRATION_EXCEPTIONS = new Set(["mglyph", "malignmark"]);
-
-const HTML_ENCODINGS = new Set(["text/html", "application/xhtml+xml"]);
-
-/**
- * Resolves an element token processed in the HTML namespace. HTML parsing
- * enters foreign content only for SVG and MathML roots.
- */
-const namespaceFromHtml = (rawTag) => {
-  const tag = rawTag.toLowerCase();
-  if (tag === "svg") return SVG_NAMESPACE;
-  if (tag === "math") return MATHML_NAMESPACE;
-  return HTML_NAMESPACE;
-};
-
-const getAttribute = (data, expectedName) => {
-  const entry = Object.entries(data?.attrs || {}).find(
-    ([name]) => name.toLowerCase() === expectedName,
-  );
-  return entry?.[1];
-};
-
-/**
- * Resolves one child at a time because MathML text integration points keep
- * immediate `mglyph` and `malignmark` children in MathML while processing
- * their other children as HTML.
- *
- * Tags are lowercased for lookup only — the emitted tag keeps its original case,
- * which matters for SVG's camelCase elements (`foreignObject`, `clipPath`).
- */
-const namespaceForChild = ({
-  parentNamespace,
-  parentTag: rawParentTag,
-  parentData,
-  childTag: rawChildTag,
-}) => {
-  const parentTag = rawParentTag.toLowerCase();
-  const childTag = rawChildTag.toLowerCase();
-
-  if (parentNamespace === HTML_NAMESPACE) {
-    return namespaceFromHtml(childTag);
-  }
-
-  if (parentNamespace === SVG_NAMESPACE) {
-    return SVG_HTML_INTEGRATION_POINTS.has(parentTag)
-      ? namespaceFromHtml(childTag)
-      : SVG_NAMESPACE;
-  }
-
-  if (MATHML_TEXT_INTEGRATION_POINTS.has(parentTag)) {
-    return MATHML_TEXT_INTEGRATION_EXCEPTIONS.has(childTag)
-      ? MATHML_NAMESPACE
-      : namespaceFromHtml(childTag);
-  }
-
-  if (parentTag === "annotation-xml") {
-    // The HTML parser handles this start tag as SVG even when annotation-xml
-    // is not an HTML integration point (that is, regardless of encoding).
-    if (childTag === "svg") {
-      return SVG_NAMESPACE;
-    }
-    const encoding = String(getAttribute(parentData, "encoding") ?? "").toLowerCase();
-    if (HTML_ENCODINGS.has(encoding)) {
-      return namespaceFromHtml(childTag);
-    }
-  }
-
-  return MATHML_NAMESPACE;
-};
-
 /** Mirrors the framework's own attribute-name validation. */
 const ATTRIBUTE_NAME = /^[a-zA-Z_:][-a-zA-Z0-9_:.]*$/;
 
@@ -177,27 +102,93 @@ const escapeAttribute = (value) =>
 const toKebab = (key) =>
   key.startsWith("--") ? key : key.replace(/[A-Z]/g, (c) => `-${c.toLowerCase()}`);
 
+const RAW_TEXT_END_TAG_DELIMITER = /[\t\n\f\r />]/;
+
+const hasDelimitedSequence = (text, offset, sequence) => {
+  if (text.slice(offset, offset + sequence.length).toLowerCase() !== sequence) {
+    return false;
+  }
+  const delimiter = text[offset + sequence.length];
+  return delimiter !== undefined && RAW_TEXT_END_TAG_DELIMITER.test(delimiter);
+};
+
+const throwRawTextEndTag = (tag) => {
+  throw new Error(
+    `[serializeVNode] <${tag}> content contains an actual closing </${tag}> tag ` +
+      "and cannot be safely serialized.",
+  );
+};
+
+/**
+ * Script data has two comment-like escaped modes. A closing </script> remains
+ * active in the ordinary escaped mode, but only exits the double-escaped mode.
+ * Track those transitions so harmless `<!--` markers remain legal while a
+ * synthetic closing tag that would be swallowed is rejected.
+ */
+const scriptTextOrThrow = (text) => {
+  let state = "data";
+
+  for (let index = 0; index < text.length;) {
+    if (state !== "double-escaped" && hasDelimitedSequence(text, index, "</script")) {
+      throwRawTextEndTag("script");
+    }
+
+    if (state === "data") {
+      if (text.startsWith("<!--", index)) {
+        state = "escaped";
+        index += 4;
+      } else {
+        index += 1;
+      }
+      continue;
+    }
+
+    if (state === "escaped") {
+      if (text.startsWith("-->", index)) {
+        state = "data";
+        index += 3;
+      } else if (hasDelimitedSequence(text, index, "<script")) {
+        state = "double-escaped";
+        index += 7;
+      } else {
+        index += 1;
+      }
+      continue;
+    }
+
+    if (text.startsWith("-->", index)) {
+      state = "data";
+      index += 3;
+    } else if (hasDelimitedSequence(text, index, "</script")) {
+      state = "escaped";
+      index += 8;
+    } else {
+      index += 1;
+    }
+  }
+
+  if (state === "double-escaped") {
+    throw new Error(
+      "[serializeVNode] <script> content ends in the script-data-double-escaped state, " +
+        "which would swallow the generated closing </script> tag.",
+    );
+  }
+};
+
 /**
  * Raw text cannot be escaped, so the only defence against content closing its
- * own element is to refuse it. Anything producing `</style` or `</script` here
- * is either a bug or an injection attempt.
+ * own element is to refuse actual matching end tags. Near-matches such as
+ * `</stylesheet>` remain ordinary text.
  */
 const rawTextOrThrow = (tag, content) => {
   const text = String(content ?? "");
-  if (new RegExp(`</\\s*${tag}`, "i").test(text)) {
-    throw new Error(
-      `[serializeVNode] <${tag}> content contains a closing "</${tag}" sequence and cannot be safely serialized.`,
-    );
-  }
-  // `<!--` inside a <script> moves the tokenizer into script-data-escaped
-  // state, where a later `</script>` no longer closes the element — the rest
-  // of the document is silently swallowed as script text. Not code execution,
-  // but total content loss, and invisible until someone views the page.
-  if (tag === "script" && text.includes("<!--")) {
-    throw new Error(
-      '[serializeVNode] <script> content contains "<!--", which changes the tokenizer state ' +
-        "so the element no longer closes at </script>. Refusing to serialize.",
-    );
+  if (tag === "script") {
+    scriptTextOrThrow(text);
+  } else {
+    const closingTag = new RegExp(`</${tag}(?=[\\t\\n\\f\\r />])`, "i");
+    if (closingTag.test(text)) {
+      throwRawTextEndTag(tag);
+    }
   }
   return text;
 };
@@ -233,6 +224,94 @@ const commentOrThrow = (content) => {
   return text;
 };
 
+const CSS_PROPERTY_NAME = /^(?:--[-_a-zA-Z0-9]+|-?[_a-zA-Z][-_a-zA-Z0-9]*)$/;
+const CSS_BLOCK_END = {
+  "(": ")",
+  "[": "]",
+  "{": "}",
+};
+
+const cssDeclarationOrThrow = (rawProperty, rawValue) => {
+  const property = toKebab(rawProperty);
+  const value = String(rawValue);
+  const blocks = [];
+  let quote = null;
+  let inComment = false;
+
+  const invalid = (reason) => {
+    throw new Error(
+      `[serializeVNode] style property ${JSON.stringify(property)} ${reason}; ` +
+        "it cannot be safely isolated as one CSS declaration.",
+    );
+  };
+
+  if (!CSS_PROPERTY_NAME.test(property)) {
+    invalid("has an invalid CSS property name");
+  }
+
+  for (let index = 0; index < value.length; index += 1) {
+    const char = value[index];
+    const next = value[index + 1];
+
+    if (inComment) {
+      if (char === "*" && next === "/") {
+        inComment = false;
+        index += 1;
+      }
+      continue;
+    }
+
+    if (quote !== null) {
+      if (char === "\\") {
+        if (next === undefined) invalid("ends with an incomplete CSS escape");
+        index += 1;
+      } else if (char === quote) {
+        quote = null;
+      } else if (char === "\n" || char === "\r" || char === "\f") {
+        invalid("contains an unescaped line break in a CSS string");
+      }
+      continue;
+    }
+
+    if (char === "/" && next === "*") {
+      inComment = true;
+      index += 1;
+      continue;
+    }
+    if (char === "'" || char === '"') {
+      quote = char;
+      continue;
+    }
+    if (char === "\\") {
+      if (next === undefined) invalid("ends with an incomplete CSS escape");
+      index += 1;
+      continue;
+    }
+    if (Object.prototype.hasOwnProperty.call(CSS_BLOCK_END, char)) {
+      blocks.push(CSS_BLOCK_END[char]);
+      continue;
+    }
+    if (char === ")" || char === "]" || char === "}") {
+      if (blocks.pop() !== char) invalid("contains unbalanced CSS blocks");
+      continue;
+    }
+    if (blocks.length === 0 && char === ";") {
+      invalid("contains a top-level semicolon");
+    }
+    // CSSStyleDeclaration property assignment does not accept a priority in
+    // the value, while reparsing an HTML style attribute does.
+    if (blocks.length === 0 && char === "!") {
+      invalid("contains a top-level priority marker");
+    }
+  }
+
+  if (inComment) invalid("contains an unterminated CSS comment");
+  if (quote !== null) invalid("contains an unterminated CSS string");
+  if (blocks.length > 0) invalid("contains unbalanced CSS blocks");
+
+  return `${property}: ${value}`;
+};
+
 const styleObjectToString = (style) => {
   if (!style || typeof style !== "object") return "";
   return Object.entries(style)
@@ -240,7 +319,7 @@ const styleObjectToString = (style) => {
     // behaviour, not declarations.
     .filter(([key]) => key !== "delayed" && key !== "remove" && key !== "destroy")
     .filter(([, value]) => value !== undefined && value !== null && value !== "")
-    .map(([key, value]) => `${toKebab(key)}: ${value}`)
+    .map(([key, value]) => cssDeclarationOrThrow(key, value))
     .join("; ");
 };
 
@@ -372,7 +451,7 @@ const serializeNode = (vnode, options, namespace) => {
   }
   const attributes = buildAttributes(vnode.data, selector);
 
-  if (VOID_ELEMENTS.has(lowerTag)) {
+  if (namespace === HTML_NAMESPACE && VOID_ELEMENTS.has(lowerTag)) {
     return `<${tag}${attributes}>`;
   }
 

--- a/packages/rettangoli-fe/src/core/view/namespaces.js
+++ b/packages/rettangoli-fe/src/core/view/namespaces.js
@@ -1,0 +1,119 @@
+export const HTML_NAMESPACE = "html";
+export const SVG_NAMESPACE = "svg";
+export const MATHML_NAMESPACE = "mathml";
+
+export const SVG_NAMESPACE_URI = "http://www.w3.org/2000/svg";
+export const MATHML_NAMESPACE_URI = "http://www.w3.org/1998/Math/MathML";
+
+const SVG_HTML_INTEGRATION_POINTS = new Set(["foreignobject", "desc", "title"]);
+const MATHML_TEXT_INTEGRATION_POINTS = new Set(["mi", "mo", "mn", "ms", "mtext"]);
+const MATHML_TEXT_INTEGRATION_EXCEPTIONS = new Set(["mglyph", "malignmark"]);
+const HTML_ENCODINGS = new Set(["text/html", "application/xhtml+xml"]);
+
+/**
+ * Resolves an element token processed in the HTML namespace. HTML parsing
+ * enters foreign content only for SVG and MathML roots.
+ */
+export const namespaceFromHtml = (rawTag) => {
+  const tag = rawTag.toLowerCase();
+  if (tag === "svg") return SVG_NAMESPACE;
+  if (tag === "math") return MATHML_NAMESPACE;
+  return HTML_NAMESPACE;
+};
+
+const getAttribute = (data, expectedName) => {
+  const entry = Object.entries(data?.attrs || {}).find(
+    ([name]) => name.toLowerCase() === expectedName,
+  );
+  return entry?.[1];
+};
+
+/**
+ * Resolves one child at a time because MathML text integration points keep
+ * immediate `mglyph` and `malignmark` children in MathML while processing
+ * their other children as HTML.
+ */
+export const namespaceForChild = ({
+  parentNamespace,
+  parentTag: rawParentTag,
+  parentData,
+  childTag: rawChildTag,
+}) => {
+  const parentTag = rawParentTag.toLowerCase();
+  const childTag = rawChildTag.toLowerCase();
+
+  if (parentNamespace === HTML_NAMESPACE) {
+    return namespaceFromHtml(childTag);
+  }
+
+  if (parentNamespace === SVG_NAMESPACE) {
+    return SVG_HTML_INTEGRATION_POINTS.has(parentTag)
+      ? namespaceFromHtml(childTag)
+      : SVG_NAMESPACE;
+  }
+
+  if (MATHML_TEXT_INTEGRATION_POINTS.has(parentTag)) {
+    return MATHML_TEXT_INTEGRATION_EXCEPTIONS.has(childTag)
+      ? MATHML_NAMESPACE
+      : namespaceFromHtml(childTag);
+  }
+
+  if (parentTag === "annotation-xml") {
+    // The HTML parser handles this start tag as SVG even when annotation-xml
+    // is not an HTML integration point (that is, regardless of encoding).
+    if (childTag === "svg") {
+      return SVG_NAMESPACE;
+    }
+    const encoding = String(getAttribute(parentData, "encoding") ?? "").toLowerCase();
+    if (HTML_ENCODINGS.has(encoding)) {
+      return namespaceFromHtml(childTag);
+    }
+  }
+
+  return MATHML_NAMESPACE;
+};
+
+const tagFromSelector = (selector) => String(selector).split(/[.#]/)[0] || "div";
+
+/**
+ * Snabbdom only infers SVG, and does so too broadly for HTML integration
+ * points. Normalize the completed tree so its DOM API calls create the same
+ * namespaces that parsing the serialized HTML produces.
+ */
+export const applyVNodeNamespaces = (vnode, namespace) => {
+  if (!vnode || vnode.sel === undefined || vnode.sel === "!") {
+    return vnode;
+  }
+
+  const tag = tagFromSelector(vnode.sel);
+  const resolvedNamespace = namespace ?? namespaceFromHtml(tag);
+  const data = vnode.data || (vnode.data = {});
+
+  if (resolvedNamespace === SVG_NAMESPACE) {
+    data.ns = SVG_NAMESPACE_URI;
+  } else if (resolvedNamespace === MATHML_NAMESPACE) {
+    data.ns = MATHML_NAMESPACE_URI;
+  } else {
+    // Remove namespace metadata added recursively by snabbdom's SVG helper
+    // beneath desc/title integration points.
+    delete data.ns;
+  }
+
+  if (Array.isArray(vnode.children)) {
+    for (const child of vnode.children) {
+      if (!child || child.sel === undefined || child.sel === "!") continue;
+      const childTag = tagFromSelector(child.sel);
+      applyVNodeNamespaces(
+        child,
+        namespaceForChild({
+          parentNamespace: resolvedNamespace,
+          parentTag: tag,
+          parentData: data,
+          childTag,
+        }),
+      );
+    }
+  }
+
+  return vnode;
+};

--- a/packages/rettangoli-fe/src/createComponent.js
+++ b/packages/rettangoli-fe/src/createComponent.js
@@ -1,49 +1,13 @@
-import { toCamelCase } from "./core/runtime/props.js";
-import { validateSchemaContract } from "./core/schema/validateSchemaContract.js";
 import { createWebComponentClass } from "./web/createWebComponentClass.js";
 import createWebPatch from "./createWebPatch.js";
 import { h } from "snabbdom/build/h.js";
+import { resolveComponentDefinition } from "./core/component/resolveComponentDefinition.js";
 
 const patch = createWebPatch();
 
-export const resolveComponentDefinition = (
-  { handlers, methods, constants, schema, view, store },
-) => {
-  if (!view) {
-    throw new Error("view is not defined");
-  }
-
-  if (!schema || typeof schema !== "object" || Array.isArray(schema)) {
-    throw new Error("schema is required. Define component metadata in .schema.yaml.");
-  }
-
-  const resolvedSchema = schema;
-  const { template, refs, styles } = view;
-
-  validateSchemaContract({
-    schema: resolvedSchema,
-    methodExports: Object.keys(methods || {}),
-  });
-
-  const elementName = resolvedSchema.componentName;
-  const propsSchema = resolvedSchema.propsSchema;
-  const propsSchemaKeys = propsSchema?.properties
-    ? [...new Set(Object.keys(propsSchema.properties).map((propKey) => toCamelCase(propKey)))]
-    : [];
-
-  return {
-    elementName,
-    propsSchema,
-    propsSchemaKeys,
-    template,
-    refs,
-    styles,
-    handlers,
-    methods,
-    constants,
-    store,
-  };
-};
+// Moved to core/component/ so consumers that only need the definition do not
+// transitively import the patch. Re-exported here for backwards compatibility.
+export { resolveComponentDefinition };
 
 const createComponent = (
   componentConfig,

--- a/packages/rettangoli-fe/src/createWebPatch.js
+++ b/packages/rettangoli-fe/src/createWebPatch.js
@@ -2,7 +2,10 @@ import { init } from 'snabbdom/build/init.js'
 import { classModule } from 'snabbdom/build/modules/class.js'
 import { propsModule } from 'snabbdom/build/modules/props.js'
 import { attributesModule } from 'snabbdom/build/modules/attributes.js'
-import { styleModule } from 'snabbdom/build/modules/style.js'
+// Vendored rather than imported from snabbdom: the published style module
+// dereferences a bare `window` at module scope, which makes importing this
+// package throw in Node. See the file header for the two-line delta.
+import { styleModule } from './web/vendor/snabbdomStyleModule.js'
 import { eventListenersModule } from 'snabbdom/build/modules/eventlisteners.js'
 
 const createWebPatch = () => {

--- a/packages/rettangoli-fe/src/parser.js
+++ b/packages/rettangoli-fe/src/parser.js
@@ -20,6 +20,7 @@ export const parseView = ({
   refs,
   handlers,
   createComponentUpdateHook,
+  wireEventListeners = true,
 }) => {
   ensureNormalizedTemplatePropertyBindings(template);
   const result = jemplRender(template, viewData, {});
@@ -34,6 +35,7 @@ export const parseView = ({
     handlers,
     viewData,
     createComponentUpdateHook,
+    wireEventListeners,
   });
 
   const vdom = h("div", { style: { display: "contents" } }, childNodes);
@@ -47,6 +49,7 @@ export const parseView = ({
  * @param {Object} params.refs
  * @param {Object} params.handlers
  * @param {Object} params.viewData
+ * @param {boolean} params.wireEventListeners
  * @returns
  */
 export const createVirtualDom = ({
@@ -56,6 +59,7 @@ export const createVirtualDom = ({
   handlers = {},
   viewData = {},
   createComponentUpdateHook,
+  wireEventListeners = true,
 }) => {
   if (!Array.isArray(items)) {
     throw new Error("[Parser] Input to createVirtualDom must be an array, got " + typeof items);
@@ -209,7 +213,7 @@ export const createVirtualDom = ({
             refMatchers,
           });
 
-          if (bestMatchRef) {
+          if (bestMatchRef && wireEventListeners) {
             const bestMatchRefKey = bestMatchRef.refKey;
             const matchIdentity = bestMatchRef.matchedValue || elementIdForRefs || bestMatchRefKey;
 

--- a/packages/rettangoli-fe/src/parser.js
+++ b/packages/rettangoli-fe/src/parser.js
@@ -3,6 +3,7 @@ import { parseAndRender as jemplParseAndRender, render as jemplRender } from "je
 import { flattenArrays } from "./utils/flattenArrays.js";
 import { parseNodeBindings } from './core/view/bindings.js';
 import { ensureNormalizedTemplatePropertyBindings } from "./core/view/templatePropertyBindings.js";
+import { applyVNodeNamespaces } from "./core/view/namespaces.js";
 import {
   createRefMatchers,
   resolveBestRefMatcher,
@@ -39,7 +40,7 @@ export const parseView = ({
   });
 
   const vdom = h("div", { style: { display: "contents" } }, childNodes);
-  return vdom;
+  return applyVNodeNamespaces(vdom);
 };
 
 /**

--- a/packages/rettangoli-fe/src/server/index.js
+++ b/packages/rettangoli-fe/src/server/index.js
@@ -57,8 +57,9 @@ export const renderView = ({ template, viewData = {}, refs = {}, renderChildren 
     template: ast,
     viewData,
     refs,
-    // Handlers are never invoked server-side; refs still resolve for ids.
-    handlers: {},
+    // Event closures are client-only. Skipping their construction also avoids
+    // requiring a store-action dispatcher that can never run on the server.
+    wireEventListeners: false,
   });
 
   return serializeVNode(vnode, renderChildren ? { renderChildren } : undefined);

--- a/packages/rettangoli-fe/src/server/index.js
+++ b/packages/rettangoli-fe/src/server/index.js
@@ -5,14 +5,61 @@
  * in a plain Node process — for HTML golden tests, static analysis over real
  * rendered output, or a server renderer.
  *
- * This is Part A of the SSR plan: the pieces needed to render a component's
- * markup outside a browser. It deliberately does NOT include a recursive
- * component renderer or any hydration support — those are Part B and are a
- * separate decision. See docs/ssr-plan.md.
+ * This is Part A of the SSR plan (packages/rettangoli-fe/docs/ssr-plan.md, also
+ * on GitHub): the pieces needed to render a component's markup outside a
+ * browser. It deliberately does NOT include a recursive component renderer or
+ * any hydration support — those are Part B and a separate decision.
+ *
+ * Child components serialize as empty custom-element tags, so this renders one
+ * component's own template rather than a whole tree.
  */
+
+import { parse as parseTemplate } from "jempl";
+import { h } from "snabbdom/build/h.js";
+
+import { parseView } from "../parser.js";
+import { serializeVNode } from "../core/server/serializeVNode.js";
 
 export { serializeVNode } from "../core/server/serializeVNode.js";
 export { resolveComponentDefinition } from "../core/component/resolveComponentDefinition.js";
-export { parseView, createVirtualDom } from "../parser.js";
 export { bindStore } from "../core/runtime/store.js";
-export { yamlToCss } from "../core/style/yamlToCss.js";
+
+/**
+ * Renders a component's template to an HTML string.
+ *
+ * Self-contained on purpose: `parseView` needs a snabbdom `h` and a
+ * jempl-*parsed* AST, and requiring callers to supply those would mean taking
+ * direct dependencies on `snabbdom/build/h.js` and `jempl/src/parse/index.js`
+ * — deep internal paths that break under strict node_modules layouts. Both are
+ * already dependencies of this package, so it supplies them.
+ *
+ * @param {object}   options
+ * @param {object|Array} options.template  a `.view.yaml` template — raw, or an
+ *   already-parsed jempl AST (as produced at build time)
+ * @param {object}   [options.viewData]    typically the output of `selectViewData`
+ * @param {object}   [options.refs]        the view's `refs` block
+ * @param {(vnode: object) => string|null} [options.renderChildren]
+ *   Escape hatch for substituting an element's children with pre-rendered HTML.
+ *   The returned string is emitted verbatim and is NOT escaped or validated, so
+ *   it must already be safe.
+ * @returns {string}
+ */
+export const renderView = ({ template, viewData = {}, refs = {}, renderChildren } = {}) => {
+  if (!template) {
+    throw new Error("[renderView] `template` is required.");
+  }
+
+  // A parsed jempl AST carries a numeric `type`; anything else is raw YAML.
+  const ast = typeof template.type === "number" ? template : parseTemplate(template);
+
+  const vnode = parseView({
+    h,
+    template: ast,
+    viewData,
+    refs,
+    // Handlers are never invoked server-side; refs still resolve for ids.
+    handlers: {},
+  });
+
+  return serializeVNode(vnode, renderChildren ? { renderChildren } : undefined);
+};

--- a/packages/rettangoli-fe/src/server/index.js
+++ b/packages/rettangoli-fe/src/server/index.js
@@ -1,0 +1,18 @@
+/**
+ * Node-safe surface of @rettangoli/fe.
+ *
+ * Nothing reachable from this entry touches a DOM global, so it can be imported
+ * in a plain Node process — for HTML golden tests, static analysis over real
+ * rendered output, or a server renderer.
+ *
+ * This is Part A of the SSR plan: the pieces needed to render a component's
+ * markup outside a browser. It deliberately does NOT include a recursive
+ * component renderer or any hydration support — those are Part B and are a
+ * separate decision. See docs/ssr-plan.md.
+ */
+
+export { serializeVNode } from "../core/server/serializeVNode.js";
+export { resolveComponentDefinition } from "../core/component/resolveComponentDefinition.js";
+export { parseView, createVirtualDom } from "../parser.js";
+export { bindStore } from "../core/runtime/store.js";
+export { yamlToCss } from "../core/style/yamlToCss.js";

--- a/packages/rettangoli-fe/src/web/componentDom.js
+++ b/packages/rettangoli-fe/src/web/componentDom.js
@@ -41,24 +41,54 @@ const markRenderTarget = (node) => {
   }
 };
 
+/**
+ * Elements that must never be adopted as the render target.
+ *
+ * The positional fallback below exists for shadow roots created before render
+ * targets were marked. But a shadow root legitimately contains other things —
+ * a `<style>`, a `<link>`, a `<slot>` — and adopting one of those is silently
+ * destructive: it is given `display: contents`, then snabbdom replaces it on
+ * the first patch (its `sel` cannot match the parser's `div` root), leaving
+ * `instance.renderTarget` pointing at a detached node.
+ *
+ * Reachable today on the hot-update path, and guaranteed the moment a shadow
+ * root carries server-rendered styles.
+ */
+const NON_ADOPTABLE_TAGS = new Set(["STYLE", "LINK", "SLOT", "TEMPLATE", "SCRIPT"]);
+
+const isAdoptableRenderTarget = (node) => {
+  if (!node || typeof node !== "object") return false;
+  const tagName = typeof node.tagName === "string" ? node.tagName.toUpperCase() : "";
+  return !NON_ADOPTABLE_TAGS.has(tagName);
+};
+
 const findExistingRenderTarget = (shadow) => {
   if (!shadow || typeof shadow !== "object") {
     return undefined;
   }
 
   if (typeof shadow.querySelector === "function") {
-    return shadow.querySelector(`[${RENDER_TARGET_ATTR}]`) ?? shadow.firstElementChild;
+    const marked = shadow.querySelector(`[${RENDER_TARGET_ATTR}]`);
+    if (marked) return marked;
+    const first = shadow.firstElementChild;
+    return isAdoptableRenderTarget(first) ? first : undefined;
   }
 
   if (Array.isArray(shadow.childNodes)) {
-    return shadow.childNodes.find(hasRenderTargetAttr) ?? shadow.childNodes[0];
+    const marked = shadow.childNodes.find(hasRenderTargetAttr);
+    if (marked) return marked;
+    return isAdoptableRenderTarget(shadow.childNodes[0]) ? shadow.childNodes[0] : undefined;
   }
 
   if (Array.isArray(shadow.children)) {
-    return shadow.children.find(hasRenderTargetAttr) ?? shadow.children[0];
+    const marked = shadow.children.find(hasRenderTargetAttr);
+    if (marked) return marked;
+    return isAdoptableRenderTarget(shadow.children[0]) ? shadow.children[0] : undefined;
   }
 
-  return shadow.firstElementChild;
+  return isAdoptableRenderTarget(shadow.firstElementChild)
+    ? shadow.firstElementChild
+    : undefined;
 };
 
 export const initializeComponentDom = ({
@@ -91,7 +121,12 @@ export const initializeComponentDom = ({
     markRenderTarget(renderTarget);
     shadow.appendChild(renderTarget);
   } else {
-    renderTarget.style.cssText = "display: contents;";
+    // Set the property rather than clobbering cssText: an adopted render
+    // target may legitimately carry inline styles (including ones the server
+    // emitted), and overwriting the whole declaration block discards them.
+    if (renderTarget.style && renderTarget.style.display !== "contents") {
+      renderTarget.style.display = "contents";
+    }
     if (!hasRenderTargetAttr(renderTarget)) {
       markRenderTarget(renderTarget);
     }

--- a/packages/rettangoli-fe/src/web/vendor/snabbdomStyleModule.js
+++ b/packages/rettangoli-fe/src/web/vendor/snabbdomStyleModule.js
@@ -40,10 +40,13 @@
  * Making the patch lazy does NOT help — the failure is module evaluation, not
  * invocation.
  *
- * THE DELTA vs upstream is exactly two lines: `raf` is resolved lazily and
- * reads `globalThis.window` instead of a bare `window`. Everything else is a
- * byte-faithful copy so runtime behaviour — including the `delayed` / `remove`
- * / `destroy` transition hooks — is unchanged in a browser.
+ * THE DELTA vs upstream is the `raf` binding alone: it resolves lazily and
+ * reads `globalThis.window` instead of a bare `window`. The rest is
+ * SEMANTICALLY faithful but reformatted to this repo's style (brace placement,
+ * single-line ifs), so runtime behaviour — including the `delayed` / `remove`
+ * / `destroy` transition hooks — is unchanged in a browser. It is not a
+ * byte-for-byte copy; `test/web/style-module.test.js` compares the normalised
+ * body against the installed snabbdom rather than the raw text.
  *
  * Keep this in sync if snabbdom is upgraded. `test/web/style-module.test.js`
  * pins the observable behaviour.
@@ -173,5 +176,3 @@ export const styleModule = {
   destroy: applyDestroyStyle,
   remove: applyRemoveStyle,
 };
-
-export default styleModule;

--- a/packages/rettangoli-fe/src/web/vendor/snabbdomStyleModule.js
+++ b/packages/rettangoli-fe/src/web/vendor/snabbdomStyleModule.js
@@ -1,0 +1,158 @@
+/**
+ * Vendored from snabbdom 3.6.2 — `snabbdom/build/modules/style.js`.
+ * MIT licensed, Copyright (c) 2015 Simon Friis Vindum.
+ *
+ * WHY THIS EXISTS
+ *
+ * Snabbdom's published style module dereferences a bare `window` at MODULE
+ * SCOPE:
+ *
+ *     const raf = typeof (window === null || window === void 0
+ *       ? void 0
+ *       : window.requestAnimationFrame) === "function" ? ... : setTimeout;
+ *
+ * `typeof (...)` looks safe but the parenthesised expression is evaluated
+ * first, so on a platform without `window` this throws `ReferenceError` at
+ * *import* time — not at call time. Because `createWebPatch.js` imports it
+ * statically, `import("@rettangoli/fe")` was unusable in Node, which blocked
+ * every Node-side tool: HTML golden tests, static analysis over real output,
+ * and any server renderer.
+ *
+ * Making the patch lazy does NOT help — the failure is module evaluation, not
+ * invocation.
+ *
+ * THE DELTA vs upstream is exactly two lines: `raf` is resolved lazily and
+ * reads `globalThis.window` instead of a bare `window`. Everything else is a
+ * byte-faithful copy so runtime behaviour — including the `delayed` / `remove`
+ * / `destroy` transition hooks — is unchanged in a browser.
+ *
+ * Keep this in sync if snabbdom is upgraded. `test/web/style-module.test.js`
+ * pins the observable behaviour.
+ */
+
+/**
+ * Resolved on first use rather than at module load. In a browser this is
+ * `window.requestAnimationFrame`; anywhere else it degrades to `setTimeout`,
+ * exactly as upstream does for non-rAF environments.
+ */
+let resolvedRaf;
+const raf = (callback) => {
+  if (resolvedRaf === undefined) {
+    const win = globalThis.window;
+    resolvedRaf =
+      typeof win?.requestAnimationFrame === "function"
+        ? win.requestAnimationFrame.bind(win)
+        : setTimeout;
+  }
+  return resolvedRaf(callback);
+};
+
+const nextFrame = function (fn) {
+  raf(function () {
+    raf(fn);
+  });
+};
+
+let reflowForced = false;
+
+function setNextFrame(obj, prop, val) {
+  nextFrame(function () {
+    obj[prop] = val;
+  });
+}
+
+function updateStyle(oldVnode, vnode) {
+  let cur;
+  let name;
+  const elm = vnode.elm;
+  let oldStyle = oldVnode.data.style;
+  let style = vnode.data.style;
+  if (!oldStyle && !style) return;
+  if (oldStyle === style) return;
+  oldStyle = oldStyle || {};
+  style = style || {};
+  const oldHasDel = "delayed" in oldStyle;
+  for (name in oldStyle) {
+    if (!(name in style)) {
+      if (name[0] === "-" && name[1] === "-") {
+        elm.style.removeProperty(name);
+      } else {
+        elm.style[name] = "";
+      }
+    }
+  }
+  for (name in style) {
+    cur = style[name];
+    if (name === "delayed" && style.delayed) {
+      for (const name2 in style.delayed) {
+        cur = style.delayed[name2];
+        if (!oldHasDel || cur !== oldStyle.delayed[name2]) {
+          setNextFrame(elm.style, name2, cur);
+        }
+      }
+    } else if (name !== "remove" && cur !== oldStyle[name]) {
+      if (name[0] === "-" && name[1] === "-") {
+        elm.style.setProperty(name, cur);
+      } else {
+        elm.style[name] = cur;
+      }
+    }
+  }
+}
+
+function applyDestroyStyle(vnode) {
+  let style;
+  let name;
+  const elm = vnode.elm;
+  const s = vnode.data.style;
+  if (!s || !(style = s.destroy)) return;
+  for (name in style) {
+    elm.style[name] = style[name];
+  }
+}
+
+function applyRemoveStyle(vnode, rm) {
+  const s = vnode.data.style;
+  if (!s || !s.remove) {
+    rm();
+    return;
+  }
+  if (!reflowForced) {
+    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+    vnode.elm.offsetLeft;
+    reflowForced = true;
+  }
+  let name;
+  const elm = vnode.elm;
+  let i = 0;
+  const style = s.remove;
+  let amount = 0;
+  const applied = [];
+  for (name in style) {
+    applied.push(name);
+    elm.style[name] = style[name];
+  }
+  const compStyle = getComputedStyle(elm);
+  const props = compStyle["transition-property"].split(", ");
+  for (; i < props.length; ++i) {
+    if (applied.indexOf(props[i]) !== -1) amount++;
+  }
+  elm.addEventListener("transitionend", function (ev) {
+    if (ev.target === elm) --amount;
+    if (amount === 0) rm();
+  });
+}
+
+function forceReflow() {
+  reflowForced = false;
+}
+
+export const styleModule = {
+  pre: forceReflow,
+  create: updateStyle,
+  update: updateStyle,
+  destroy: applyDestroyStyle,
+  remove: applyRemoveStyle,
+};
+
+export default styleModule;

--- a/packages/rettangoli-fe/src/web/vendor/snabbdomStyleModule.js
+++ b/packages/rettangoli-fe/src/web/vendor/snabbdomStyleModule.js
@@ -1,6 +1,25 @@
 /**
  * Vendored from snabbdom 3.6.2 — `snabbdom/build/modules/style.js`.
- * MIT licensed, Copyright (c) 2015 Simon Friis Vindum.
+ *
+ * Copyright (c) 2015 Simon Friis Vindum
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  *
  * WHY THIS EXISTS
  *

--- a/packages/rettangoli-fe/test/package-smoke-test.js
+++ b/packages/rettangoli-fe/test/package-smoke-test.js
@@ -114,11 +114,17 @@ try {
       import assert from "node:assert/strict";
       import { createRequire } from "node:module";
 
-      globalThis.window = {};
+      // Deliberately NO \`globalThis.window\` stub. This file used to declare one,
+      // which silently hid the fact that the package could not be imported in a
+      // real Node process. The whole point of the smoke test is to import the
+      // PACKED artifact exactly as a Node consumer would.
+      assert.equal(typeof globalThis.window, "undefined");
+      assert.equal(typeof globalThis.document, "undefined");
 
       const fe = await import("@rettangoli/fe");
       const contracts = await import("@rettangoli/fe/contracts");
       const cli = await import("@rettangoli/fe/cli");
+      const server = await import("@rettangoli/fe/server");
       const require = createRequire(import.meta.url);
 
       assert.equal(typeof fe.createComponent, "function");
@@ -126,9 +132,19 @@ try {
       assert.equal(typeof contracts.validateSchemaContract, "function");
       assert.equal(typeof cli.build, "function");
       assert.equal(typeof cli.watch, "function");
+      assert.equal(typeof server.renderView, "function");
+      assert.equal(typeof server.serializeVNode, "function");
+      assert.equal(typeof server.bindStore, "function");
       assert.match(require.resolve("@rettangoli/fe"), /src\\/index\\.js$/);
       assert.match(require.resolve("@rettangoli/fe/contracts"), /contracts\\/index\\.js$/);
       assert.match(require.resolve("@rettangoli/fe/cli"), /cli\\/index\\.js$/);
+      assert.match(require.resolve("@rettangoli/fe/server"), /server\\/index\\.js$/);
+
+      // End to end through the packed files, not the source tree.
+      assert.equal(
+        server.renderView({ template: [{ "p.x": "\${msg}" }], viewData: { msg: "ok" } }),
+        '<div style="display: contents"><p class="x">ok</p></div>',
+      );
     `,
   );
   run(process.execPath, [smokeModulePath], { cwd: temporaryDirectory });

--- a/packages/rettangoli-fe/test/runtime/component-dom-hardening.test.js
+++ b/packages/rettangoli-fe/test/runtime/component-dom-hardening.test.js
@@ -1,0 +1,170 @@
+/**
+ * Covers two latent defects in render-target adoption.
+ *
+ * Both are reachable on the hot-update path today, and both become certain the
+ * moment a shadow root carries server-rendered content.
+ */
+
+import { describe, expect, it } from "vitest";
+import { initializeComponentDom } from "../../src/web/componentDom.js";
+
+const createStyleSheet = () => ({
+  replaceSync(text) {
+    this.text = text;
+  },
+});
+
+/** A stand-in element with a real tagName, which is what the guard keys off. */
+const createNode = (tagName, attrs = {}) => {
+  const node = {
+    tagName,
+    style: { cssText: "", display: "" },
+    parentNode: null,
+    __attrs: new Map(Object.entries(attrs)),
+    setAttribute(name, value) {
+      this.__attrs.set(name, String(value));
+    },
+    getAttribute(name) {
+      return this.__attrs.has(name) ? this.__attrs.get(name) : null;
+    },
+  };
+  return node;
+};
+
+const createShadow = (children) => {
+  const shadow = {
+    adoptedStyleSheets: [],
+    children,
+    get firstElementChild() {
+      return shadow.children[0] ?? null;
+    },
+    querySelector(selector) {
+      if (selector !== "[data-rtgl-render-target]") return null;
+      return (
+        shadow.children.find(
+          (child) => child.getAttribute?.("data-rtgl-render-target") !== null,
+        ) ?? null
+      );
+    },
+    appendChild(child) {
+      if (!shadow.children.includes(child)) shadow.children.push(child);
+      child.parentNode = shadow;
+    },
+  };
+  return shadow;
+};
+
+const createHost = (shadow) => ({
+  shadowRoot: shadow,
+  style: {},
+  appended: [],
+  appendChild(child) {
+    this.appended.push(child);
+  },
+});
+
+describe("render target adoption", () => {
+  it("never adopts a <style> as the render target", () => {
+    // The failure this prevents: the <style> is stamped as the render target
+    // and given display:contents, then snabbdom replaces it on the first patch
+    // because its sel cannot match the parser's `div` root -- leaving
+    // instance.renderTarget pointing at a detached node.
+    const styleNode = createNode("STYLE");
+    const shadow = createShadow([styleNode]);
+    const created = createNode("DIV");
+
+    const dom = initializeComponentDom({
+      host: createHost(shadow),
+      cssText: "",
+      createStyleSheet,
+      createElement: () => created,
+    });
+
+    expect(dom.renderTarget).not.toBe(styleNode);
+    expect(dom.renderTarget).toBe(created);
+    expect(styleNode.getAttribute("data-rtgl-render-target")).toBeNull();
+  });
+
+  it.each(["LINK", "SLOT", "TEMPLATE", "SCRIPT"])(
+    "never adopts a <%s> as the render target",
+    (tagName) => {
+      const node = createNode(tagName);
+      const shadow = createShadow([node]);
+      const created = createNode("DIV");
+
+      const dom = initializeComponentDom({
+        host: createHost(shadow),
+        cssText: "",
+        createStyleSheet,
+        createElement: () => created,
+      });
+
+      expect(dom.renderTarget).toBe(created);
+    },
+  );
+
+  it("still adopts an explicitly marked render target even after a <style>", () => {
+    const styleNode = createNode("STYLE");
+    const marked = createNode("DIV", { "data-rtgl-render-target": "" });
+    const shadow = createShadow([styleNode, marked]);
+
+    const dom = initializeComponentDom({
+      host: createHost(shadow),
+      cssText: "",
+      createStyleSheet,
+      createElement: () => createNode("DIV"),
+    });
+
+    expect(dom.renderTarget).toBe(marked);
+  });
+
+  it("still adopts an unmarked plain element, preserving legacy behaviour", () => {
+    const legacy = createNode("DIV");
+    const shadow = createShadow([legacy]);
+
+    const dom = initializeComponentDom({
+      host: createHost(shadow),
+      cssText: "",
+      createStyleSheet,
+      createElement: () => createNode("DIV"),
+    });
+
+    expect(dom.renderTarget).toBe(legacy);
+    expect(legacy.getAttribute("data-rtgl-render-target")).toBe("");
+  });
+});
+
+describe("render target inline styles", () => {
+  it("does not clobber existing inline styles when adopting", () => {
+    const adopted = createNode("DIV", { "data-rtgl-render-target": "" });
+    adopted.style.cssText = "color: red;";
+    const shadow = createShadow([adopted]);
+
+    initializeComponentDom({
+      host: createHost(shadow),
+      cssText: "",
+      createStyleSheet,
+      createElement: () => createNode("DIV"),
+    });
+
+    // display is set, and the pre-existing declaration block survives.
+    expect(adopted.style.display).toBe("contents");
+    expect(adopted.style.cssText).toBe("color: red;");
+  });
+
+  it("leaves display alone when it is already contents", () => {
+    const adopted = createNode("DIV", { "data-rtgl-render-target": "" });
+    adopted.style.display = "contents";
+    adopted.style.cssText = "display: contents; color: blue;";
+    const shadow = createShadow([adopted]);
+
+    initializeComponentDom({
+      host: createHost(shadow),
+      cssText: "",
+      createStyleSheet,
+      createElement: () => createNode("DIV"),
+    });
+
+    expect(adopted.style.cssText).toBe("display: contents; color: blue;");
+  });
+});

--- a/packages/rettangoli-fe/test/runtime/template-normalization.test.js
+++ b/packages/rettangoli-fe/test/runtime/template-normalization.test.js
@@ -1,0 +1,62 @@
+/**
+ * Documents a constraint that is easy to violate and expensive to discover.
+ *
+ * `ensureNormalizedTemplatePropertyBindings` is guarded by a module-level
+ * WeakSet. That looks like memoization — an optimisation you could drop, or
+ * replace by normalizing once at build time — but it is a CORRECTNESS GUARD.
+ *
+ * Normalization rewrites `:value=${title}` to `:value=title`, and the validator
+ * rejects that bare form. So the pass is NOT idempotent: run it twice on the
+ * same template *shape* and the second run throws.
+ *
+ * The WeakSet works today because the build inlines the RAW parsed AST and
+ * normalization happens once per template object at runtime. It would stop
+ * working the moment a normalized template is serialized and reloaded, because
+ * the clone arrives with a fresh object identity.
+ *
+ * If you are here because you want to move normalization to build time: this
+ * is why you cannot, not without also making the validator accept the
+ * normalized form.
+ */
+
+import { describe, expect, it } from "vitest";
+import { ensureNormalizedTemplatePropertyBindings } from "../../src/core/view/templatePropertyBindings.js";
+import jemplParse from "jempl/src/parse/index.js";
+
+const parse = (raw) => jemplParse(JSON.parse(JSON.stringify(raw)));
+
+describe("template property-binding normalization", () => {
+  it("rewrites the interpolation form to a bare path", () => {
+    const template = parse([{ "x-child :value=${title}": null }]);
+    ensureNormalizedTemplatePropertyBindings(template);
+    expect(JSON.stringify(template)).toContain("x-child :value=title");
+  });
+
+  it("is a no-op on the same object the second time (identity-guarded)", () => {
+    const template = parse([{ "x-child :value=${title}": null }]);
+    ensureNormalizedTemplatePropertyBindings(template);
+    const once = JSON.stringify(template);
+
+    expect(() => ensureNormalizedTemplatePropertyBindings(template)).not.toThrow();
+    expect(JSON.stringify(template)).toBe(once);
+  });
+
+  it("THROWS on a structurally identical clone — the pass is not idempotent", () => {
+    const template = parse([{ "x-child :value=${title}": null }]);
+    ensureNormalizedTemplatePropertyBindings(template);
+
+    // A build-time-serialized AST arrives with a new object identity, so the
+    // WeakSet does not recognise it and the validator sees `:value=title`.
+    const clone = JSON.parse(JSON.stringify(template));
+    expect(() => ensureNormalizedTemplatePropertyBindings(clone)).toThrow(
+      /Property-form bindings must use/,
+    );
+  });
+
+  it("accepts a freshly parsed template every time", () => {
+    for (let i = 0; i < 3; i += 1) {
+      const template = parse([{ "x-child :value=${title}": null }]);
+      expect(() => ensureNormalizedTemplatePropertyBindings(template)).not.toThrow();
+    }
+  });
+});

--- a/packages/rettangoli-fe/test/runtime/template-normalization.test.js
+++ b/packages/rettangoli-fe/test/runtime/template-normalization.test.js
@@ -53,6 +53,34 @@ describe("template property-binding normalization", () => {
     );
   });
 
+  it("is indistinguishable from legacy author syntax, which is why the message cannot be improved", () => {
+    // `:value=title` is BOTH what the normalizer produces AND legitimate legacy
+    // syntax that the framework deliberately rejects (see
+    // loop-property-binding.test.js "rejects legacy property-form source
+    // syntax"). The two are byte-identical, so a friendlier "already
+    // normalized" message would mislead the far more common case of an author
+    // using the legacy form. Left as-is deliberately.
+    const authored = parse([{ "my-item :value=title": null }]);
+    const normalizedClone = (() => {
+      const t = parse([{ "my-item :value=${title}": null }]);
+      ensureNormalizedTemplatePropertyBindings(t);
+      return JSON.parse(JSON.stringify(t));
+    })();
+
+    const messageFor = (template) => {
+      try {
+        ensureNormalizedTemplatePropertyBindings(template);
+        return null;
+      } catch (error) {
+        return error.message;
+      }
+    };
+
+    expect(messageFor(authored)).toBe(messageFor(normalizedClone));
+  });
+
+
+
   it("accepts a freshly parsed template every time", () => {
     for (let i = 0; i < 3; i += 1) {
       const template = parse([{ "x-child :value=${title}": null }]);

--- a/packages/rettangoli-fe/test/runtime/vnode-namespaces.test.js
+++ b/packages/rettangoli-fe/test/runtime/vnode-namespaces.test.js
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { parse } from "jempl";
+import { h } from "snabbdom/build/h.js";
+
+import { parseView } from "../../src/parser.js";
+
+const SVG_NAMESPACE_URI = "http://www.w3.org/2000/svg";
+const MATHML_NAMESPACE_URI = "http://www.w3.org/1998/Math/MathML";
+
+describe("vnode namespace normalization", () => {
+  it("adds MathML namespaces and preserves parser integration points", () => {
+    const vdom = parseView({
+      h,
+      template: parse([
+        {
+          math: [
+            { mi: [{ style: "html integration child" }] },
+            {
+              "annotation-xml": [
+                {
+                  svg: [
+                    {
+                      foreignObject: [{ style: "html integration child" }],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ]),
+      viewData: {},
+      refs: {},
+      handlers: {},
+    });
+
+    const math = vdom.children[0];
+    const mi = math.children[0];
+    const annotation = math.children[1];
+    const svg = annotation.children[0];
+    const foreignObject = svg.children[0];
+
+    expect(math.data.ns).toBe(MATHML_NAMESPACE_URI);
+    expect(mi.data.ns).toBe(MATHML_NAMESPACE_URI);
+    expect(mi.children[0].data.ns).toBeUndefined();
+    expect(annotation.data.ns).toBe(MATHML_NAMESPACE_URI);
+    expect(svg.data.ns).toBe(SVG_NAMESPACE_URI);
+    expect(foreignObject.data.ns).toBe(SVG_NAMESPACE_URI);
+    expect(foreignObject.children[0].data.ns).toBeUndefined();
+  });
+
+  it("removes snabbdom's SVG namespace beneath title and desc integration points", () => {
+    const vdom = parseView({
+      h,
+      template: parse([
+        {
+          svg: [
+            { title: [{ style: "html child" }] },
+            { desc: [{ div: "html child" }] },
+          ],
+        },
+      ]),
+      viewData: {},
+      refs: {},
+      handlers: {},
+    });
+
+    const svg = vdom.children[0];
+    expect(svg.data.ns).toBe(SVG_NAMESPACE_URI);
+    expect(svg.children[0].data.ns).toBe(SVG_NAMESPACE_URI);
+    expect(svg.children[0].children[0].data.ns).toBeUndefined();
+    expect(svg.children[1].data.ns).toBe(SVG_NAMESPACE_URI);
+    expect(svg.children[1].children[0].data.ns).toBeUndefined();
+  });
+});

--- a/packages/rettangoli-fe/test/server/__goldens__/counter-initial.html
+++ b/packages/rettangoli-fe/test/server/__goldens__/counter-initial.html
@@ -1,0 +1,14 @@
+<div style="display: contents">
+<div style="display:flex;flex-direction:column;gap:8px;padding:16px;width:220px;font-family:monospace" id="root">
+<div style="display:flex;align-items:flex-end;height:200px;background:#eee;padding:4px">
+<div data-testid="counter-bar" style="width:40px;background:dodgerblue;height:0px;min-height:2px" id="bar">
+</div>
+</div>
+<div style="font-size:11px">Count: 0</div>
+<div style="display:flex;gap:4px">
+<button data-testid="decrement" style="width:40px;height:32px" id="decrementBtn">-</button>
+<button data-testid="increment" style="width:40px;height:32px" id="incrementBtn">+</button>
+</div>
+<button data-testid="toggle" style="height:32px" id="toggleBtn">Toggle</button>
+</div>
+</div>

--- a/packages/rettangoli-fe/test/server/__goldens__/counter-mutated.html
+++ b/packages/rettangoli-fe/test/server/__goldens__/counter-mutated.html
@@ -1,0 +1,16 @@
+<div style="display: contents">
+<div style="display:flex;flex-direction:column;gap:8px;padding:16px;width:220px;font-family:monospace" id="root">
+<div style="display:flex;align-items:flex-end;height:200px;background:#eee;padding:4px">
+<div data-testid="counter-bar" style="width:40px;background:dodgerblue;height:60px;min-height:2px" id="bar">
+</div>
+</div>
+<div style="font-size:11px">Count: 3</div>
+<div style="display:flex;gap:4px">
+<button data-testid="decrement" style="width:40px;height:32px" id="decrementBtn">-</button>
+<button data-testid="increment" style="width:40px;height:32px" id="incrementBtn">+</button>
+</div>
+<button data-testid="toggle" style="height:32px" id="toggleBtn">Toggle</button>
+<div data-testid="panel" style="width:80px;height:80px;background:mediumseagreen;border-radius:4px" id="panel">
+</div>
+</div>
+</div>

--- a/packages/rettangoli-fe/test/server/__goldens__/itemList-initial.html
+++ b/packages/rettangoli-fe/test/server/__goldens__/itemList-initial.html
@@ -1,0 +1,16 @@
+<div style="display: contents">
+<div style="display:flex;flex-direction:column;gap:8px;padding:16px;width:240px;font-family:monospace" id="root">
+<div style="display:flex;gap:4px">
+<input data-testid="input" style="flex:1;height:28px" placeholder="Add item" id="itemInput">
+<button data-testid="add" style="height:28px" id="addBtn">Add</button>
+</div>
+<div data-testid="empty" style="height:60px;background:#ddd;display:flex;align-items:center;justify-content:center;font-size:11px">No items</div>
+<div style="display:flex;gap:4px;margin-top:4px">
+<button data-testid="filter-all" style="background:steelblue;color:white;height:24px;border:none;padding:0 8px;cursor:pointer;border-radius:2px" id="filterAll">All</button>
+<button data-testid="filter-red" style="background:#ddd;height:24px;border:none;padding:0 8px;cursor:pointer;border-radius:2px" id="filterRed">Red</button>
+<button data-testid="filter-blue" style="background:#ddd;height:24px;border:none;padding:0 8px;cursor:pointer;border-radius:2px" id="filterBlue">Blue</button>
+</div>
+<div data-testid="count-bar" style="height:8px;background:steelblue;width:0px;min-width:2px;border-radius:2px">
+</div>
+</div>
+</div>

--- a/packages/rettangoli-fe/test/server/__goldens__/itemList-populated.html
+++ b/packages/rettangoli-fe/test/server/__goldens__/itemList-populated.html
@@ -1,0 +1,20 @@
+<div style="display: contents">
+<div style="display:flex;flex-direction:column;gap:8px;padding:16px;width:240px;font-family:monospace" id="root">
+<div style="display:flex;gap:4px">
+<input data-testid="input" style="flex:1;height:28px" placeholder="Add item" id="itemInput">
+<button data-testid="add" style="height:28px" id="addBtn">Add</button>
+</div>
+<div data-testid="list" style="display:flex;flex-direction:column;gap:2px" id="list">
+<div data-testid="item-0" data-item-id="1" style="height:32px;background:salmon;border-radius:2px;cursor:pointer;padding:0 8px;display:flex;align-items:center;font-size:11px;color:white" id="item0">alpha</div>
+<div data-testid="item-1" data-item-id="2" style="height:32px;background:cornflowerblue;border-radius:2px;cursor:pointer;padding:0 8px;display:flex;align-items:center;font-size:11px;color:white" id="item1">beta</div>
+<div data-testid="item-2" data-item-id="3" style="height:32px;background:salmon;border-radius:2px;cursor:pointer;padding:0 8px;display:flex;align-items:center;font-size:11px;color:white" id="item2">gamma</div>
+</div>
+<div style="display:flex;gap:4px;margin-top:4px">
+<button data-testid="filter-all" style="background:steelblue;color:white;height:24px;border:none;padding:0 8px;cursor:pointer;border-radius:2px" id="filterAll">All</button>
+<button data-testid="filter-red" style="background:#ddd;height:24px;border:none;padding:0 8px;cursor:pointer;border-radius:2px" id="filterRed">Red</button>
+<button data-testid="filter-blue" style="background:#ddd;height:24px;border:none;padding:0 8px;cursor:pointer;border-radius:2px" id="filterBlue">Blue</button>
+</div>
+<div data-testid="count-bar" style="height:8px;background:steelblue;width:90px;min-width:2px;border-radius:2px">
+</div>
+</div>
+</div>

--- a/packages/rettangoli-fe/test/server/component-golden.test.js
+++ b/packages/rettangoli-fe/test/server/component-golden.test.js
@@ -1,0 +1,153 @@
+/**
+ * HTML goldens for REAL components.
+ *
+ * This is the payoff of the Node-renderable work. Before it, the only way to
+ * see what a component produced was a Docker-pinned Playwright screenshot diff
+ * — which cannot localise a regression, cannot run in a unit suite, and cannot
+ * distinguish "rendered correctly" from "wiped and re-rendered to the same
+ * pixels". The repo had 1,301 `.webp` references and zero `.html` goldens.
+ *
+ * These render the shipped e2e fixtures through the real pipeline
+ * (resolveComponentDefinition -> bindStore -> parseView -> serializeVNode) in
+ * bare Node, and diff against committed markup. A change to the parser, the
+ * store binding, or the serializer shows up here as a readable text diff.
+ *
+ * Regenerate after an intended change:
+ *   UPDATE_GOLDENS=1 npx vitest run packages/rettangoli-fe/test/server/component-golden.test.js
+ */
+
+import { describe, expect, it } from "vitest";
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
+import path from "node:path";
+import yaml from "js-yaml";
+import { h } from "snabbdom/build/h.js";
+import jemplParse from "jempl/src/parse/index.js";
+
+import { serializeVNode } from "../../src/core/server/serializeVNode.js";
+import { parseView } from "../../src/parser.js";
+import { bindStore } from "../../src/core/runtime/store.js";
+import { resolveComponentDefinition } from "../../src/core/component/resolveComponentDefinition.js";
+
+const PKG = path.resolve(import.meta.dirname, "../..");
+const GOLDEN_DIR = path.join(import.meta.dirname, "__goldens__");
+const UPDATE = process.env.UPDATE_GOLDENS === "1";
+
+/** Loads a real four-file component from an e2e fixture directory. */
+const loadComponent = async (suite, name) => {
+  const dir = path.join(PKG, "e2e", suite, "fe/components");
+  const read = (ext) => {
+    const file = path.join(dir, `${name}.${ext}`);
+    return existsSync(file) ? readFileSync(file, "utf8") : null;
+  };
+
+  const viewSource = read("view.yaml");
+  const schemaSource = read("schema.yaml");
+  const storeModule = existsSync(path.join(dir, `${name}.store.js`))
+    ? await import(path.join(dir, `${name}.store.js`))
+    : {};
+
+  return {
+    view: yaml.load(viewSource),
+    schema: yaml.load(schemaSource),
+    store: storeModule,
+  };
+};
+
+/**
+ * The full server render path. Handlers are deliberately never invoked — this
+ * is the component's initial state, which is exactly what a server can know.
+ */
+const renderToHtml = ({ view, schema, store }, { props = {}, mutate } = {}) => {
+  const definition = resolveComponentDefinition({
+    view,
+    schema,
+    store,
+    handlers: {},
+    methods: {},
+    constants: {},
+  });
+
+  const bound = bindStore(store, props, {}, {});
+  // Drive the store through real actions so goldens can cover branches that
+  // only appear after state changes ($if / $for with data).
+  if (mutate) mutate(bound);
+
+  const vdom = parseView({
+    h,
+    template: jemplParse(JSON.parse(JSON.stringify(definition.template))),
+    viewData: bound.selectViewData ? bound.selectViewData() : {},
+    refs: definition.refs || {},
+    handlers: {},
+  });
+
+  return serializeVNode(vdom);
+};
+
+/** Cheap readability: one tag per line, so diffs point at a single element. */
+const pretty = (html) => html.replace(/></g, ">\n<");
+
+const assertGolden = (name, html) => {
+  if (!existsSync(GOLDEN_DIR)) mkdirSync(GOLDEN_DIR, { recursive: true });
+  const file = path.join(GOLDEN_DIR, `${name}.html`);
+  const actual = `${pretty(html)}\n`;
+
+  if (UPDATE || !existsSync(file)) {
+    writeFileSync(file, actual);
+    return;
+  }
+  expect(actual, `golden mismatch for ${name}`).toBe(readFileSync(file, "utf8"));
+};
+
+describe("HTML goldens for real components", () => {
+  it("renders counter at its initial state", async () => {
+    const component = await loadComponent("interactions", "counter");
+    const html = renderToHtml(component);
+    assertGolden("counter-initial", html);
+
+    // Anchors that make the golden meaningful rather than just stable.
+    expect(html).toContain("Count: 0");
+    expect(html).toContain('data-testid="counter-bar"');
+    // `$if showPanel` is false at rest, so the panel must be absent.
+    expect(html).not.toContain('data-testid="panel"');
+  });
+
+  it("renders counter after real store actions, exercising $if and interpolation", async () => {
+    const component = await loadComponent("interactions", "counter");
+    const html = renderToHtml(component, {
+      mutate: (store) => {
+        store.increment();
+        store.increment();
+        store.increment();
+        store.togglePanel();
+      },
+    });
+    assertGolden("counter-mutated", html);
+
+    expect(html).toContain("Count: 3");
+    // barHeight = min(3 * 20, 200)
+    expect(html).toContain("height:60px");
+    expect(html).toContain('data-testid="panel"');
+  });
+
+  it("renders itemList, exercising $for over store data", async () => {
+    const component = await loadComponent("interactions", "itemList");
+    const html = renderToHtml(component);
+    assertGolden("itemList-initial", html);
+    expect(html.startsWith("<div")).toBe(true);
+  });
+
+  it("produces byte-identical output across repeated renders", async () => {
+    const component = await loadComponent("interactions", "counter");
+    const once = renderToHtml(component);
+    const twice = renderToHtml(component);
+    expect(once).toBe(twice);
+  });
+
+  it("never leaks props, listeners or hooks into the markup", async () => {
+    const component = await loadComponent("interactions", "counter");
+    const html = renderToHtml(component);
+    expect(html).not.toContain("[object Object]");
+    expect(html).not.toContain("function");
+    expect(html).not.toMatch(/\son[a-z]+="/);
+  });
+});

--- a/packages/rettangoli-fe/test/server/component-golden.test.js
+++ b/packages/rettangoli-fe/test/server/component-golden.test.js
@@ -91,10 +91,14 @@ const assertGolden = (name, html) => {
   const file = path.join(GOLDEN_DIR, `${name}.html`);
   const actual = `${pretty(html)}\n`;
 
-  if (UPDATE || !existsSync(file)) {
+  if (UPDATE) {
     writeFileSync(file, actual);
     return;
   }
+  // Deliberately NOT auto-writing when the file is missing: a deleted or
+  // never-committed golden would then silently regenerate and report green,
+  // which is the failure mode goldens exist to prevent.
+  expect(existsSync(file), `missing golden ${name}.html — run with UPDATE_GOLDENS=1`).toBe(true);
   expect(actual, `golden mismatch for ${name}`).toBe(readFileSync(file, "utf8"));
 };
 
@@ -129,11 +133,30 @@ describe("HTML goldens for real components", () => {
     expect(html).toContain('data-testid="panel"');
   });
 
-  it("renders itemList, exercising $for over store data", async () => {
+  it("renders itemList empty state", async () => {
     const component = await loadComponent("interactions", "itemList");
     const html = renderToHtml(component);
     assertGolden("itemList-initial", html);
-    expect(html.startsWith("<div")).toBe(true);
+    // items: [] means the $else branch -- assert we are really in it.
+    expect(html).toContain('data-testid="empty"');
+  });
+
+  it("renders itemList WITH items, actually exercising $for", async () => {
+    const component = await loadComponent("interactions", "itemList");
+    const html = renderToHtml(component, {
+      mutate: (store) => {
+        store.addItem({ name: "alpha" });
+        store.addItem({ name: "beta" });
+        store.addItem({ name: "gamma" });
+      },
+    });
+    assertGolden("itemList-populated", html);
+
+    // The empty branch is gone and every item was iterated.
+    expect(html).not.toContain('data-testid="empty"');
+    for (const label of ["alpha", "beta", "gamma"]) {
+      expect(html, `$for should have emitted "${label}"`).toContain(label);
+    }
   });
 
   it("produces byte-identical output across repeated renders", async () => {
@@ -144,10 +167,21 @@ describe("HTML goldens for real components", () => {
   });
 
   it("never leaks props, listeners or hooks into the markup", async () => {
-    const component = await loadComponent("interactions", "counter");
-    const html = renderToHtml(component);
+    // The fixtures render with props/on/hook all empty, so asserting their
+    // absence there proves nothing. Build a vnode that genuinely carries all
+    // three, so removing the serializer's guards makes this fail.
+    const { h } = await import("snabbdom/build/h.js");
+    const vnode = h("x-child", {
+      attrs: { keep: "yes" },
+      props: { payload: { deep: true }, cb: () => {}, when: new Date(0) },
+      on: { click: () => {} },
+      hook: { insert: () => {} },
+    });
+
+    const html = serializeVNode(vnode);
+    expect(html).toBe('<x-child keep="yes"></x-child>');
     expect(html).not.toContain("[object Object]");
-    expect(html).not.toContain("function");
-    expect(html).not.toMatch(/\son[a-z]+="/);
+    expect(html).not.toMatch(/\son[a-z]+=/);
+    expect(html).not.toContain("payload");
   });
 });

--- a/packages/rettangoli-fe/test/server/node-environment.test.js
+++ b/packages/rettangoli-fe/test/server/node-environment.test.js
@@ -25,16 +25,10 @@ describe("node environment", () => {
 
   it("imports the server entry without a DOM", async () => {
     const mod = await import("../../src/server/index.js");
+    expect(typeof mod.renderView).toBe("function");
     expect(typeof mod.serializeVNode).toBe("function");
-    expect(typeof mod.parseView).toBe("function");
     expect(typeof mod.bindStore).toBe("function");
     expect(typeof mod.resolveComponentDefinition).toBe("function");
-    expect(typeof mod.yamlToCss).toBe("function");
-  });
-
-  it("imports the parser entry without a DOM", async () => {
-    const mod = await import("../../src/parser.js");
-    expect(typeof mod.parseView).toBe("function");
   });
 
   it("imports the web binding without a DOM (constructing still needs one)", async () => {
@@ -75,8 +69,7 @@ describe("package exports map", () => {
   // a consumer bind a different jempl version than it hoisted.
   it.each([
     ["@rettangoli/fe", ["createComponent"]],
-    ["@rettangoli/fe/server", ["serializeVNode", "parseView", "bindStore"]],
-    ["@rettangoli/fe/parser", ["parseView"]],
+    ["@rettangoli/fe/server", ["renderView", "serializeVNode", "bindStore"]],
     ["@rettangoli/fe/contracts", []],
   ])("resolves %s", async (specifier, expectedExports) => {
     const mod = await import(specifier);
@@ -103,44 +96,38 @@ describe("package exports map", () => {
 });
 
 describe("end to end: a component renders to HTML in bare Node", () => {
-  it("runs store -> parseView -> serializeVNode with no DOM", async () => {
-    const { serializeVNode, parseView, bindStore } = await import("../../src/server/index.js");
-    const { h } = await import("snabbdom/build/h.js");
-    const jemplParse = (await import("jempl/src/parse/index.js")).default;
+  it("renders a component with ONLY what ./server exports — no extra deps", async () => {
+    // The point of renderView: a consumer needs neither snabbdom's `h` nor
+    // jempl's parser, both of which live behind deep internal paths.
+    const { renderView, bindStore } = await import("../../src/server/index.js");
 
-    const template = jemplParse([
-      { "div.card": [{ "h1#title": "${name}" }, { p: "count=${count}" }] },
-    ]);
     const store = {
       createInitialState: () => ({ count: 3 }),
       selectViewData: ({ state, props }) => ({ name: props.name, count: state.count }),
     };
-
     const bound = bindStore(store, { name: "Ada" }, {}, {});
-    const vdom = parseView({
-      h,
-      template,
+
+    const html = renderView({
+      template: [{ "div.card": [{ "h1#title": "${name}" }, { p: "count=${count}" }] }],
       viewData: bound.selectViewData(),
-      refs: {},
-      handlers: {},
     });
 
-    expect(serializeVNode(vdom)).toBe(
+    expect(html).toBe(
       '<div style="display: contents"><div class="card"><h1 id="title">Ada</h1><p>count=3</p></div></div>',
     );
   });
 
-  it("is deterministic across repeated renders", async () => {
-    const { serializeVNode, parseView } = await import("../../src/server/index.js");
-    const { h } = await import("snabbdom/build/h.js");
+  it("accepts an already-parsed jempl AST, as produced at build time", async () => {
+    const { renderView } = await import("../../src/server/index.js");
     const jemplParse = (await import("jempl/src/parse/index.js")).default;
+    expect(renderView({ template: jemplParse([{ p: "${x}" }]), viewData: { x: "ok" } }))
+      .toBe('<div style="display: contents"><p>ok</p></div>');
+  });
 
-    const render = () => {
-      const template = jemplParse([{ "div#root": ["${a}", { span: "${b}" }] }]);
-      return serializeVNode(
-        parseView({ h, template, viewData: { a: "x", b: "y" }, refs: {}, handlers: {} }),
-      );
-    };
+  it("is deterministic across repeated renders", async () => {
+    const { renderView } = await import("../../src/server/index.js");
+    const render = () =>
+      renderView({ template: [{ "div#root": ["${a}", { span: "${b}" }] }], viewData: { a: "x", b: "y" } });
     expect(render()).toBe(render());
   });
 });

--- a/packages/rettangoli-fe/test/server/node-environment.test.js
+++ b/packages/rettangoli-fe/test/server/node-environment.test.js
@@ -124,6 +124,28 @@ describe("end to end: a component renders to HTML in bare Node", () => {
       .toBe('<div style="display: contents"><p>ok</p></div>');
   });
 
+  it("renders refs with action listeners without constructing client event closures", async () => {
+    const { renderView } = await import("../../src/server/index.js");
+    expect(renderView({
+      template: [{ "button#saveButton": "Save" }],
+      refs: {
+        saveButton: {
+          eventListeners: {
+            click: { action: "save" },
+          },
+        },
+      },
+    })).toBe(
+      '<div style="display: contents"><button id="saveButton">Save</button></div>',
+    );
+  });
+
+  it("matches client precedence when selector and authored classes coexist", async () => {
+    const { renderView } = await import("../../src/server/index.js");
+    expect(renderView({ template: [{ "div.foo class=bar": "x" }] }))
+      .toBe('<div style="display: contents"><div class="bar">x</div></div>');
+  });
+
   it("refuses view data that would inject markup through an interpolated tag", async () => {
     // `{ "${tag}": ... }` puts view data straight into the sel: parseView
     // yields `sel: "div><img"`, which previously serialized to real elements.
@@ -135,6 +157,16 @@ describe("end to end: a component renders to HTML in bare Node", () => {
         viewData: { tag: "div><img src=x onerror=alert(1)" },
       }),
     ).toThrow(/invalid tag name/);
+  });
+
+  it("refuses an interpolated plaintext tag that would swallow the response", async () => {
+    const { renderView } = await import("../../src/server/index.js");
+    expect(() =>
+      renderView({
+        template: [{ "${tag}": "unsafe" }],
+        viewData: { tag: "plaintext" },
+      }),
+    ).toThrow(/HTML tokenizer never recognizes its closing tag/);
   });
 
   it("is deterministic across repeated renders", async () => {

--- a/packages/rettangoli-fe/test/server/node-environment.test.js
+++ b/packages/rettangoli-fe/test/server/node-environment.test.js
@@ -1,0 +1,146 @@
+/**
+ * Guards the property that makes every Node-side tool possible: this package
+ * must be importable without a DOM.
+ *
+ * This regressed silently for a long time because nothing asserted it. The
+ * cause was subtle — snabbdom's style module dereferences a bare `window` at
+ * MODULE scope, so the failure was at import, not at call, and no amount of
+ * lazy instantiation would have fixed it.
+ */
+
+import { describe, expect, it } from "vitest";
+
+describe("node environment", () => {
+  it("runs these tests without a DOM", () => {
+    expect(typeof globalThis.document).toBe("undefined");
+    expect(typeof globalThis.window).toBe("undefined");
+    expect(typeof globalThis.HTMLElement).toBe("undefined");
+  });
+
+  it("imports the package entry without a DOM", async () => {
+    const mod = await import("../../src/index.js");
+    expect(typeof mod.createComponent).toBe("function");
+    expect(typeof mod.createI18nRuntime).toBe("function");
+  });
+
+  it("imports the server entry without a DOM", async () => {
+    const mod = await import("../../src/server/index.js");
+    expect(typeof mod.serializeVNode).toBe("function");
+    expect(typeof mod.parseView).toBe("function");
+    expect(typeof mod.bindStore).toBe("function");
+    expect(typeof mod.resolveComponentDefinition).toBe("function");
+    expect(typeof mod.yamlToCss).toBe("function");
+  });
+
+  it("imports the parser entry without a DOM", async () => {
+    const mod = await import("../../src/parser.js");
+    expect(typeof mod.parseView).toBe("function");
+  });
+
+  it("imports the web binding without a DOM (constructing still needs one)", async () => {
+    // Importing must not throw; only *calling* the factory requires HTMLElement.
+    const mod = await import("../../src/web/createWebComponentClass.js");
+    expect(typeof mod.createWebComponentClass).toBe("function");
+  });
+
+  it("builds the snabbdom patch without a DOM", async () => {
+    const createWebPatch = (await import("../../src/createWebPatch.js")).default;
+    expect(typeof createWebPatch()).toBe("function");
+  });
+
+  it("resolves a component definition without a DOM", async () => {
+    const { resolveComponentDefinition } = await import(
+      "../../src/core/component/resolveComponentDefinition.js"
+    );
+    const definition = resolveComponentDefinition({
+      schema: { componentName: "x-a", propsSchema: { properties: { fooBar: { type: "string" } } } },
+      view: { template: [], refs: {}, styles: {} },
+      store: {},
+      handlers: {},
+      methods: {},
+    });
+    expect(definition.elementName).toBe("x-a");
+    expect(definition.propsSchemaKeys).toEqual(["fooBar"]);
+  });
+
+  it("still exposes resolveComponentDefinition from its original module", async () => {
+    const mod = await import("../../src/createComponent.js");
+    expect(typeof mod.resolveComponentDefinition).toBe("function");
+  });
+});
+
+describe("package exports map", () => {
+  // Resolving through the bare specifier is what consumers actually do, and it
+  // is what stops them reaching into node_modules by path — the hazard that let
+  // a consumer bind a different jempl version than it hoisted.
+  it.each([
+    ["@rettangoli/fe", ["createComponent"]],
+    ["@rettangoli/fe/server", ["serializeVNode", "parseView", "bindStore"]],
+    ["@rettangoli/fe/parser", ["parseView"]],
+    ["@rettangoli/fe/contracts", []],
+  ])("resolves %s", async (specifier, expectedExports) => {
+    const mod = await import(specifier);
+    for (const name of expectedExports) {
+      expect(typeof mod[name], `${specifier} should export ${name}`).toBe("function");
+    }
+  });
+
+  it("does not expose arbitrary internal paths", async () => {
+    // Asserted in a real Node process: Vite resolves bare specifiers at
+    // transform time, so an unexported subpath fails the whole module here
+    // rather than rejecting at runtime.
+    const { execFileSync } = await import("node:child_process");
+    const script =
+      "import('@rettangoli/fe/src/parser.js')" +
+      ".then(() => { console.log('RESOLVED'); })" +
+      ".catch((e) => { console.log(e.code); });";
+    const out = execFileSync(process.execPath, ["-e", script], {
+      cwd: new URL("../../", import.meta.url).pathname,
+      encoding: "utf8",
+    }).trim();
+    expect(out).toBe("ERR_PACKAGE_PATH_NOT_EXPORTED");
+  });
+});
+
+describe("end to end: a component renders to HTML in bare Node", () => {
+  it("runs store -> parseView -> serializeVNode with no DOM", async () => {
+    const { serializeVNode, parseView, bindStore } = await import("../../src/server/index.js");
+    const { h } = await import("snabbdom/build/h.js");
+    const jemplParse = (await import("jempl/src/parse/index.js")).default;
+
+    const template = jemplParse([
+      { "div.card": [{ "h1#title": "${name}" }, { p: "count=${count}" }] },
+    ]);
+    const store = {
+      createInitialState: () => ({ count: 3 }),
+      selectViewData: ({ state, props }) => ({ name: props.name, count: state.count }),
+    };
+
+    const bound = bindStore(store, { name: "Ada" }, {}, {});
+    const vdom = parseView({
+      h,
+      template,
+      viewData: bound.selectViewData(),
+      refs: {},
+      handlers: {},
+    });
+
+    expect(serializeVNode(vdom)).toBe(
+      '<div style="display: contents"><div class="card"><h1 id="title">Ada</h1><p>count=3</p></div></div>',
+    );
+  });
+
+  it("is deterministic across repeated renders", async () => {
+    const { serializeVNode, parseView } = await import("../../src/server/index.js");
+    const { h } = await import("snabbdom/build/h.js");
+    const jemplParse = (await import("jempl/src/parse/index.js")).default;
+
+    const render = () => {
+      const template = jemplParse([{ "div#root": ["${a}", { span: "${b}" }] }]);
+      return serializeVNode(
+        parseView({ h, template, viewData: { a: "x", b: "y" }, refs: {}, handlers: {} }),
+      );
+    };
+    expect(render()).toBe(render());
+  });
+});

--- a/packages/rettangoli-fe/test/server/node-environment.test.js
+++ b/packages/rettangoli-fe/test/server/node-environment.test.js
@@ -124,6 +124,19 @@ describe("end to end: a component renders to HTML in bare Node", () => {
       .toBe('<div style="display: contents"><p>ok</p></div>');
   });
 
+  it("refuses view data that would inject markup through an interpolated tag", async () => {
+    // `{ "${tag}": ... }` puts view data straight into the sel: parseView
+    // yields `sel: "div><img"`, which previously serialized to real elements.
+    // Verified in Chromium before the fix — the onerror handler fired.
+    const { renderView } = await import("../../src/server/index.js");
+    expect(() =>
+      renderView({
+        template: [{ "${tag}": "hi" }],
+        viewData: { tag: "div><img src=x onerror=alert(1)" },
+      }),
+    ).toThrow(/invalid tag name/);
+  });
+
   it("is deterministic across repeated renders", async () => {
     const { renderView } = await import("../../src/server/index.js");
     const render = () =>

--- a/packages/rettangoli-fe/test/server/serialize-vnode.test.js
+++ b/packages/rettangoli-fe/test/server/serialize-vnode.test.js
@@ -48,10 +48,20 @@ describe("serializeVNode: raw text elements", () => {
       .toBe("<script>if (a < b) {}</script>");
   });
 
+  it.each(["iframe", "xmp", "noembed", "noframes"])(
+    "emits <%s> content verbatim",
+    (tag) => {
+      expect(serializeVNode(h(tag, {}, ["a < b"])))
+        .toBe(`<${tag}>a < b</${tag}>`);
+    },
+  );
+
   it("refuses raw-text content that would close its own element", () => {
     expect(() => serializeVNode(h("style", {}, ["x{}</style><img onerror=alert(1)>"])))
       .toThrow(/cannot be safely serialized/);
     expect(() => serializeVNode(h("script", {}, ["</script><img onerror=alert(1)>"])))
+      .toThrow(/cannot be safely serialized/);
+    expect(() => serializeVNode(h("iframe", {}, ["</iframe><img onerror=alert(1)>"])))
       .toThrow(/cannot be safely serialized/);
   });
 
@@ -115,6 +125,37 @@ describe("serializeVNode: foreign content (SVG / MathML)", () => {
     },
   );
 
+  it.each([
+    ["math", "foreignObject"],
+    ["math", "desc"],
+    ["math", "title"],
+    ["svg", "mi"],
+    ["svg", "mo"],
+    ["svg", "mn"],
+    ["svg", "ms"],
+    ["svg", "mtext"],
+  ])(
+    "does not apply another namespace's integration rule to %s > %s",
+    (foreignRoot, integrationPoint) => {
+      const html = serializeVNode(
+        h(foreignRoot, {}, [h(integrationPoint, {}, [h("style", {}, [css])])]),
+      );
+      expect(html).toContain("&lt;img");
+      expect(html).not.toContain("<img");
+    },
+  );
+
+  it.each(["mglyph", "malignmark"])(
+    "keeps math > mi > %s and its descendants in MathML",
+    (exception) => {
+      const html = serializeVNode(
+        h("math", {}, [h("mi", {}, [h(exception, {}, [h("style", {}, [css])])])]),
+      );
+      expect(html).toContain("&lt;img");
+      expect(html).not.toContain("<img");
+    },
+  );
+
   it("stays foreign through a non-integration element", () => {
     const html = serializeVNode(h("svg", {}, [h("g", {}, [h("style", {}, [css])])]));
     expect(html).toContain("&lt;img");
@@ -138,6 +179,25 @@ describe("serializeVNode: foreign content (SVG / MathML)", () => {
     expect(foreignEncoded).toContain("&lt;img");
   });
 
+  it("enters SVG for annotation-xml > svg regardless of encoding", () => {
+    for (const attrs of [
+      {},
+      { encoding: "application/mathml+xml" },
+    ]) {
+      const html = serializeVNode(
+        h("math", {}, [
+          h("annotation-xml", { attrs }, [
+            h("svg", {}, [
+              h("foreignObject", {}, [h("style", {}, [css])]),
+            ]),
+          ]),
+        ]),
+      );
+      expect(html).toContain("<img");
+      expect(html).not.toContain("&lt;img");
+    }
+  });
+
   it("preserves the original tag case for camelCase SVG elements", () => {
     expect(serializeVNode(h("svg", {}, [h("foreignObject", {}, ["x"])])))
       .toBe("<svg><foreignObject>x</foreignObject></svg>");
@@ -156,13 +216,22 @@ describe("serializeVNode: tag names", () => {
       .toThrow(/invalid tag name/);
   });
 
+  it.each(["plaintext", "PLAINTEXT"])(
+    "refuses unclosable HTML <%s>",
+    (tag) => {
+      expect(() => serializeVNode(h(tag, {}, ["swallows the document"])))
+        .toThrow(/HTML tokenizer never recognizes its closing tag/);
+    },
+  );
+
   it("still accepts the tag shapes the framework really emits", () => {
     // Plain, custom element, camelCase SVG, and snabbdom's tag#id.class form.
     expect(serializeVNode(h("div"))).toBe("<div></div>");
     expect(serializeVNode(h("rtgl-view"))).toBe("<rtgl-view></rtgl-view>");
     expect(serializeVNode(h("svg", {}, [h("foreignObject")])))
       .toBe("<svg><foreignObject></foreignObject></svg>");
-    expect(serializeVNode(h("div#root.card"))).toBe("<div></div>");
+    expect(serializeVNode(h("div#root.card")))
+      .toBe('<div id="root" class="card"></div>');
   });
 });
 
@@ -235,12 +304,18 @@ describe("serializeVNode: attribute encoding", () => {
       .toBe('<div d="keep"></div>');
   });
 
-  it("merges data.class and an authored class into ONE class attribute", () => {
+  it("lets an authored class replace data.class, matching module order", () => {
     const html = serializeVNode(
       h("div", { attrs: { class: "authored" }, class: { alpha: true, beta: false } }),
     );
-    expect(html).toBe('<div class="authored alpha"></div>');
+    expect(html).toBe('<div class="authored"></div>');
     expect(html.match(/class=/g)).toHaveLength(1);
+  });
+
+  it("applies data.class changes to selector-derived classes", () => {
+    expect(serializeVNode(
+      h("div.base.remove", { class: { remove: false, added: true } }),
+    )).toBe('<div class="base added"></div>');
   });
 
   it("renders style objects as kebab-case css and preserves custom properties", () => {

--- a/packages/rettangoli-fe/test/server/serialize-vnode.test.js
+++ b/packages/rettangoli-fe/test/server/serialize-vnode.test.js
@@ -55,10 +55,92 @@ describe("serializeVNode: raw text elements", () => {
       .toThrow(/cannot be safely serialized/);
   });
 
+  it("refuses <script> content containing `<!--`, which prevents the tag closing", () => {
+    // `<!--` moves the tokenizer into script-data-escaped state, so a later
+    // </script> no longer closes the element and the rest of the document is
+    // swallowed as script text. Confirmed in parse5, jsdom and Chromium.
+    expect(() => serializeVNode(h("script", {}, ['{"a":"<!--<script>"}'])))
+      .toThrow(/changes the tokenizer state/);
+  });
+
   it("still escapes textarea and title, which ARE escapable raw text", () => {
     expect(serializeVNode(h("textarea", {}, ["<b>&</b>"])))
       .toBe("<textarea>&lt;b&gt;&amp;&lt;/b&gt;</textarea>");
     expect(serializeVNode(h("title", {}, ["a < b"]))).toBe("<title>a &lt; b</title>");
+  });
+});
+
+describe("serializeVNode: foreign content (SVG / MathML)", () => {
+  // <style>/<script> are RAWTEXT only in the HTML namespace. Inside <svg> or
+  // <math> the tokenizer stays in data state, so emitting verbatim there
+  // injects live markup -- reproduced as a working XSS in Chromium during
+  // review. Namespace cannot be read off the vnode (snabbdom only stamps
+  // data.ns for svg), so it is tracked structurally.
+  const css = "a::after{content:'<img src=x onerror=alert(1)>'}";
+
+  it("escapes <style> inside <svg> instead of emitting it raw", () => {
+    const html = serializeVNode(h("svg", {}, [h("style", {}, [css])]));
+    expect(html).toContain("&lt;img");
+    expect(html).not.toContain("<img");
+  });
+
+  it("escapes <style> inside <math>, which carries no data.ns at all", () => {
+    const html = serializeVNode(h("math", {}, [h("style", {}, [css])]));
+    expect(html).toContain("&lt;img");
+    expect(html).not.toContain("<img");
+  });
+
+  it("keeps raw-text semantics in the HTML namespace", () => {
+    expect(serializeVNode(h("style", {}, [css]))).toContain("<img");
+  });
+
+  it.each(["foreignObject", "desc", "title"])(
+    "restores HTML raw text inside svg > %s",
+    (integrationPoint) => {
+      const html = serializeVNode(
+        h("svg", {}, [h(integrationPoint, {}, [h("style", {}, [css])])]),
+      );
+      expect(html).toContain("<img");
+      expect(html).not.toContain("&lt;img");
+    },
+  );
+
+  it.each(["mi", "mo", "mn", "ms", "mtext"])(
+    "restores HTML raw text inside math > %s",
+    (integrationPoint) => {
+      const html = serializeVNode(
+        h("math", {}, [h(integrationPoint, {}, [h("style", {}, [css])])]),
+      );
+      expect(html).toContain("<img");
+    },
+  );
+
+  it("stays foreign through a non-integration element", () => {
+    const html = serializeVNode(h("svg", {}, [h("g", {}, [h("style", {}, [css])])]));
+    expect(html).toContain("&lt;img");
+  });
+
+  it("honours annotation-xml encoding", () => {
+    const htmlEncoded = serializeVNode(
+      h("math", {}, [
+        h("annotation-xml", { attrs: { encoding: "text/html" } }, [h("style", {}, [css])]),
+      ]),
+    );
+    expect(htmlEncoded).toContain("<img");
+
+    const foreignEncoded = serializeVNode(
+      h("math", {}, [
+        h("annotation-xml", { attrs: { encoding: "application/mathml+xml" } }, [
+          h("style", {}, [css]),
+        ]),
+      ]),
+    );
+    expect(foreignEncoded).toContain("&lt;img");
+  });
+
+  it("preserves the original tag case for camelCase SVG elements", () => {
+    expect(serializeVNode(h("svg", {}, [h("foreignObject", {}, ["x"])])))
+      .toBe("<svg><foreignObject>x</foreignObject></svg>");
   });
 });
 
@@ -68,9 +150,18 @@ describe("serializeVNode: comments", () => {
   });
 
   it("refuses comment content that would terminate the comment early", () => {
-    expect(() => serializeVNode({ sel: "!", text: "a--><img onerror=alert(1)>" }))
-      .toThrow(/may not contain/);
-    expect(() => serializeVNode({ sel: "!", text: "trailing-" })).toThrow(/may not contain/);
+    // Each of these terminates the comment early; the `>` cases were an XSS
+    // hole found in review and reproduced in Chromium.
+    for (const hostile of [
+      "a--><img onerror=alert(1)>",   // contains --
+      "trailing-",                     // ends with -
+      "><img src=x onerror=alert(1)>", // comment-start state: > closes it
+      "-><img src=x onerror=alert(1)>",// comment-start-dash state
+      "<!-- nested",
+    ]) {
+      expect(() => serializeVNode({ sel: "!", text: hostile }), hostile)
+        .toThrow(/terminate the comment early/);
+    }
   });
 });
 
@@ -170,6 +261,13 @@ describe("serializeVNode: element shapes", () => {
   it("returns an empty string for null/undefined", () => {
     expect(serializeVNode(null)).toBe("");
     expect(serializeVNode(undefined)).toBe("");
+  });
+
+  it("tolerates an explicit `data: null` without crashing", () => {
+    // A default parameter only applies to `undefined`, so this previously
+    // threw a bare, unattributable TypeError.
+    expect(serializeVNode({ sel: "div", data: null, children: [] })).toBe("<div></div>");
+    expect(serializeVNode({ sel: "div", data: null, text: "x" })).toBe("<div>x</div>");
   });
 
   it("lets a caller substitute children via renderChildren", () => {

--- a/packages/rettangoli-fe/test/server/serialize-vnode.test.js
+++ b/packages/rettangoli-fe/test/server/serialize-vnode.test.js
@@ -1,0 +1,181 @@
+import { describe, expect, it } from "vitest";
+import { h } from "snabbdom/build/h.js";
+
+import { serializeVNode } from "../../src/core/server/serializeVNode.js";
+
+describe("serializeVNode: escaping", () => {
+  it("escapes text so markup cannot be injected", () => {
+    expect(serializeVNode(h("div", {}, ["<script>alert(1)</script>"])))
+      .toBe("<div>&lt;script&gt;alert(1)&lt;/script&gt;</div>");
+  });
+
+  it("escapes quotes in attribute values so they cannot break out", () => {
+    const html = serializeVNode(h("div", { attrs: { title: '" onload="alert(1)' } }, ["x"]));
+    expect(html).toBe('<div title="&quot; onload=&quot;alert(1)">x</div>');
+
+    const openTag = html.slice(0, html.indexOf(">") + 1);
+    // One attribute on the tag, and exactly two raw quotes: the delimiters.
+    // The payload's own quotes became &quot;, so it cannot start a new
+    // attribute -- which is what makes the injected `onload=` inert text.
+    expect(openTag.match(/\s[a-zA-Z-]+="/g)).toHaveLength(1);
+    expect(openTag.match(/"/g)).toHaveLength(2);
+  });
+
+  it("escapes ampersands in both text and attributes", () => {
+    expect(serializeVNode(h("a", { attrs: { href: "/a?x=1&y=2" } }, ["A&B"])))
+      .toBe('<a href="/a?x=1&amp;y=2">A&amp;B</a>');
+  });
+
+  it("escapes an already-escaped entity exactly once", () => {
+    expect(serializeVNode(h("div", {}, ["&amp;"]))).toBe("<div>&amp;amp;</div>");
+  });
+
+  it("leaves single quotes alone because attributes are always double-quoted", () => {
+    expect(serializeVNode(h("div", { attrs: { title: "it's" } }, ["x"])))
+      .toBe("<div title=\"it's\">x</div>");
+  });
+});
+
+describe("serializeVNode: raw text elements", () => {
+  it("emits <style> content verbatim, because escaping would corrupt the CSS", () => {
+    const html = serializeVNode(h("style", {}, ['.a > .b { content: "<" }']));
+    expect(html).toBe('<style>.a > .b { content: "<" }</style>');
+    expect(html).not.toContain("&gt;");
+  });
+
+  it("emits <script> content verbatim", () => {
+    expect(serializeVNode(h("script", {}, ["if (a < b) {}"])))
+      .toBe("<script>if (a < b) {}</script>");
+  });
+
+  it("refuses raw-text content that would close its own element", () => {
+    expect(() => serializeVNode(h("style", {}, ["x{}</style><img onerror=alert(1)>"])))
+      .toThrow(/cannot be safely serialized/);
+    expect(() => serializeVNode(h("script", {}, ["</script><img onerror=alert(1)>"])))
+      .toThrow(/cannot be safely serialized/);
+  });
+
+  it("still escapes textarea and title, which ARE escapable raw text", () => {
+    expect(serializeVNode(h("textarea", {}, ["<b>&</b>"])))
+      .toBe("<textarea>&lt;b&gt;&amp;&lt;/b&gt;</textarea>");
+    expect(serializeVNode(h("title", {}, ["a < b"]))).toBe("<title>a &lt; b</title>");
+  });
+});
+
+describe("serializeVNode: comments", () => {
+  it("emits comment vnodes", () => {
+    expect(serializeVNode({ sel: "!", text: " sep " })).toBe("<!-- sep -->");
+  });
+
+  it("refuses comment content that would terminate the comment early", () => {
+    expect(() => serializeVNode({ sel: "!", text: "a--><img onerror=alert(1)>" }))
+      .toThrow(/may not contain/);
+    expect(() => serializeVNode({ sel: "!", text: "trailing-" })).toThrow(/may not contain/);
+  });
+});
+
+describe("serializeVNode: props are never emitted", () => {
+  it("drops data.props entirely, including values with no HTML form", () => {
+    const html = serializeVNode(
+      h("x-child", {
+        props: {
+          user: { name: "Ada" },
+          when: new Date("1843-01-01"),
+          cb: () => {},
+          list: [1, 2, 3],
+        },
+      }),
+    );
+    expect(html).toBe("<x-child></x-child>");
+    expect(html).not.toContain("[object Object]");
+  });
+
+  it("keeps attribute-form bindings, which the parser mirrors into attrs", () => {
+    expect(serializeVNode(h("x-child", { attrs: { label: "hi" }, props: { label: "hi" } })))
+      .toBe('<x-child label="hi"></x-child>');
+  });
+
+  it("never invents a lowercased duplicate of a hyphenated attribute", () => {
+    // This is the concrete `snabbdom-to-html` defect: it emits `h-bc` AND
+    // `hbc` from attrs+props, and both are in observedAttributes.
+    const html = serializeVNode(
+      h("rtgl-view", { attrs: { "h-bc": "ac" }, props: { "h-bc": "ac" } }),
+    );
+    expect(html).toBe('<rtgl-view h-bc="ac"></rtgl-view>');
+    expect(html).not.toMatch(/\shbc=/);
+  });
+});
+
+describe("serializeVNode: attribute encoding", () => {
+  it("preserves empty-string attributes, which is the boolean encoding", () => {
+    expect(serializeVNode(h("rtgl-view", { attrs: { wrap: "", sv: "" } })))
+      .toBe('<rtgl-view wrap="" sv=""></rtgl-view>');
+  });
+
+  it("emits `true` as the boolean form", () => {
+    expect(serializeVNode(h("input", { attrs: { disabled: true } })))
+      .toBe('<input disabled="">');
+  });
+
+  it("omits false / null / undefined attributes", () => {
+    expect(serializeVNode(h("div", { attrs: { a: false, b: null, c: undefined, d: "keep" } })))
+      .toBe('<div d="keep"></div>');
+  });
+
+  it("merges data.class and an authored class into ONE class attribute", () => {
+    const html = serializeVNode(
+      h("div", { attrs: { class: "authored" }, class: { alpha: true, beta: false } }),
+    );
+    expect(html).toBe('<div class="authored alpha"></div>');
+    expect(html.match(/class=/g)).toHaveLength(1);
+  });
+
+  it("renders style objects as kebab-case css and preserves custom properties", () => {
+    expect(serializeVNode(h("div", { style: { display: "contents", marginTop: "4px", "--x": "1" } })))
+      .toBe('<div style="display: contents; margin-top: 4px; --x: 1"></div>');
+  });
+
+  it("drops snabbdom's transition sub-objects from style", () => {
+    expect(serializeVNode(
+      h("div", { style: { color: "red", delayed: { opacity: "1" }, remove: { opacity: "0" }, destroy: { opacity: "0" } } }),
+    )).toBe('<div style="color: red"></div>');
+  });
+
+  it("merges an attrs.style string with a data.style object", () => {
+    expect(serializeVNode(h("div", { attrs: { style: "color: red;" }, style: { display: "contents" } })))
+      .toBe('<div style="color: red; display: contents"></div>');
+  });
+
+  it("rejects invalid attribute names rather than emitting broken markup", () => {
+    expect(serializeVNode(h("div", { attrs: { "bad name": "x", "ok": "y" } })))
+      .toBe('<div ok="y"></div>');
+  });
+});
+
+describe("serializeVNode: element shapes", () => {
+  it("does not close void elements", () => {
+    expect(serializeVNode(h("img", { attrs: { src: "/a.png" } }))).toBe('<img src="/a.png">');
+    expect(serializeVNode(h("br"))).toBe("<br>");
+  });
+
+  it("serializes nested children in document order", () => {
+    expect(serializeVNode(h("ul", {}, [h("li", {}, ["a"]), h("li", {}, ["b"])])))
+      .toBe("<ul><li>a</li><li>b</li></ul>");
+  });
+
+  it("handles the text-on-element form h(tag, data, 'string')", () => {
+    expect(serializeVNode(h("p", {}, "hello"))).toBe("<p>hello</p>");
+  });
+
+  it("returns an empty string for null/undefined", () => {
+    expect(serializeVNode(null)).toBe("");
+    expect(serializeVNode(undefined)).toBe("");
+  });
+
+  it("lets a caller substitute children via renderChildren", () => {
+    const html = serializeVNode(h("x-host", {}, [h("span", {}, ["ignored"])]), {
+      renderChildren: (vnode) => (vnode.sel === "x-host" ? "<i>substituted</i>" : null),
+    });
+    expect(html).toBe("<x-host><i>substituted</i></x-host>");
+  });
+});

--- a/packages/rettangoli-fe/test/server/serialize-vnode.test.js
+++ b/packages/rettangoli-fe/test/server/serialize-vnode.test.js
@@ -144,6 +144,28 @@ describe("serializeVNode: foreign content (SVG / MathML)", () => {
   });
 });
 
+describe("serializeVNode: tag names", () => {
+  // Attribute names were validated from the start; tag names were not, which
+  // made this the one way left to break out of a tag. The browser rejects the
+  // same string via document.createElement (InvalidCharacterError), so without
+  // the guard the server path was strictly weaker than the client it mirrors.
+  it("refuses a tag name that would break out of the tag", () => {
+    expect(() => serializeVNode(h("div><img src=x onerror=alert(1)", {}, ["x"])))
+      .toThrow(/invalid tag name/);
+    expect(() => serializeVNode(h("div onload=alert(1)", {}, ["x"])))
+      .toThrow(/invalid tag name/);
+  });
+
+  it("still accepts the tag shapes the framework really emits", () => {
+    // Plain, custom element, camelCase SVG, and snabbdom's tag#id.class form.
+    expect(serializeVNode(h("div"))).toBe("<div></div>");
+    expect(serializeVNode(h("rtgl-view"))).toBe("<rtgl-view></rtgl-view>");
+    expect(serializeVNode(h("svg", {}, [h("foreignObject")])))
+      .toBe("<svg><foreignObject></foreignObject></svg>");
+    expect(serializeVNode(h("div#root.card"))).toBe("<div></div>");
+  });
+});
+
 describe("serializeVNode: comments", () => {
   it("emits comment vnodes", () => {
     expect(serializeVNode({ sel: "!", text: " sep " })).toBe("<!-- sep -->");

--- a/packages/rettangoli-fe/test/server/serialize-vnode.test.js
+++ b/packages/rettangoli-fe/test/server/serialize-vnode.test.js
@@ -65,12 +65,28 @@ describe("serializeVNode: raw text elements", () => {
       .toThrow(/cannot be safely serialized/);
   });
 
-  it("refuses <script> content containing `<!--`, which prevents the tag closing", () => {
-    // `<!--` moves the tokenizer into script-data-escaped state, so a later
-    // </script> no longer closes the element and the rest of the document is
-    // swallowed as script text. Confirmed in parse5, jsdom and Chromium.
+  it.each([
+    ["style", "</stylesheet>"],
+    ["script", "</scripture>"],
+    ["style", "</ style>"],
+  ])("allows <%s> text that only resembles an end tag", (tag, text) => {
+    expect(serializeVNode(h(tag, {}, [text]))).toBe(`<${tag}>${text}</${tag}>`);
+  });
+
+  it("allows harmless script comment markers and escaped-state round trips", () => {
+    for (const text of [
+      "<!-- legacy wrapper -->",
+      'const marker = "<!--";',
+      "<!--<script></script>-->",
+    ]) {
+      expect(serializeVNode(h("script", {}, [text])))
+        .toBe(`<script>${text}</script>`);
+    }
+  });
+
+  it("refuses script text left in the double-escaped state", () => {
     expect(() => serializeVNode(h("script", {}, ['{"a":"<!--<script>"}'])))
-      .toThrow(/changes the tokenizer state/);
+      .toThrow(/script-data-double-escaped state/);
   });
 
   it("still escapes textarea and title, which ARE escapable raw text", () => {
@@ -323,6 +339,38 @@ describe("serializeVNode: attribute encoding", () => {
       .toBe('<div style="display: contents; margin-top: 4px; --x: 1"></div>');
   });
 
+  it("rejects style values that can escape into another declaration", () => {
+    expect(() => serializeVNode(
+      h("div", { style: { color: "red; background-image: url(https://example.test/x)" } }),
+    )).toThrow(/top-level semicolon/);
+    expect(() => serializeVNode(
+      h("div", { style: { "--theme": "red; background: black" } }),
+    )).toThrow(/top-level semicolon/);
+  });
+
+  it("allows semicolons isolated inside CSS strings and functions", () => {
+    expect(serializeVNode(h("div", {
+      style: {
+        content: '"a;b"',
+        "--asset": 'url("data:image/svg+xml;a")',
+      },
+    }))).toBe(
+      '<div style="content: &quot;a;b&quot;; --asset: url(&quot;data:image/svg+xml;a&quot;)"></div>',
+    );
+  });
+
+  it("rejects property names and values that cannot form one isolated declaration", () => {
+    expect(() => serializeVNode(
+      h("div", { style: { "color; background": "red" } }),
+    )).toThrow(/invalid CSS property name/);
+    expect(() => serializeVNode(
+      h("div", { style: { color: "var(--broken" } }),
+    )).toThrow(/unbalanced CSS blocks/);
+    expect(() => serializeVNode(
+      h("div", { style: { color: "red !important" } }),
+    )).toThrow(/priority marker/);
+  });
+
   it("drops snabbdom's transition sub-objects from style", () => {
     expect(serializeVNode(
       h("div", { style: { color: "red", delayed: { opacity: "1" }, remove: { opacity: "0" }, destroy: { opacity: "0" } } }),
@@ -344,6 +392,15 @@ describe("serializeVNode: element shapes", () => {
   it("does not close void elements", () => {
     expect(serializeVNode(h("img", { attrs: { src: "/a.png" } }))).toBe('<img src="/a.png">');
     expect(serializeVNode(h("br"))).toBe("<br>");
+  });
+
+  it("closes HTML void-element names in foreign namespaces", () => {
+    expect(serializeVNode(
+      h("svg", {}, [h("input"), h("circle")]),
+    )).toBe("<svg><input></input><circle></circle></svg>");
+    expect(serializeVNode(
+      h("math", {}, [h("input"), h("mi", {}, ["x"])]),
+    )).toBe("<math><input></input><mi>x</mi></math>");
   });
 
   it("serializes nested children in document order", () => {

--- a/packages/rettangoli-fe/test/web/style-module.browser.mjs
+++ b/packages/rettangoli-fe/test/web/style-module.browser.mjs
@@ -1,0 +1,145 @@
+/**
+ * Browser verification for the vendored snabbdom style module.
+ *
+ * Unit tests use stubs, which cannot prove the one thing that actually matters:
+ * that in a real browser the vendored copy still resolves
+ * `window.requestAnimationFrame` and applies styles identically to upstream.
+ * A regression here would be invisible in Node and obvious in production.
+ *
+ *   node packages/rettangoli-fe/test/web/style-module.browser.mjs
+ */
+
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { createServer } from "node:http";
+
+/**
+ * Playwright is deliberately NOT a dependency of this package — it would add
+ * ~150 MB of browsers to every install for a check that runs on demand. It is
+ * resolved from the workspace root instead, so give a useful message rather
+ * than a bare MODULE_NOT_FOUND when it is absent.
+ */
+let chromium;
+try {
+  ({ chromium } = await import("playwright"));
+} catch {
+  console.error(
+    "[browser] playwright is not installed.\n" +
+      "          This check is optional and runs from the workspace root:\n" +
+      "            bun install && npx playwright install chromium\n" +
+      "          The unit suite (`bun run test`) covers everything except real-browser rAF resolution.",
+  );
+  process.exit(2);
+}
+
+const ROOT = path.resolve(import.meta.dirname, "../../../..");
+
+const checks = [];
+const check = (name, pass, detail = "") => {
+  checks.push({ name, pass });
+  console.log(`  ${pass ? "PASS" : "FAIL"}  ${name}${detail ? `  (${detail})` : ""}`);
+};
+
+// Serve the monorepo so the browser can load real ES modules from node_modules.
+const serve = (port) =>
+  new Promise((resolve) => {
+    const server = createServer(async (req, res) => {
+      try {
+        const urlPath = decodeURIComponent(req.url.split("?")[0]);
+        if (urlPath === "/") {
+          res.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+          res.end('<!doctype html><html><body><div id="host"></div></body></html>');
+          return;
+        }
+        const file = path.join(ROOT, urlPath);
+        if (!file.startsWith(ROOT)) return res.writeHead(403).end();
+        const body = await readFile(file);
+        res.writeHead(200, { "content-type": "text/javascript; charset=utf-8" });
+        res.end(body);
+      } catch {
+        res.writeHead(404).end("not found");
+      }
+    });
+    server.listen(port, () => resolve(server));
+  });
+
+const main = async () => {
+  const port = 3577;
+  const server = await serve(port);
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+
+  const errors = [];
+  page.on("pageerror", (e) => errors.push(String(e)));
+
+  await page.goto(`http://127.0.0.1:${port}/`, { waitUntil: "domcontentloaded" });
+
+  const result = await page.evaluate(async (base) => {
+    const { init } = await import(`${base}/node_modules/snabbdom/build/init.js`);
+    const { h } = await import(`${base}/node_modules/snabbdom/build/h.js`);
+    const { styleModule } = await import(
+      `${base}/packages/rettangoli-fe/src/web/vendor/snabbdomStyleModule.js`
+    );
+
+    const patch = init([styleModule]);
+    const host = document.getElementById("host");
+
+    // 1. plain declarations + a custom property
+    const a = patch(host, h("div", { style: { display: "contents", "--tone": "7" } }));
+    const elm = a.elm;
+    const afterCreate = {
+      display: elm.style.display,
+      tone: elm.style.getPropertyValue("--tone"),
+    };
+
+    // 2. update: change one, remove another
+    const b = patch(a, h("div", { style: { display: "block" } }));
+    const afterUpdate = {
+      display: b.elm.style.display,
+      tone: b.elm.style.getPropertyValue("--tone"),
+    };
+
+    // 3. `delayed` must apply on a later frame, not synchronously
+    const c = patch(b, h("div", { style: { delayed: { opacity: "0.5" } } }));
+    const opacityImmediately = c.elm.style.opacity;
+    await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(() => r())));
+    await new Promise((r) => requestAnimationFrame(r));
+    const opacityAfterFrames = c.elm.style.opacity;
+
+    return {
+      afterCreate,
+      afterUpdate,
+      opacityImmediately,
+      opacityAfterFrames,
+      rafIsReal: typeof window.requestAnimationFrame === "function",
+    };
+  }, `http://127.0.0.1:${port}`);
+
+  console.log("[browser] vendored style module\n");
+  check("applies plain declarations", result.afterCreate.display === "contents",
+    `display=${result.afterCreate.display}`);
+  check("applies custom properties via setProperty", result.afterCreate.tone === "7",
+    `--tone=${result.afterCreate.tone}`);
+  check("updates changed declarations", result.afterUpdate.display === "block",
+    `display=${result.afterUpdate.display}`);
+  check("removes declarations that disappeared", result.afterUpdate.tone === "",
+    `--tone=${JSON.stringify(result.afterUpdate.tone)}`);
+  check("does not apply `delayed` synchronously", result.opacityImmediately === "",
+    `opacity=${JSON.stringify(result.opacityImmediately)}`);
+  check("applies `delayed` on a later frame — proves rAF resolved",
+    result.opacityAfterFrames === "0.5", `opacity=${result.opacityAfterFrames}`);
+  check("browser really has requestAnimationFrame", result.rafIsReal);
+  check("no page errors", errors.length === 0, errors[0] ?? "");
+
+  await browser.close();
+  server.close();
+
+  const failed = checks.filter((c) => !c.pass);
+  console.log(`\n[browser] ${checks.length - failed.length}/${checks.length} passed`);
+  if (failed.length) process.exit(1);
+};
+
+main().catch((error) => {
+  console.error("[browser] error:", error);
+  process.exit(1);
+});

--- a/packages/rettangoli-fe/test/web/style-module.test.js
+++ b/packages/rettangoli-fe/test/web/style-module.test.js
@@ -101,4 +101,106 @@ describe("vendored style module", () => {
     // Deferred via the rAF/setTimeout path, so not visible on this tick.
     expect(applied(elm)).toEqual({});
   });
+
+  // The lazy `raf` is the ONLY line this file changes from upstream. Asserting
+  // that `delayed` is deferred does not cover it: a raf that drops its callback
+  // passes that test, and every other test in the package, silently. These two
+  // pin the property that the callback is actually invoked.
+  it("eventually applies `delayed` — proves raf invokes its callback", async () => {
+    const elm = createElementStub();
+    styleModule.update(
+      { data: { style: {} } },
+      { data: { style: { delayed: { opacity: "0.5" } } }, elm },
+    );
+    // nextFrame double-nests raf, which falls back to setTimeout in Node.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(applied(elm).opacity).toBe("0.5");
+  });
+
+  it("prefers window.requestAnimationFrame and invokes it bound to window", async () => {
+    // Run in a child process: `raf` is memoized on first call, so proving the
+    // window path needs a fresh module realm with a window already present.
+    // Vite cannot resolve a fully dynamic specifier, and vi.resetModules would
+    // disturb the rest of this file.
+    const { execFileSync } = await import("node:child_process");
+    const moduleUrl = new URL(
+      "../../src/web/vendor/snabbdomStyleModule.js",
+      import.meta.url,
+    ).href;
+
+    const script = `
+      const calls = [];
+      globalThis.window = {
+        requestAnimationFrame(cb) {
+          calls.push(this === globalThis.window);   // upstream binds to window
+          return setTimeout(cb, 0);
+        },
+      };
+      const { styleModule } = await import(${JSON.stringify(moduleUrl)});
+      const elm = { style: {} };
+      styleModule.update(
+        { data: { style: {} } },
+        { data: { style: { delayed: { opacity: "1" } } }, elm },
+      );
+      await new Promise((r) => setTimeout(r, 5));
+      console.log(JSON.stringify({
+        used: calls.length > 0,
+        boundToWindow: calls.length > 0 && calls.every(Boolean),
+        opacity: elm.style.opacity,
+      }));
+    `;
+
+    const out = execFileSync(process.execPath, ["--input-type=module", "-e", script], {
+      encoding: "utf8",
+    }).trim();
+    const result = JSON.parse(out);
+
+    expect(result.used, "window.requestAnimationFrame should have been used").toBe(true);
+    expect(result.boundToWindow, "raf must be invoked with `this` === window").toBe(true);
+    expect(result.opacity, "the deferred declaration must actually land").toBe("1");
+  });
+});
+
+describe("vendored copy vs upstream snabbdom", () => {
+  // The file header claims the copy stays faithful, but nothing was checking.
+  // Replacing node_modules' style.js with a bare `throw` previously left the
+  // whole suite green, proving no test read upstream at all.
+  it("differs from upstream only in the lazy raf resolution", async () => {
+    const { readFileSync } = await import("node:fs");
+    const { createRequire } = await import("node:module");
+    const require = createRequire(import.meta.url);
+
+    const upstreamPath = require.resolve("snabbdom/build/modules/style.js");
+    const upstream = readFileSync(upstreamPath, "utf8");
+    const vendored = readFileSync(
+      new URL("../../src/web/vendor/snabbdomStyleModule.js", import.meta.url),
+      "utf8",
+    );
+
+    // Compare the mechanical body: everything from nextFrame onward, with
+    // comments and whitespace normalised away.
+    const body = (source) => {
+      const start = source.indexOf("function updateStyle");
+      const end = source.indexOf("export const styleModule");
+      return source
+        .slice(start, end)
+        .replace(/\/\*[\s\S]*?\*\//g, "")
+        .replace(/\/\/[^\n]*/g, "")
+        .replace(/\s+/g, " ")
+        .trim();
+    };
+
+    expect(body(vendored), "vendored style module has drifted from upstream").toBe(
+      body(upstream),
+    );
+  });
+
+  it("pins the upstream version the copy was taken from", async () => {
+    const { createRequire } = await import("node:module");
+    const require = createRequire(import.meta.url);
+    // Bumping snabbdom without re-checking the copy should fail loudly here.
+    expect(require("snabbdom/package.json").version).toBe("3.6.2");
+  });
 });

--- a/packages/rettangoli-fe/test/web/style-module.test.js
+++ b/packages/rettangoli-fe/test/web/style-module.test.js
@@ -1,0 +1,104 @@
+/**
+ * Pins the behaviour of the vendored snabbdom style module.
+ *
+ * The vendored copy exists only so the package imports in Node; its runtime
+ * behaviour in a browser must stay byte-equivalent to upstream. If snabbdom is
+ * upgraded, these tests are what tell you whether the copy still matches.
+ */
+
+import { describe, expect, it } from "vitest";
+import { styleModule } from "../../src/web/vendor/snabbdomStyleModule.js";
+
+/** Minimal stand-in for an element's CSSStyleDeclaration. */
+const createElementStub = () => ({
+  style: {
+    custom: {},
+    setProperty(name, value) {
+      this.custom[name] = value;
+    },
+    removeProperty(name) {
+      delete this.custom[name];
+    },
+  },
+});
+
+const applied = (elm) =>
+  Object.fromEntries(
+    Object.entries(elm.style).filter(
+      ([key, value]) => key !== "custom" && typeof value !== "function",
+    ),
+  );
+
+const update = (oldStyle, newStyle) => {
+  const elm = createElementStub();
+  styleModule.update({ data: { style: oldStyle } }, { data: { style: newStyle }, elm });
+  return { direct: applied(elm), custom: elm.style.custom };
+};
+
+describe("vendored style module", () => {
+  it("imports without a DOM — the reason it is vendored at all", () => {
+    expect(typeof globalThis.window).toBe("undefined");
+    expect(typeof styleModule).toBe("object");
+  });
+
+  it("exposes the same hook set as upstream", () => {
+    expect(Object.keys(styleModule).sort()).toEqual(
+      ["create", "destroy", "pre", "remove", "update"].sort(),
+    );
+  });
+
+  it("applies new declarations", () => {
+    expect(update({}, { color: "red" }).direct).toEqual({ color: "red" });
+  });
+
+  it("clears declarations that were removed", () => {
+    expect(update({ color: "red" }, {}).direct).toEqual({ color: "" });
+  });
+
+  it("routes custom properties through setProperty/removeProperty", () => {
+    expect(update({}, { "--x": "1" }).custom).toEqual({ "--x": "1" });
+    expect(update({ "--x": "1" }, {}).custom).toEqual({});
+  });
+
+  it("updates only changed declarations", () => {
+    expect(update({ a: "1", b: "2" }, { b: "3" })).toEqual({
+      direct: { a: "", b: "3" },
+      custom: {},
+    });
+  });
+
+  it("does nothing when both sides are absent or identical", () => {
+    const elm = createElementStub();
+    styleModule.update({ data: {} }, { data: {}, elm });
+    expect(applied(elm)).toEqual({});
+
+    const shared = { color: "red" };
+    const elm2 = createElementStub();
+    styleModule.update({ data: { style: shared } }, { data: { style: shared }, elm: elm2 });
+    expect(applied(elm2)).toEqual({});
+  });
+
+  it("applies destroy styles", () => {
+    const elm = createElementStub();
+    styleModule.destroy({ data: { style: { destroy: { opacity: "0" } } }, elm });
+    expect(applied(elm)).toEqual({ opacity: "0" });
+  });
+
+  it("calls the remove callback immediately when there is no remove style", () => {
+    let called = false;
+    styleModule.remove({ data: { style: {} }, elm: createElementStub() }, () => {
+      called = true;
+    });
+    expect(called).toBe(true);
+  });
+
+  it("defers `delayed` declarations rather than applying them synchronously", () => {
+    const elm = createElementStub();
+    styleModule.update(
+      { data: { style: {} } },
+      { data: { style: { delayed: { opacity: "1" } } }, elm },
+    );
+    // Deferred via the rAF/setTimeout path, so not visible on this tick.
+    expect(applied(elm)).toEqual({});
+  });
+});

--- a/packages/rettangoli-fe/test/web/style-module.test.js
+++ b/packages/rettangoli-fe/test/web/style-module.test.js
@@ -180,9 +180,12 @@ describe("vendored copy vs upstream snabbdom", () => {
     );
 
     // Compare the mechanical body: everything from nextFrame onward, with
-    // comments and whitespace normalised away.
+    // comments and whitespace normalised away. Starting at `nextFrame` rather
+    // than `updateStyle` deliberately covers nextFrame/setNextFrame — the lines
+    // adjacent to the modified `raf`, and so the likeliest place for a careless
+    // re-vendor to drift.
     const body = (source) => {
-      const start = source.indexOf("function updateStyle");
+      const start = source.indexOf("const nextFrame");
       const end = source.indexOf("export const styleModule");
       return source
         .slice(start, end)

--- a/packages/rettangoli-fe/vitest.config.js
+++ b/packages/rettangoli-fe/vitest.config.js
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    // Pinned, not inherited. Several suites assert that this package is
+    // importable with NO DOM at all (test/server/node-environment.test.js) —
+    // the property that makes server rendering and HTML goldens possible.
+    // Switching this to "jsdom" would supply `window`/`document` globally and
+    // turn those guards into assertions about jsdom instead of about Node.
+    environment: "node",
+  },
+});

--- a/packages/rettangoli-ui/package.json
+++ b/packages/rettangoli-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rettangoli/ui",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "description": "A UI component library for building web interfaces.",
   "main": "./src/index.js",
   "type": "module",
@@ -64,7 +64,7 @@
   },
   "homepage": "https://github.com/yuusoft-org/rettangoli#readme",
   "dependencies": {
-    "@rettangoli/fe": "1.3.0",
+    "@rettangoli/fe": "1.4.0",
     "jempl": "1.0.1"
   }
 }


### PR DESCRIPTION
## What

`import("@rettangoli/fe")` threw in Node, which blocked every Node-side tool. This makes the package importable and adds a vnode→HTML serializer, so components can render outside a browser.

```
$ node -e "import('@rettangoli/fe')"
# before:  ReferenceError: window is not defined
# after:   resolves
```

**Scope is Part A of `docs/ssr-plan.md`.** It adds no SSR, no hydration, and no recursive component renderer — those are Part B and a separate decision. Nothing changes for existing consumers.

## Why the obvious fix didn't work

snabbdom's style module dereferences a bare `window` at **module** scope:

```js
const raf = typeof (window === null || window === void 0
  ? void 0 : window.requestAnimationFrame) === "function" ? ... : setTimeout;
```

`typeof (...)` looks safe, but the parenthesised expression evaluates first — so the throw is at *import*, not at call. Making the patch lazy does nothing; the static import is what fails.

Vendored that module (snabbdom 3.6.2, MIT) with a **two-line delta**: `raf` resolves lazily from `globalThis.window`. Browser behaviour is unchanged.

## Changes

| | |
|---|---|
| `src/web/vendor/snabbdomStyleModule.js` | vendored, 2 lines changed |
| `src/core/component/resolveComponentDefinition.js` | moved off the patch's import graph, re-exported for compat |
| `src/core/server/serializeVNode.js` | vnode → HTML |
| `src/server/index.js` | Node-safe entry |
| `src/web/componentDom.js` | render-target adoption hardened; inline styles no longer clobbered |
| `package.json` | `./server` and `./parser` exports |

### Why not `snabbdom-to-html`

It stringifies `data.props` into lowercased attributes — a node with `h-bc="ac"` emits **both** `h-bc` and `hbc`, and object props emit `[object Object]`. Those invented names are in `observedAttributes`, so `attributeChangedCallback` would overwrite real props with garbage. It also drops empty-string attributes, which is exactly rettangoli's boolean encoding.

### Two latent bugs fixed

- A `<style>`/`<link>`/`<slot>` in a shadow root could be stamped as the render target, then replaced by the first patch — leaving `instance.renderTarget` detached. Reachable on the hot-update path today.
- `renderTarget.style.cssText` was clobbered wholesale, discarding inline styles on an adopted target.

## Testing

**307 tests in this package, up from 237.**

The notable addition is **HTML goldens for real components** — the repo had 1,301 `.webp` references and zero `.html` goldens, so the only way to see a component's output was a Docker-pinned screenshot diff that can't localise a regression. These render the shipped e2e fixtures through the real pipeline in bare Node:

```html
<div style="font-size:11px">Count: 3</div>
<div data-testid="panel" style="...background:mediumseagreen..." id="panel"></div>
```

That's `counter` after three real store actions — `$if` branch taken, `height:60px` derived from state.

Also:
- `test:browser` (8 checks, real Chromium) covers what stubs can't — including the `delayed` transition path, which proves rAF still resolves. Playwright is intentionally *not* a dependency; the script exits with guidance if absent.
- Package smoke test (pack → install → import) passes.
- `@rettangoli/ui` builds and passes its 260 tests against this.
- **Full monorepo run matches the pre-change baseline exactly** — same 4 pre-existing failures in `rettangoli-be`/`rettangoli-tui`/`rettangoli-cli`, verified by stashing these changes and re-running.

## Notes for review

- `docs/ssr-plan.md` is included as the rationale. It covers Part B too, and carries corrections from an adversarial review — including one place where the plan's own prescribed fix was proven wrong.
- Files aren't Prettier-formatted, matching the package (`parser.js`, `index.js` and others don't conform either, and there's no lint script). Reformatting would have buried the diff.
- One deliberate non-change: the plan proposed moving template normalization to build time. That would break every property-binding view — normalization isn't idempotent, and the `WeakSet` is a correctness guard rather than a memo. There's no live bug, so the code is unchanged and the constraint is captured in `test/runtime/template-normalization.test.js`.
