### PR TITLE
feat(fe): add recursive server renderer

### DIFF
--- a/packages/rettangoli-fe/docs/roadmap.md
+++ b/packages/rettangoli-fe/docs/roadmap.md
@@ -39,11 +39,12 @@ This roadmap is the planning source for `packages/rettangoli-fe`.
 - Continue aligning `overview.md`, `view.md`, `store.md`, `handlers.md`, `schema.md`, `methods.md`, `constants.md`.
 - Add concise invalid/valid examples when contracts evolve.
 
-6. `[P1]` End-to-end testing via `@rettangoli/vt` on examples
+6. `[P1][DONE]` End-to-end testing via `@rettangoli/vt` on FE fixtures
 - **Motivation:** Unit and contract tests verify internal correctness but cannot catch real-browser regressions (rendering, event timing, lifecycle, interactions). We should not rely on users to report bugs that automated E2E can catch first.
 - **Approach:** Use `@rettangoli/vt` (which already uses Playwright) to run visual + interaction tests against `examples/`. Write VT specs with steps (click, write, keypress, select, wait, screenshot) to exercise real component behavior, then assert screenshot output matches reference via pixelmatch.
 - **No new framework needed** — leverage existing VT infrastructure instead of building a standalone Playwright E2E suite from scratch.
-- **Test location:** VT specs live in each example's `vt/specs/` directory (e.g. `examples/example1/vt/specs/`).
+- **Test location:** VT specs live under each FE E2E fixture's `vt/specs/`
+  directory (for example, `e2e/interactions/vt/specs/`).
 - **Scenarios to cover via VT specs:**
   - Component renders correctly in real browser (initial state screenshot)
   - Props/attributes produce expected visual output (multiple viewData variants in `.examples.yaml`)
@@ -54,10 +55,18 @@ This roadmap is the planning source for `packages/rettangoli-fe`.
   - Edge cases: empty state, error state, boundary values
 - **Workflow:**
   1. `rtgl fe build` in the example project
-  2. `rtgl vt generate` to capture candidate screenshots
+  2. `rtgl vt screenshot` to capture candidate screenshots
   3. `rtgl vt report` to compare against reference — fails on mismatch
   4. `rtgl vt accept` to update baselines when changes are intentional
-- **CI integration:** run `rtgl vt generate && rtgl vt report` on examples as part of PR checks
+- **CI integration:** run `rtgl vt screenshot && rtgl vt report` on the FE E2E
+  fixtures as part of PR checks
+- **Completed coverage:**
+  - 8 VT interaction specs across the `dashboard` and `interactions` FE
+    examples
+  - click, write, keyboard, wait, state-transition, control-flow, i18n, and
+    composed parent/child scenarios with screenshot assertions
+  - a `ci-ui.yaml` matrix that builds both examples, captures and reports via
+    the pinned VT browser image, and uploads failure artifacts
 
 ## Backlog
 

--- a/packages/rettangoli-fe/docs/schema.md
+++ b/packages/rettangoli-fe/docs/schema.md
@@ -14,6 +14,7 @@ Supported fields:
 - `propsSchema` (optional)
 - `events` (optional)
 - `methods` (optional)
+- `ssr` (optional boolean; defaults to `true`)
 
 `attrsSchema` is not supported.
 
@@ -90,11 +91,21 @@ methods:
 - each `methods.properties.<methodName>` SHOULD match a named export in `.methods.js`
 - if `methods` is declared, `.methods.js` SHOULD exist
 
+### `ssr`
+
+- optional boolean, default `true`
+- set to `false` for components that cannot produce deterministic server markup
+- the server renderer emits an opted-out component as a bare host without a
+  declarative shadow root or `data-rtgl-hydrate` marker
+- use this for genuinely client-only surfaces such as canvas, WebGL, or editor
+  mounts; it is not an imperative `isSsr` runtime branch
+
 ## 4. Validation Errors
 
 Runtime validation errors:
 - `componentName is required.`
 - `attrsSchema is not supported.`
+- `ssr must be a boolean.`
 - `methods must be an object schema with a properties map.`
 - `methods.type must be 'object'.`
 - `methods.properties must be an object keyed by method name.`

--- a/packages/rettangoli-fe/docs/ssr-plan.md
+++ b/packages/rettangoli-fe/docs/ssr-plan.md
@@ -1,6 +1,7 @@
 # SSR for @rettangoli/fe — implementation plan
 
-Status: proposal, backed by a working prototype.
+Status: Parts A and B1 implemented; B2–B4 remain a proposal backed by a
+working prototype.
 Scope: framework-level (`@rettangoli/fe`).
 
 The prototype and its test suite live outside this repo, in the app used to
@@ -17,8 +18,11 @@ than as part of the design.
 
 ## 0. Status
 
-**Part A is implemented and merged into `packages/rettangoli-fe`.** Part B is
-unstarted and remains a separate decision.
+**Part A is implemented and merged into `packages/rettangoli-fe`. Stage B1 is
+also implemented:** the Node-safe entry now resolves a caller-supplied
+component registry, runs each component store, recursively renders registered
+child tags, and emits nested declarative shadow roots. Hydration and consumer
+adoption (B2–B4) remain separate decisions.
 
 What shipped:
 
@@ -26,17 +30,19 @@ What shipped:
 |---|---|
 | `src/web/vendor/snabbdomStyleModule.js` | vendored from snabbdom 3.6.2; two lines changed so `raf` resolves lazily |
 | `src/core/component/resolveComponentDefinition.js` | moved out of `createComponent.js`, off the patch's import graph |
-| `src/core/server/serializeVNode.js` | vnode → HTML, ~190 lines |
+| `src/core/server/serializeVNode.js` | namespace-aware vnode → HTML serializer |
 | `src/server/index.js` | the Node-safe entry |
+| `src/server/renderer.js` | recursive renderer + document wrapper (B1) |
+| `src/core/style/commonComponentStyles.js` | shared web/server shadow-root styles |
 | `src/web/componentDom.js` | render-target adoption hardened; inline styles no longer clobbered |
-| `package.json` | `./server` and `./parser` exports |
+| `package.json` | Node-safe `./server` export |
 
-Verification: **302 tests** in `@rettangoli/fe` (up from 237), **8/8** browser
-checks against real Chromium, package smoke test (pack → install → import), and
-`@rettangoli/ui` builds and passes its 260 tests against the modified
-framework. Full monorepo run matches the pre-change baseline exactly — the same
-four pre-existing failures in `rettangoli-be` / `rettangoli-tui` /
-`rettangoli-cli`, none touched by this work.
+Current verification: **378 tests** in `@rettangoli/fe`, including five HTML
+goldens, recursive parent/child output, deterministic cycle/depth failures, and
+schema-level `ssr: false` coverage. The package smoke test packs, installs, and
+imports the public server surface in bare Node. FE browser coverage now has
+eight VT specs across the `dashboard` and `interactions` examples in the
+`ci-ui.yaml` matrix.
 
 The headline result:
 
@@ -89,20 +95,15 @@ Node, gives the project HTML golden tests it currently has none of, and fixes
 three latent bugs.
 
 **Project B — SSR itself.**
-Recursive renderer, hydration, registration order, telemetry, parity gates.
-Larger, and a genuine product bet with an ongoing maintenance cost, because
-hydration mismatches fail silently rather than loudly.
+The recursive renderer (B1) now exists. Hydration, registration order,
+telemetry, parity gates, and app adoption remain. Those later stages are the
+genuine product bet with an ongoing maintenance cost, because hydration
+mismatches fail silently rather than loudly.
 
-**Recommendation: do A now, decide B separately.** A is finishing something
-already in progress — `src/core/**` is already pure and all DOM already lives
-in `src/web/`; the separation is simply unfinished, undone by one module-scope
-line. If B never happens, none of A is wasted. If B does happen, A is what
-makes it assembly rather than invention.
-
-**The trap to avoid** is doing B first. Writing the server renderer as a second
-copy of the component construction sequence, before extracting the shared core,
-makes the framework harder to maintain rather than better. Order matters more
-than scope here.
+The original sequencing recommendation was followed: A shipped before B1, so
+the renderer reuses the extracted definition/store/parser/serializer path
+instead of maintaining a second component-construction implementation. The
+remaining separate decision is whether to take on B2 and its parity gate.
 
 Sections below are tagged **[A]** or **[B]** accordingly.
 
@@ -531,6 +532,32 @@ Requirements, each verified by test:
 Resolves tag → component, runs the store, calls `parseView`, recurses into
 child components, emits per-component declarative shadow roots.
 
+**Implemented.** `renderComponent` takes a root tag and an explicit
+`components` registry. Registry values may be raw component configs, resolved
+definitions, or `{ componentConfig, deps }` registrations; arrays, objects,
+and Maps are accepted. No process-global registry or request state is used.
+
+The implementation mirrors the browser's first-render inputs:
+
+- schema-declared props only, including attribute fallback
+- setup/component constants through `resolveConstants`
+- `createInitialState` and `selectViewData` through `bindStore`
+- current i18n messages and locale service
+
+Registered child tags recurse. Unregistered custom elements remain ordinary
+markup. `ssr: false` emits a bare host without a shadow root or hydrate marker.
+Cycles report the complete tag path, and `maxDepth` (default 100) bounds
+acyclic recursion. Both failures throw deterministic errors so callers can
+choose their shell fallback explicitly.
+
+Each rendered component emits the shared shadow styles, its `.view.yaml`
+styles, and a marked `data-rtgl-render-target` inside
+`<template shadowrootmode="open">`. `renderDocument` wraps trusted renderer
+markup in a complete document while escaping title and document attributes.
+
+Still deliberately absent: DOM adoption, hydrating patch behavior,
+registration ordering, telemetry, or any other B2 behavior.
+
 ### 5.3 [B] A hydrating first patch — **required**
 
 Four things, not one. The line budget below covers the first only.
@@ -638,21 +665,19 @@ framework's contract stays at four inputs.
 Consistency here is not testable by inspection: a hydration mismatch is not an
 error. It re-renders and looks correct. The suite has to be the gate.
 
-Existing in the prototype's `ssr-poc/tests/` — 37 unit tests (1.4 s) plus 8
-browser checks. These should move into this package as the framework work
-lands:
+The prototype started with 37 unit tests plus 8 browser checks. Framework-side
+A/B1 coverage has now moved into this package: serializer cases, five HTML
+goldens (including nested parent/child shadow roots), Node/package smoke tests,
+schema opt-out coverage, repeated-render determinism, and stable cycle/depth
+failures.
 
-**`serialize.test.js` (20)** — escaping, raw-text elements, boolean attributes,
-props never emitted, class/style merging, void elements, injection cases.
+The remaining groups belong to B2/B4:
 
-**`invariants.test.js` (12)** — byte-identical output across repeated renders
-and under a shifted `Date.now`; every store imports and runs in bare Node; no
-`Math.random`/`Date.now` in any `selectViewData`; unique component names; zero
-render failures; one render target per shadow root; no `[object Object]`;
-balanced tags.
-
-**`ssr-hazards.test.js` (5)** — static scan for browser globals in the
-first-render path, with an allowlist so it fails on *new* offenders.
+- static first-render hazard scans for browser globals and
+  `Math.random`/`Date.now`, with an allowlist so new offenders fail loudly
+- consumer-wide invariants over every store/component, beyond the framework
+  fixtures now covered here
+- the rebuilt browser hydration/adoption parity gate below
 
 This catches what execution tests cannot. `globalThis.window?.innerWidth ?? FALLBACK`
 does not throw in Node — it silently returns a different value than the client.
@@ -696,40 +721,49 @@ The entire application integration:
 ```js
 import { renderComponent, renderDocument } from "@rettangoli/fe/server";
 
+// The build/prerender integration supplies the same component configs used by
+// the browser bundle. Raw configs, resolved definitions, and
+// { componentConfig, deps } registrations are accepted.
+import { components } from "./server-components.js";
+import { i18nRuntime } from "./server-i18n.js";
+
 const handler = async (req, res) => {
   const url = new URL(req.url, `http://${req.headers.host}`);
-  const env = {
-    platform: "web",
-    locale: url.searchParams.get("locale") ?? "en",
-    theme: "dark",
-    route: url.pathname,
-    query: Object.fromEntries(url.searchParams),
-  };
-
-  const { html, head } = await renderComponent({ component: "rvn-app", props: {}, env });
+  const { html, head } = renderComponent({
+    component: "rvn-app",
+    components,
+    i18nRuntime,
+    props: {
+      route: url.pathname,
+      query: Object.fromEntries(url.searchParams),
+    },
+  });
 
   res.writeHead(200, { "content-type": "text/html; charset=utf-8" });
-  res.end(renderDocument({ html, head, env, title: "Projects" }));
+  res.end(renderDocument({
+    html,
+    head,
+    lang: i18nRuntime.current(),
+    title: "Projects",
+  }));
 };
 ```
 
 No jsdom, no DOM shim, no headless browser, no per-request global state — safe
-to call concurrently. Measured: **~12 ms warm** (min 10.3, max 17.3 over 8
+to call concurrently. The prototype measured **~12 ms warm** (min 10.3, max 17.3 over 8
 requests), 7.7 KB out.
 
-`env` here is a **transport shape for the request**, not a new store input —
-§5.7 still forbids an ambient bag reaching stores. Its values land as follows:
-
-- `locale` — the one value the framework already threads into the store context
-- `platform`, `theme` — build-time constants, not per-request
-- `route`, `query` — passed to the **root component as props**, per §4.1
-
-Whatever the server passes here, the client must be given the same values.
+There is no `env` or `isSsr` input. Route/query values belong in declared root
+props, per §4.1. Platform/theme remain build-time or CSS concerns. Locale and
+messages come from the existing i18n runtime contract. Whatever the server
+passes as props/constants/i18n must also be present on the client's first
+render.
 
 The same `renderComponent` call serves build-time prerendering, so "static now,
-server later" stays one code path. A render failure should fall back to the
-plain `<rvn-app></rvn-app>` shell — degrading to what ships today, never taking
-the page down.
+server later" stays one code path. `renderComponent` surfaces contract,
+cycle, depth, and serialization errors; the consumer boundary should catch
+those and fall back to the plain `<rvn-app></rvn-app>` shell — degrading to
+what ships today, never taking the page down.
 
 ---
 
@@ -737,33 +771,32 @@ the page down.
 
 Each stage ships alone and is independently valuable.
 
-### Part A — framework hygiene (do this regardless)
+### Part A — framework hygiene (done)
 
-**Stage A1 — core/binding split (§5.0).** Move `resolveComponentDefinition`
-into `core/`, make the patch lazy, extract the construction sequence, thread
-the existing `componentDom` factories through. Plus the three latent bugs in
-§5.6.
+**Stage A1 — core/binding split (§5.0) — done.** `resolveComponentDefinition`
+lives in `core/`; the guarded vendored snabbdom style module keeps imports
+Node-safe; web-only construction lives behind the web binding.
 
 Exit: `node -e "import('@rettangoli/fe')"` succeeds. That one result unblocks
 every Node-side tool.
 
-**Stage A2 — serializer + exports (§5.1, §5.6).** Ship the vnode→HTML
-serializer with its unit suite, and add the `./server` / `./parser` export
-entries.
+**Stage A2 — serializer + exports (§5.1, §5.6) — done.** The vnode→HTML
+serializer, unit suite, `./server` entry, and HTML goldens are shipped. A
+separate `./parser` export was intentionally unnecessary because `renderView`
+owns the parser/helper dependencies.
 
-Exit: components render to HTML in bare Node, and the project has **HTML golden
-tests** — against 1,301 `.webp` pixel references and zero `.html` goldens
-today. Ships as a minor version bump of `@rettangoli/fe`, republished through
-`rtgl`.
+Exit met: components render to HTML in bare Node and the project has five
+readable `.html` goldens alongside its pixel references.
 
 **Stop here if SSR is not wanted.** Nothing above is wasted, no consumer
 changes, no ongoing maintenance commitment.
 
-### Part B — SSR (a separate decision)
+### Part B — SSR (B1 done; B2–B4 remain separate decisions)
 
-**Stage B1 — recursive renderer (§5.2).** Resolve tag → component, run the
-store, recurse, emit nested declarative shadow roots. Still no consumer
-changes; the output is testable on its own.
+**Stage B1 — recursive renderer (§5.2) — done.** Resolves tag → component, runs
+the store, recurses, emits nested declarative shadow roots, supports
+declarative opt-out, and guards cycles/depth. There are still no consumer
+changes; the output is covered by HTML goldens.
 
 **Stage B2 — hydration + ordering (§5.3–5.5).** Hydrating patch, topological
 registration, `defer-hydration`, `__rtglSsr` telemetry, parity gate in CI. This
@@ -875,33 +908,22 @@ the client.
 
 ## 10. Decisions
 
-### 10.0 Still open — blocking the start of work
+### 10.0 Still open
 
-Surfaced by the 26 Jul review. Everything else in this document is settled.
-
-**A. How to make the package importable in Node** (§5.0). Vendor snabbdom's
-style module — 113 lines, 2 of which touch `window`, verified working and keeps
-the API synchronous — or keep `.` browser-only and expose Node solely via
-`./server` / `./parser`. Blocks stage A1.
-
-**B. `rtgl-popover`** (§5.7, §9.1). Fix it in `@rettangoli/ui`, or accept CSR
+**`rtgl-popover`** (§5.7, §9.1). Fix it in `@rettangoli/ui`, or accept CSR
 fallback on the 13+ views containing one. Blocks stage B4, not earlier.
 
-**C. Accept that Part A is larger than first stated** (§5.0). HMR landed after
-the plan's evidence was gathered; the construction sequence now exists twice and
-both paths must move together. A is still worth doing — it is no longer
-"small".
+The former Node-import and Part-A-sizing decisions are resolved. The guarded
+vendored style module shipped, and both cold/HMR paths were kept behind the
+shared core contracts.
 
 ### 10.1 Settled
 
 Recorded so they are not relitigated.
 
-**0. Project A ships regardless; Project B is a separate decision.** See §1.1.
-A is finishing a separation the framework already began and is justified by
-Node-importability and HTML golden tests alone. B is a product bet with an
-ongoing maintenance cost. Do A first — writing the server renderer before
-extracting the core is the one sequencing mistake that makes the framework
-worse rather than better.
+**0. A shipped before B1; B2 remains a separate decision.** See §1.1. The
+sequencing constraint was satisfied. Hydration is where silent mismatch risk
+and the ongoing parity-gate commitment begin.
 
 **1. Time-to-interactive is out of scope.** This project delivers a correct
 first paint, not a faster boot. TTI work (bundle size, boot sequencing,

--- a/packages/rettangoli-fe/spec/schema-contract.spec.yaml
+++ b/packages/rettangoli-fe/spec/schema-contract.spec.yaml
@@ -24,6 +24,20 @@ in:
         type: object
 throws: attrsSchema is not supported
 ---
+case: accepts boolean ssr opt-out
+in:
+  - schema:
+      componentName: todo-item
+      ssr: false
+out: true
+---
+case: rejects non-boolean ssr opt-out
+in:
+  - schema:
+      componentName: todo-item
+      ssr: "false"
+throws: ssr must be a boolean
+---
 case: validates declared methods against exported method names
 in:
   - schema:

--- a/packages/rettangoli-fe/src/core/component/resolveComponentDefinition.js
+++ b/packages/rettangoli-fe/src/core/component/resolveComponentDefinition.js
@@ -41,6 +41,7 @@ export const resolveComponentDefinition = (
 
   return {
     elementName,
+    ssr: resolvedSchema.ssr !== false,
     propsSchema,
     propsSchemaKeys,
     template,

--- a/packages/rettangoli-fe/src/core/schema/validateSchemaContract.js
+++ b/packages/rettangoli-fe/src/core/schema/validateSchemaContract.js
@@ -11,6 +11,13 @@ export const validateSchemaContract = ({ schema, methodExports = [] }) => {
     throw new Error("attrsSchema is not supported.");
   }
 
+  if (
+    Object.prototype.hasOwnProperty.call(schema, "ssr")
+    && typeof schema.ssr !== "boolean"
+  ) {
+    throw new Error("ssr must be a boolean.");
+  }
+
   if (Object.prototype.hasOwnProperty.call(schema, "methods")) {
     const methodsSchema = schema.methods;
 

--- a/packages/rettangoli-fe/src/core/style/commonComponentStyles.js
+++ b/packages/rettangoli-fe/src/core/style/commonComponentStyles.js
@@ -1,0 +1,20 @@
+/**
+ * Styles installed in every Rettangoli component shadow root.
+ *
+ * Kept in core so the web binding and the server renderer emit the exact same
+ * rules. The server places them in a declarative-shadow-root <style>; the web
+ * binding installs them as a constructable stylesheet.
+ */
+export const COMMON_COMPONENT_STYLE_TEXT = `
+  a, a:link, a:visited, a:hover, a:active {
+    display: contents;
+    color: inherit;
+    text-decoration: none;
+    background: none;
+    border: none;
+    padding: 0;
+    margin: 0;
+    font: inherit;
+    cursor: pointer;
+  }
+`;

--- a/packages/rettangoli-fe/src/server/index.js
+++ b/packages/rettangoli-fe/src/server/index.js
@@ -5,13 +5,8 @@
  * in a plain Node process — for HTML golden tests, static analysis over real
  * rendered output, or a server renderer.
  *
- * This is Part A of the SSR plan (packages/rettangoli-fe/docs/ssr-plan.md, also
- * on GitHub): the pieces needed to render a component's markup outside a
- * browser. It deliberately does NOT include a recursive component renderer or
- * any hydration support — those are Part B and a separate decision.
- *
- * Child components serialize as empty custom-element tags, so this renders one
- * component's own template rather than a whole tree.
+ * This includes Parts A and B1 of the SSR plan: one-view serialization plus a
+ * recursive component renderer. Hydration remains deliberately out of scope.
  */
 
 import { parse as parseTemplate } from "jempl";
@@ -23,6 +18,7 @@ import { serializeVNode } from "../core/server/serializeVNode.js";
 export { serializeVNode } from "../core/server/serializeVNode.js";
 export { resolveComponentDefinition } from "../core/component/resolveComponentDefinition.js";
 export { bindStore } from "../core/runtime/store.js";
+export { renderComponent, renderDocument } from "./renderer.js";
 
 /**
  * Renders a component's template to an HTML string.

--- a/packages/rettangoli-fe/src/server/renderer.js
+++ b/packages/rettangoli-fe/src/server/renderer.js
@@ -1,0 +1,423 @@
+import { parse as parseTemplate } from "jempl";
+import { h } from "snabbdom/build/h.js";
+
+import { resolveComponentDefinition } from "../core/component/resolveComponentDefinition.js";
+import { bindStore } from "../core/runtime/store.js";
+import { resolveConstants } from "../core/runtime/constants.js";
+import { serializeVNode } from "../core/server/serializeVNode.js";
+import { COMMON_COMPONENT_STYLE_TEXT } from "../core/style/commonComponentStyles.js";
+import { yamlToCss } from "../core/style/yamlToCss.js";
+import { parseView } from "../parser.js";
+
+const HYDRATE_ATTRIBUTE = "data-rtgl-hydrate";
+const RENDER_TARGET_ATTRIBUTE = "data-rtgl-render-target";
+const DEFAULT_MAX_DEPTH = 100;
+const ATTRIBUTE_NAME = /^[a-zA-Z_:][-a-zA-Z0-9_:.]*$/;
+
+const hasOwn = (value, key) =>
+  Object.prototype.hasOwnProperty.call(value, key);
+
+const toKebabCase = (value) =>
+  value.replace(/([a-z0-9])([A-Z])/g, "$1-$2").toLowerCase();
+
+const tagFromSelector = (selector) =>
+  String(selector).split(/[.#]/)[0].toLowerCase();
+
+const isResolvedDefinition = (value) =>
+  value
+  && typeof value === "object"
+  && typeof value.elementName === "string"
+  && hasOwn(value, "template");
+
+const resolveRegistration = (value) => {
+  const registration = (
+    value
+    && typeof value === "object"
+    && (hasOwn(value, "componentConfig") || hasOwn(value, "definition"))
+  )
+    ? value
+    : { componentConfig: value };
+  const rawDefinition = registration.definition
+    ?? (isResolvedDefinition(registration.componentConfig)
+      ? registration.componentConfig
+      : resolveComponentDefinition(registration.componentConfig || {}));
+  const definition = {
+    ...rawDefinition,
+    propsSchemaKeys: rawDefinition.propsSchemaKeys || [],
+    ssr: rawDefinition.ssr !== false,
+  };
+
+  return {
+    definition,
+    deps: registration.deps || {},
+  };
+};
+
+const getRegistryValues = (components) => {
+  if (components instanceof Map) {
+    return [...components.values()];
+  }
+  if (Array.isArray(components)) {
+    return components;
+  }
+  if (components && typeof components === "object") {
+    return Object.values(components);
+  }
+  throw new Error(
+    "[renderComponent] `components` must be an array, object, or Map of component configs.",
+  );
+};
+
+const createRegistry = (components) => {
+  const registry = new Map();
+
+  for (const value of getRegistryValues(components)) {
+    const registration = resolveRegistration(value);
+    const elementName = registration.definition.elementName.toLowerCase();
+    if (registry.has(elementName)) {
+      throw new Error(
+        `[renderComponent] duplicate component definition for "${elementName}".`,
+      );
+    }
+    registry.set(elementName, registration);
+  }
+
+  return registry;
+};
+
+const clearHydrateAttribute = (attrs) => {
+  for (const name of Object.keys(attrs)) {
+    if (name.toLowerCase() === HYDRATE_ATTRIBUTE) {
+      delete attrs[name];
+    }
+  }
+};
+
+const setHydrateAttribute = (vnode, enabled) => {
+  const data = vnode.data || (vnode.data = {});
+  const attrs = data.attrs || (data.attrs = {});
+  clearHydrateAttribute(attrs);
+  if (enabled) {
+    attrs[HYDRATE_ATTRIBUTE] = "";
+  }
+};
+
+const readAttributeProp = (attrs, propName) => {
+  if (hasOwn(attrs, propName)) {
+    return attrs[propName] === "" ? true : attrs[propName];
+  }
+  const kebabName = toKebabCase(propName);
+  if (hasOwn(attrs, kebabName)) {
+    return attrs[kebabName] === "" ? true : attrs[kebabName];
+  }
+  return undefined;
+};
+
+/**
+ * Mirrors createPropsProxy: only schema-declared keys are visible, all declared
+ * keys are enumerable, property assignments win, and attributes are fallback
+ * values.
+ */
+const createServerProps = ({ definition, props, attrs }) => {
+  const sourceProps = props && typeof props === "object" ? props : {};
+  const sourceAttrs = attrs && typeof attrs === "object" ? attrs : {};
+
+  return Object.fromEntries(
+    definition.propsSchemaKeys.map((propName) => [
+      propName,
+      hasOwn(sourceProps, propName)
+        ? sourceProps[propName]
+        : readAttributeProp(sourceAttrs, propName),
+    ]),
+  );
+};
+
+const escapeDocumentText = (value) =>
+  String(value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+
+const escapeDocumentAttribute = (value) =>
+  escapeDocumentText(value).replace(/"/g, "&quot;");
+
+const attributesToString = (attributes, label) => {
+  if (!attributes || typeof attributes !== "object" || Array.isArray(attributes)) {
+    throw new Error(`[renderDocument] \`${label}\` must be an object.`);
+  }
+
+  return Object.entries(attributes)
+    .filter(([, value]) => value !== false && value !== null && value !== undefined)
+    .map(([name, value]) => {
+      if (!ATTRIBUTE_NAME.test(name)) {
+        throw new Error(
+          `[renderDocument] invalid ${label} name ${JSON.stringify(name)}.`,
+        );
+      }
+      return value === true || value === ""
+        ? ` ${name}=""`
+        : ` ${name}="${escapeDocumentAttribute(value)}"`;
+    })
+    .join("");
+};
+
+const assertMaxDepth = (maxDepth) => {
+  if (!Number.isInteger(maxDepth) || maxDepth < 1) {
+    throw new Error("[renderComponent] `maxDepth` must be a positive integer.");
+  }
+};
+
+const enterComponent = ({ elementName, path, maxDepth }) => {
+  if (path.includes(elementName)) {
+    throw new Error(
+      `[renderComponent] component cycle detected: ${[...path, elementName].join(" -> ")}.`,
+    );
+  }
+  const nextPath = [...path, elementName];
+  if (nextPath.length > maxDepth) {
+    throw new Error(
+      `[renderComponent] maximum component depth ${maxDepth} exceeded at ` +
+        `${nextPath.join(" -> ")}.`,
+    );
+  }
+  return nextPath;
+};
+
+const serializeChildren = (children, options) => {
+  if (!Array.isArray(children)) {
+    return "";
+  }
+  return children.map((child) => serializeVNode(child, options)).join("");
+};
+
+/**
+ * Renders a registered component tree to nested declarative shadow roots.
+ *
+ * `components` accepts raw component configs, resolved definitions, or
+ * `{ componentConfig, deps }` registrations. Arrays, plain objects, and Maps
+ * are supported so build tools can hand their existing registry shape through
+ * without installing global state.
+ */
+export const renderComponent = ({
+  component,
+  components,
+  props = {},
+  attributes = {},
+  constants = {},
+  i18n,
+  locale,
+  i18nRuntime,
+  maxDepth = DEFAULT_MAX_DEPTH,
+} = {}) => {
+  if (typeof component !== "string" || component.trim() === "") {
+    throw new Error("[renderComponent] `component` must be a component tag name.");
+  }
+  if (!attributes || typeof attributes !== "object" || Array.isArray(attributes)) {
+    throw new Error("[renderComponent] `attributes` must be an object.");
+  }
+  assertMaxDepth(maxDepth);
+
+  const registry = createRegistry(components);
+  const rootName = component.trim().toLowerCase();
+  const rootRegistration = registry.get(rootName);
+  if (!rootRegistration) {
+    throw new Error(`[renderComponent] unknown root component "${rootName}".`);
+  }
+
+  const substitutions = new WeakMap();
+  const serializerOptions = {
+    renderChildren: (vnode) => {
+      if (!substitutions.has(vnode)) {
+        return null;
+      }
+      const substitution = substitutions.get(vnode);
+      return substitution.shadowRoot
+        + (substitution.preserveLightDom
+          ? serializeChildren(vnode.children, serializerOptions)
+          : "");
+    },
+  };
+
+  const getRuntimeContext = (registration) => {
+    const runtime = i18nRuntime ?? registration.deps?.__rtglI18nRuntime;
+    const messages = i18n ?? runtime?.getMessages?.() ?? {};
+    return {
+      messages,
+      store: {
+        getI18n: () => messages,
+        locale: locale ?? runtime?.locale,
+      },
+    };
+  };
+
+  const renderShadowRoot = ({ registration, componentProps, path }) => {
+    const { definition } = registration;
+    const runtimeContext = getRuntimeContext(registration);
+    const resolvedConstants = resolveConstants({
+      setupConstants: {
+        ...(registration.deps?.constants || {}),
+        ...(constants || {}),
+      },
+      fileConstants: definition.constants,
+    });
+    const store = bindStore(
+      definition.store,
+      componentProps,
+      resolvedConstants,
+      runtimeContext.store,
+    );
+    const selectedViewData = store.selectViewData ? store.selectViewData() : {};
+    const template = typeof definition.template?.type === "number"
+      ? definition.template
+      : parseTemplate(definition.template);
+    const vnode = parseView({
+      h,
+      template,
+      viewData: {
+        ...(selectedViewData || {}),
+        i18n: runtimeContext.messages,
+      },
+      refs: definition.refs || {},
+      wireEventListeners: false,
+    });
+
+    const data = vnode.data || (vnode.data = {});
+    const attrs = data.attrs || (data.attrs = {});
+    attrs[RENDER_TARGET_ATTRIBUTE] = "";
+
+    prepareTree(vnode, path);
+
+    const componentCss = yamlToCss(definition.elementName, definition.styles);
+    const cssText = componentCss
+      ? `${COMMON_COMPONENT_STYLE_TEXT}\n${componentCss}`
+      : COMMON_COMPONENT_STYLE_TEXT;
+    const style = serializeVNode(h("style", cssText));
+    const view = serializeVNode(vnode, serializerOptions);
+    return `<template shadowrootmode="open">${style}${view}</template>`;
+  };
+
+  const prepareTree = (vnode, path) => {
+    if (!vnode || vnode.sel === undefined || vnode.sel === "!") {
+      return;
+    }
+
+    const tag = tagFromSelector(vnode.sel);
+    const registration = vnode.data?.ns === undefined
+      ? registry.get(tag)
+      : undefined;
+
+    if (registration) {
+      const { definition } = registration;
+      setHydrateAttribute(vnode, definition.ssr);
+
+      if (!definition.ssr) {
+        substitutions.set(vnode, {
+          preserveLightDom: false,
+          shadowRoot: "",
+        });
+        return;
+      }
+
+      const childPath = enterComponent({
+        elementName: definition.elementName.toLowerCase(),
+        path,
+        maxDepth,
+      });
+      const childProps = createServerProps({
+        definition,
+        props: vnode.data?.props,
+        attrs: vnode.data?.attrs,
+      });
+      const shadowRoot = renderShadowRoot({
+        registration,
+        componentProps: childProps,
+        path: childPath,
+      });
+      substitutions.set(vnode, {
+        preserveLightDom: true,
+        shadowRoot,
+      });
+
+      for (const child of vnode.children || []) {
+        prepareTree(child, childPath);
+      }
+      return;
+    }
+
+    for (const child of vnode.children || []) {
+      prepareTree(child, path);
+    }
+  };
+
+  const rootAttributes = { ...attributes };
+  clearHydrateAttribute(rootAttributes);
+  if (!rootRegistration.definition.ssr) {
+    return {
+      head: "",
+      html: serializeVNode(h(rootName, { attrs: rootAttributes }, [])),
+    };
+  }
+
+  rootAttributes[HYDRATE_ATTRIBUTE] = "";
+  const rootPath = enterComponent({
+    elementName: rootName,
+    path: [],
+    maxDepth,
+  });
+  const rootProps = createServerProps({
+    definition: rootRegistration.definition,
+    props,
+    attrs: rootAttributes,
+  });
+  const shadowRoot = renderShadowRoot({
+    registration: rootRegistration,
+    componentProps: rootProps,
+    path: rootPath,
+  });
+  const html = serializeVNode(
+    h(rootName, { attrs: rootAttributes }, []),
+    { renderChildren: () => shadowRoot },
+  );
+
+  return { head: "", html };
+};
+
+/**
+ * Wraps trusted renderer output in a complete HTML document.
+ *
+ * `html` and `head` are markup by design. Text and attribute fields are
+ * escaped here; callers must only pass trusted, already-serialized markup in
+ * the two raw slots.
+ */
+export const renderDocument = ({
+  html,
+  head = "",
+  title,
+  lang,
+  htmlAttributes = {},
+  bodyAttributes = {},
+} = {}) => {
+  if (typeof html !== "string") {
+    throw new Error("[renderDocument] `html` must be a string.");
+  }
+  if (typeof head !== "string") {
+    throw new Error("[renderDocument] `head` must be a string.");
+  }
+
+  const resolvedHtmlAttributes = { ...htmlAttributes };
+  if (lang !== undefined) {
+    resolvedHtmlAttributes.lang = lang;
+  }
+  const htmlAttrs = attributesToString(
+    resolvedHtmlAttributes,
+    "htmlAttributes",
+  );
+  const bodyAttrs = attributesToString(bodyAttributes, "bodyAttributes");
+  const titleMarkup = title === undefined
+    ? ""
+    : `<title>${escapeDocumentText(title)}</title>`;
+
+  return "<!doctype html>"
+    + `<html${htmlAttrs}><head><meta charset="utf-8">${titleMarkup}${head}</head>`
+    + `<body${bodyAttrs}>${html}</body></html>`;
+};

--- a/packages/rettangoli-fe/src/server/renderer.js
+++ b/packages/rettangoli-fe/src/server/renderer.js
@@ -103,12 +103,30 @@ const setHydrateAttribute = (vnode, enabled) => {
 };
 
 const readAttributeProp = (attrs, propName) => {
-  if (hasOwn(attrs, propName)) {
-    return attrs[propName] === "" ? true : attrs[propName];
+  const read = (name) => {
+    if (!hasOwn(attrs, name)) {
+      return { present: false };
+    }
+
+    const value = attrs[name];
+    if (value === false || value === null || value === undefined) {
+      return { present: false };
+    }
+    if (value === true || value === "") {
+      return { present: true, value: true };
+    }
+    return { present: true, value: String(value) };
+  };
+
+  const direct = read(propName);
+  if (direct.present) {
+    return direct.value;
   }
+
   const kebabName = toKebabCase(propName);
-  if (hasOwn(attrs, kebabName)) {
-    return attrs[kebabName] === "" ? true : attrs[kebabName];
+  const kebab = read(kebabName);
+  if (kebab.present) {
+    return kebab.value;
   }
   return undefined;
 };
@@ -190,6 +208,16 @@ const serializeChildren = (children, options) => {
   return children.map((child) => serializeVNode(child, options)).join("");
 };
 
+const serializeLightDom = (vnode, options) => {
+  if (Array.isArray(vnode.children) && vnode.children.length > 0) {
+    return serializeChildren(vnode.children, options);
+  }
+  if (vnode.text !== undefined && vnode.text !== null) {
+    return serializeVNode({ text: vnode.text }, options);
+  }
+  return "";
+};
+
 /**
  * Renders a registered component tree to nested declarative shadow roots.
  *
@@ -233,7 +261,7 @@ export const renderComponent = ({
       const substitution = substitutions.get(vnode);
       return substitution.shadowRoot
         + (substitution.preserveLightDom
-          ? serializeChildren(vnode.children, serializerOptions)
+          ? serializeLightDom(vnode, serializerOptions)
           : "");
     },
   };

--- a/packages/rettangoli-fe/src/web/componentDom.js
+++ b/packages/rettangoli-fe/src/web/componentDom.js
@@ -1,18 +1,5 @@
 import { getNativeHostStyle } from "../core/runtime/props.js";
-
-const COMMON_LINK_STYLE_TEXT = `
-  a, a:link, a:visited, a:hover, a:active {
-    display: contents;
-    color: inherit;
-    text-decoration: none;
-    background: none;
-    border: none;
-    padding: 0;
-    margin: 0;
-    font: inherit;
-    cursor: pointer;
-  }
-`;
+import { COMMON_COMPONENT_STYLE_TEXT } from "../core/style/commonComponentStyles.js";
 
 const RENDER_TARGET_ATTR = "data-rtgl-render-target";
 const RENDER_TARGET_FLAG = "__rtglRenderTarget";
@@ -101,7 +88,7 @@ export const initializeComponentDom = ({
   const shadow = existingShadow ?? host.attachShadow({ mode: "open" });
 
   const commonStyleSheet = createStyleSheet();
-  commonStyleSheet.replaceSync(COMMON_LINK_STYLE_TEXT);
+  commonStyleSheet.replaceSync(COMMON_COMPONENT_STYLE_TEXT);
 
   const adoptedStyleSheets = [commonStyleSheet];
 

--- a/packages/rettangoli-fe/test/package-smoke-test.js
+++ b/packages/rettangoli-fe/test/package-smoke-test.js
@@ -133,6 +133,8 @@ try {
       assert.equal(typeof cli.build, "function");
       assert.equal(typeof cli.watch, "function");
       assert.equal(typeof server.renderView, "function");
+      assert.equal(typeof server.renderComponent, "function");
+      assert.equal(typeof server.renderDocument, "function");
       assert.equal(typeof server.serializeVNode, "function");
       assert.equal(typeof server.bindStore, "function");
       assert.match(require.resolve("@rettangoli/fe"), /src\\/index\\.js$/);
@@ -144,6 +146,28 @@ try {
       assert.equal(
         server.renderView({ template: [{ "p.x": "\${msg}" }], viewData: { msg: "ok" } }),
         '<div style="display: contents"><p class="x">ok</p></div>',
+      );
+
+      const componentConfig = {
+        schema: {
+          componentName: "x-smoke",
+          propsSchema: { type: "object", properties: { message: {} } },
+        },
+        view: { template: [{ p: "\${message}" }], refs: {}, styles: {} },
+        store: {
+          selectViewData: ({ props }) => ({ message: props.message }),
+        },
+      };
+      const rendered = server.renderComponent({
+        component: "x-smoke",
+        components: [componentConfig],
+        props: { message: "recursive ok" },
+      });
+      assert.match(rendered.html, /shadowrootmode="open"/);
+      assert.match(rendered.html, /<p>recursive ok<\\/p>/);
+      assert.match(
+        server.renderDocument({ ...rendered, title: "Smoke" }),
+        /^<!doctype html><html><head>/,
       );
     `,
   );

--- a/packages/rettangoli-fe/test/server/__goldens__/recursive-parent-child.html
+++ b/packages/rettangoli-fe/test/server/__goldens__/recursive-parent-child.html
@@ -1,0 +1,28 @@
+<x-parent data-rtgl-hydrate=""><template shadowrootmode="open"><style>
+  a, a:link, a:visited, a:hover, a:active {
+    display: contents;
+    color: inherit;
+    text-decoration: none;
+    background: none;
+    border: none;
+    padding: 0;
+    margin: 0;
+    font: inherit;
+    cursor: pointer;
+  }
+</style><div data-rtgl-render-target="" style="display: contents"><section><h1>Hello SSR</h1><x-child data-rtgl-hydrate=""><template shadowrootmode="open"><style>
+  a, a:link, a:visited, a:hover, a:active {
+    display: contents;
+    color: inherit;
+    text-decoration: none;
+    background: none;
+    border: none;
+    padding: 0;
+    margin: 0;
+    font: inherit;
+    cursor: pointer;
+  }
+
+:host {
+  display: block;
+}</style><div data-rtgl-render-target="" style="display: contents"><p>nested</p></div></template></x-child></section></div></template></x-parent>

--- a/packages/rettangoli-fe/test/server/node-environment.test.js
+++ b/packages/rettangoli-fe/test/server/node-environment.test.js
@@ -26,6 +26,8 @@ describe("node environment", () => {
   it("imports the server entry without a DOM", async () => {
     const mod = await import("../../src/server/index.js");
     expect(typeof mod.renderView).toBe("function");
+    expect(typeof mod.renderComponent).toBe("function");
+    expect(typeof mod.renderDocument).toBe("function");
     expect(typeof mod.serializeVNode).toBe("function");
     expect(typeof mod.bindStore).toBe("function");
     expect(typeof mod.resolveComponentDefinition).toBe("function");
@@ -69,7 +71,10 @@ describe("package exports map", () => {
   // a consumer bind a different jempl version than it hoisted.
   it.each([
     ["@rettangoli/fe", ["createComponent"]],
-    ["@rettangoli/fe/server", ["renderView", "serializeVNode", "bindStore"]],
+    [
+      "@rettangoli/fe/server",
+      ["renderView", "renderComponent", "renderDocument", "serializeVNode", "bindStore"],
+    ],
     ["@rettangoli/fe/contracts", []],
   ])("resolves %s", async (specifier, expectedExports) => {
     const mod = await import(specifier);

--- a/packages/rettangoli-fe/test/server/recursive-renderer.test.js
+++ b/packages/rettangoli-fe/test/server/recursive-renderer.test.js
@@ -1,0 +1,361 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  renderComponent,
+  renderDocument,
+  resolveComponentDefinition,
+} from "../../src/server/index.js";
+
+const GOLDEN_DIR = path.join(import.meta.dirname, "__goldens__");
+
+const defineComponent = ({
+  name,
+  template,
+  props = {},
+  store = {},
+  constants = {},
+  styles,
+  refs = {},
+  ssr,
+}) => ({
+  constants,
+  handlers: {},
+  methods: {},
+  schema: {
+    componentName: name,
+    propsSchema: {
+      type: "object",
+      properties: props,
+    },
+    ...(ssr === undefined ? {} : { ssr }),
+  },
+  store,
+  view: { refs, styles, template },
+});
+
+const parentComponent = defineComponent({
+  name: "x-parent",
+  props: { greeting: {} },
+  template: [
+    {
+      section: [
+        { h1: "${heading}" },
+        { "x-child :label=${childLabel}": "" },
+      ],
+    },
+  ],
+  store: {
+    selectViewData: ({ props, constants, i18n }) => ({
+      childLabel: { text: constants.childText },
+      heading: `${props.greeting} ${i18n.title}`,
+    }),
+  },
+});
+
+const childComponent = defineComponent({
+  name: "x-child",
+  props: { label: {} },
+  styles: {
+    ":host": {
+      display: "block",
+    },
+  },
+  store: {
+    selectViewData: ({ props }) => ({
+      text: props.label.text,
+    }),
+  },
+  template: [{ p: "${text}" }],
+});
+
+const renderParentChild = () =>
+  renderComponent({
+    component: "x-parent",
+    components: [parentComponent, childComponent],
+    constants: { childText: "nested" },
+    i18n: { title: "SSR" },
+    props: { greeting: "Hello" },
+  });
+
+describe("recursive server renderer", () => {
+  it("matches the nested parent/child declarative-shadow-root golden", () => {
+    const { head, html } = renderParentChild();
+    const expected = readFileSync(
+      path.join(GOLDEN_DIR, "recursive-parent-child.html"),
+      "utf8",
+    ).trimEnd();
+
+    expect(head).toBe("");
+    expect(html).toBe(expected);
+    expect(html.match(/shadowrootmode="open"/g)).toHaveLength(2);
+    expect(html.match(/data-rtgl-render-target=""/g)).toHaveLength(2);
+    expect(html).toContain("<h1>Hello SSR</h1>");
+    expect(html).toContain("<p>nested</p>");
+    // Object-valued property bindings feed the child but never leak into HTML.
+    expect(html).not.toContain("[object Object]");
+    expect(html).not.toContain("label=");
+  });
+
+  it("is byte-identical across repeated recursive renders", () => {
+    expect(renderParentChild()).toEqual(renderParentChild());
+  });
+
+  it("accepts resolved definitions and object registries", () => {
+    const resolvedParent = resolveComponentDefinition(parentComponent);
+    const resolvedChild = resolveComponentDefinition(childComponent);
+
+    const result = renderComponent({
+      component: "x-parent",
+      components: {
+        parent: { definition: resolvedParent },
+        child: { definition: resolvedChild },
+      },
+      constants: { childText: "nested" },
+      i18n: { title: "SSR" },
+      props: { greeting: "Hello" },
+    });
+
+    expect(result).toEqual(renderParentChild());
+  });
+
+  it("leaves unregistered custom elements as ordinary markup", () => {
+    const root = defineComponent({
+      name: "x-root",
+      template: [{ "third-party-widget :payload=${payload}": [{ span: "light" }] }],
+      store: {
+        selectViewData: () => ({ payload: { private: true } }),
+      },
+    });
+
+    const { html } = renderComponent({
+      component: "x-root",
+      components: [root],
+    });
+    expect(html).toContain(
+      "<third-party-widget><span>light</span></third-party-widget>",
+    );
+    expect(html).not.toContain("[object Object]");
+  });
+
+  it("does not construct client action listeners while recursively rendering", () => {
+    const root = defineComponent({
+      name: "x-root",
+      refs: {
+        saveButton: {
+          eventListeners: {
+            click: { action: "save" },
+          },
+        },
+      },
+      template: [{ "button#saveButton": "Save" }],
+    });
+
+    const { html } = renderComponent({
+      component: "x-root",
+      components: [root],
+    });
+    expect(html).toContain('<button id="saveButton">Save</button>');
+    expect(html).not.toMatch(/\son[a-z]+=/);
+  });
+
+  it("uses root attributes as schema-prop fallbacks", () => {
+    const root = defineComponent({
+      name: "x-root",
+      props: { displayLabel: {} },
+      store: {
+        selectViewData: ({ props }) => ({ label: props.displayLabel }),
+      },
+      template: [{ p: "${label}" }],
+    });
+
+    const { html } = renderComponent({
+      component: "x-root",
+      components: [root],
+      attributes: { "display-label": "From attribute" },
+    });
+    expect(html).toContain("<p>From attribute</p>");
+  });
+
+  it("only resolves component tags in the HTML namespace", () => {
+    const root = defineComponent({
+      name: "x-root",
+      template: [
+        { svg: [{ "x-leaf": "" }] },
+        { "x-leaf": "" },
+      ],
+    });
+    const leaf = defineComponent({
+      name: "x-leaf",
+      template: [{ p: "HTML leaf" }],
+    });
+
+    const { html } = renderComponent({
+      component: "x-root",
+      components: [root, leaf],
+    });
+    expect(html).toContain("<svg><x-leaf></x-leaf></svg>");
+    expect(html.match(/shadowrootmode="open"/g)).toHaveLength(2);
+    expect(html.match(/<p>HTML leaf<\/p>/g)).toHaveLength(1);
+  });
+
+  it("renders ssr:false components as bare, unmarked hosts without running their store", () => {
+    const clientOnly = defineComponent({
+      name: "x-client-only",
+      ssr: false,
+      template: [{ p: "never rendered" }],
+      store: {
+        createInitialState: () => {
+          throw new Error("client-only store ran");
+        },
+      },
+    });
+    const root = defineComponent({
+      name: "x-root",
+      template: [
+        {
+          "x-client-only data-rtgl-hydrate=forged": [
+            { span: "also omitted" },
+          ],
+        },
+      ],
+    });
+
+    const { html } = renderComponent({
+      component: "x-root",
+      components: [root, clientOnly],
+    });
+    expect(html).toContain("<x-client-only></x-client-only>");
+    expect(html).not.toContain("never rendered");
+    expect(html).not.toContain("also omitted");
+    expect(html.match(/data-rtgl-hydrate=""/g)).toHaveLength(1);
+  });
+
+  it("renders an ssr:false root as a bare host", () => {
+    const clientOnly = defineComponent({
+      name: "x-client-only",
+      ssr: false,
+      template: [{ p: "never rendered" }],
+    });
+
+    expect(
+      renderComponent({
+        component: "x-client-only",
+        components: [clientOnly],
+        attributes: {
+          id: "editor",
+          "data-rtgl-hydrate": "forged",
+        },
+      }),
+    ).toEqual({
+      head: "",
+      html: '<x-client-only id="editor"></x-client-only>',
+    });
+  });
+
+  it("fails deterministically on a component cycle", () => {
+    const a = defineComponent({
+      name: "x-a",
+      template: [{ "x-b": "" }],
+    });
+    const b = defineComponent({
+      name: "x-b",
+      template: [{ "x-a": "" }],
+    });
+    const render = () =>
+      renderComponent({
+        component: "x-a",
+        components: [a, b],
+      });
+
+    expect(render).toThrow(
+      "[renderComponent] component cycle detected: x-a -> x-b -> x-a.",
+    );
+    expect(render).toThrow(
+      "[renderComponent] component cycle detected: x-a -> x-b -> x-a.",
+    );
+  });
+
+  it("fails deterministically when maxDepth is exceeded", () => {
+    const a = defineComponent({
+      name: "x-a",
+      template: [{ "x-b": "" }],
+    });
+    const b = defineComponent({
+      name: "x-b",
+      template: [{ "x-c": "" }],
+    });
+    const c = defineComponent({
+      name: "x-c",
+      template: [{ p: "deep" }],
+    });
+
+    expect(() =>
+      renderComponent({
+        component: "x-a",
+        components: [a, b, c],
+        maxDepth: 2,
+      }),
+    ).toThrow(
+      "[renderComponent] maximum component depth 2 exceeded at x-a -> x-b -> x-c.",
+    );
+  });
+
+  it("validates registry and depth inputs with stable errors", () => {
+    expect(() =>
+      renderComponent({ component: "x-a" }),
+    ).toThrow("`components` must be an array, object, or Map");
+    expect(() =>
+      renderComponent({
+        component: "x-missing",
+        components: [parentComponent],
+      }),
+    ).toThrow('unknown root component "x-missing"');
+    expect(() =>
+      renderComponent({
+        component: "x-parent",
+        components: [parentComponent, parentComponent],
+      }),
+    ).toThrow('duplicate component definition for "x-parent"');
+    expect(() =>
+      renderComponent({
+        component: "x-parent",
+        components: [parentComponent],
+        maxDepth: 0,
+      }),
+    ).toThrow("`maxDepth` must be a positive integer");
+  });
+});
+
+describe("renderDocument", () => {
+  it("wraps trusted markup and escapes document metadata", () => {
+    const document = renderDocument({
+      html: "<x-root></x-root>",
+      head: '<link rel="stylesheet" href="/app.css">',
+      title: "A < B & C",
+      lang: 'en" data-forged="yes',
+      htmlAttributes: { dir: "ltr" },
+      bodyAttributes: { class: "app", hidden: true },
+    });
+
+    expect(document).toBe(
+      "<!doctype html>"
+      + '<html dir="ltr" lang="en&quot; data-forged=&quot;yes">'
+      + '<head><meta charset="utf-8"><title>A &lt; B &amp; C</title>'
+      + '<link rel="stylesheet" href="/app.css"></head>'
+      + '<body class="app" hidden=""><x-root></x-root></body></html>',
+    );
+  });
+
+  it("requires serialized HTML and validates document attribute names", () => {
+    expect(() => renderDocument()).toThrow("`html` must be a string");
+    expect(() =>
+      renderDocument({
+        html: "",
+        bodyAttributes: { "bad name": "x" },
+      }),
+    ).toThrow('invalid bodyAttributes name "bad name"');
+  });
+});

--- a/packages/rettangoli-fe/test/server/recursive-renderer.test.js
+++ b/packages/rettangoli-fe/test/server/recursive-renderer.test.js
@@ -179,6 +179,52 @@ describe("recursive server renderer", () => {
     expect(html).toContain("<p>From attribute</p>");
   });
 
+  it("normalizes root attribute fallbacks to their DOM values", () => {
+    const root = defineComponent({
+      name: "x-root",
+      props: { count: {}, disabled: {}, enabled: {} },
+      store: {
+        selectViewData: ({ props }) => ({
+          snapshot: [
+            `${typeof props.count}:${props.count}`,
+            `${typeof props.disabled}:${props.disabled}`,
+            `${typeof props.enabled}:${props.enabled}`,
+          ].join("|"),
+        }),
+      },
+      template: [{ p: "${snapshot}" }],
+    });
+
+    const { html } = renderComponent({
+      component: "x-root",
+      components: [root],
+      attributes: { count: 0, disabled: false, enabled: true },
+    });
+
+    expect(html).toContain(
+      "<p>string:0|undefined:undefined|boolean:true</p>",
+    );
+  });
+
+  it("preserves text light-DOM content when recursing into a child", () => {
+    const child = defineComponent({
+      name: "x-child",
+      template: [{ slot: "" }],
+    });
+    const root = defineComponent({
+      name: "x-root",
+      template: [{ "x-child": "Hello from light DOM" }],
+    });
+
+    const { html } = renderComponent({
+      component: "x-root",
+      components: [root, child],
+    });
+
+    expect(html).toContain("<slot></slot>");
+    expect(html).toContain("</template>Hello from light DOM</x-child>");
+  });
+
   it("only resolves component tags in the HTML namespace", () => {
     const root = defineComponent({
       name: "x-root",


### PR DESCRIPTION
## Summary

- add Node-safe `renderComponent` and `renderDocument` exports for recursive component-tree rendering
- resolve registered child tags and emit per-component declarative shadow roots with shared browser/server styles
- mirror schema props, attribute fallback, constants, store selectors, and i18n inputs without constructing client event listeners
- add declarative `ssr: false` opt-out plus deterministic cycle and maximum-depth failures
- update the FE schema contract, roadmap, and SSR implementation status

This completes SSR Stage B1 only. Hydration, client DOM adoption, registration ordering, and telemetry remain intentionally out of scope.

## Tests

- `npm test` — 25 files, 378/378 tests passed
- `npx vitest run test/server/recursive-renderer.test.js --reporter=verbose` — 14/14 focused renderer tests passed
- `npm run test:package` — packed, installed, imported, and executed the public recursive server API successfully

Focused coverage includes nested parent/child HTML goldens, typed property flow, root attribute fallback, constants/i18n, action-listener suppression, HTML-vs-SVG namespace handling, unknown custom elements, registry shapes, `ssr: false`, deterministic cycles/depth limits, document escaping, Node imports, and packed-package exports.