### PR TITLE
fix(fe): reload incompatible watch updates

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -41,7 +41,7 @@
     },
     "packages/rettangoli-cli": {
       "name": "rtgl",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "bin": {
         "rtgl": "cli.js",
       },
@@ -58,7 +58,7 @@
     },
     "packages/rettangoli-fe": {
       "name": "@rettangoli/fe",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "dependencies": {
         "immer": "^10.1.1",
         "jempl": "1.0.1",
@@ -1043,6 +1043,8 @@
     "@rettangoli/tui/puty": ["puty@0.1.2", "", { "dependencies": { "js-yaml": "~4.1.0" }, "peerDependencies": { "vitest": ">=1.0.0" } }, "sha512-VNEwqORf0u/LiVdjyHPsIOKWC5z4uNuHhMgYu9WGea6u3YCP4OimQHQfWkw0DB/tE3KuWgPO0dhkM8uH4Yweig=="],
 
     "@rettangoli/tui/vite": ["vite@6.3.5", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ=="],
+
+    "@rettangoli/ui/@rettangoli/fe": ["@rettangoli/fe@1.4.0", "", { "dependencies": { "immer": "^10.1.1", "jempl": "1.0.1", "js-yaml": "^4.1.0", "snabbdom": "^3.6.2", "vite": "^8.1.4" } }, "sha512-yPXRJW28EJtIlYkXpi7dR1JxmqOOasZCgsZE9d59HUw+d0XiEWYn4qLZ30t2sSVqSWpbsz472VVeQEoi5Kz9nw=="],
 
     "@rettangoli/ui/esbuild": ["esbuild@0.20.2", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.20.2", "@esbuild/android-arm": "0.20.2", "@esbuild/android-arm64": "0.20.2", "@esbuild/android-x64": "0.20.2", "@esbuild/darwin-arm64": "0.20.2", "@esbuild/darwin-x64": "0.20.2", "@esbuild/freebsd-arm64": "0.20.2", "@esbuild/freebsd-x64": "0.20.2", "@esbuild/linux-arm": "0.20.2", "@esbuild/linux-arm64": "0.20.2", "@esbuild/linux-ia32": "0.20.2", "@esbuild/linux-loong64": "0.20.2", "@esbuild/linux-mips64el": "0.20.2", "@esbuild/linux-ppc64": "0.20.2", "@esbuild/linux-riscv64": "0.20.2", "@esbuild/linux-s390x": "0.20.2", "@esbuild/linux-x64": "0.20.2", "@esbuild/netbsd-x64": "0.20.2", "@esbuild/openbsd-x64": "0.20.2", "@esbuild/sunos-x64": "0.20.2", "@esbuild/win32-arm64": "0.20.2", "@esbuild/win32-ia32": "0.20.2", "@esbuild/win32-x64": "0.20.2" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-WdOOppmUNU+IbZ0PaDiTst80zjnrOkyJNHoKupIcVyU8Lvla3Ugx94VzkQ32Ijqd7UhHJy75gNWDMUekcrSJ6g=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -117,7 +117,7 @@
       "name": "@rettangoli/ui",
       "version": "1.16.0",
       "dependencies": {
-        "@rettangoli/fe": "1.4.0",
+        "@rettangoli/fe": "1.4.1",
         "jempl": "1.0.1",
       },
       "devDependencies": {
@@ -1043,8 +1043,6 @@
     "@rettangoli/tui/puty": ["puty@0.1.2", "", { "dependencies": { "js-yaml": "~4.1.0" }, "peerDependencies": { "vitest": ">=1.0.0" } }, "sha512-VNEwqORf0u/LiVdjyHPsIOKWC5z4uNuHhMgYu9WGea6u3YCP4OimQHQfWkw0DB/tE3KuWgPO0dhkM8uH4Yweig=="],
 
     "@rettangoli/tui/vite": ["vite@6.3.5", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ=="],
-
-    "@rettangoli/ui/@rettangoli/fe": ["@rettangoli/fe@1.4.0", "", { "dependencies": { "immer": "^10.1.1", "jempl": "1.0.1", "js-yaml": "^4.1.0", "snabbdom": "^3.6.2", "vite": "^8.1.4" } }, "sha512-yPXRJW28EJtIlYkXpi7dR1JxmqOOasZCgsZE9d59HUw+d0XiEWYn4qLZ30t2sSVqSWpbsz472VVeQEoi5Kz9nw=="],
 
     "@rettangoli/ui/esbuild": ["esbuild@0.20.2", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.20.2", "@esbuild/android-arm": "0.20.2", "@esbuild/android-arm64": "0.20.2", "@esbuild/android-x64": "0.20.2", "@esbuild/darwin-arm64": "0.20.2", "@esbuild/darwin-x64": "0.20.2", "@esbuild/freebsd-arm64": "0.20.2", "@esbuild/freebsd-x64": "0.20.2", "@esbuild/linux-arm": "0.20.2", "@esbuild/linux-arm64": "0.20.2", "@esbuild/linux-ia32": "0.20.2", "@esbuild/linux-loong64": "0.20.2", "@esbuild/linux-mips64el": "0.20.2", "@esbuild/linux-ppc64": "0.20.2", "@esbuild/linux-riscv64": "0.20.2", "@esbuild/linux-s390x": "0.20.2", "@esbuild/linux-x64": "0.20.2", "@esbuild/netbsd-x64": "0.20.2", "@esbuild/openbsd-x64": "0.20.2", "@esbuild/sunos-x64": "0.20.2", "@esbuild/win32-arm64": "0.20.2", "@esbuild/win32-ia32": "0.20.2", "@esbuild/win32-x64": "0.20.2" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-WdOOppmUNU+IbZ0PaDiTst80zjnrOkyJNHoKupIcVyU8Lvla3Ugx94VzkQ32Ijqd7UhHJy75gNWDMUekcrSJ6g=="],
 

--- a/packages/rettangoli-cli/package.json
+++ b/packages/rettangoli-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rtgl",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "CLI tool for Rettangoli - A frontend framework and development toolkit",
   "type": "module",
   "bin": {
@@ -51,7 +51,7 @@
     "js-yaml": "^4.1.0",
     "@rettangoli/check": "0.1.6",
     "@rettangoli/be": "2.0.0",
-    "@rettangoli/fe": "1.4.0",
+    "@rettangoli/fe": "1.4.1",
     "@rettangoli/sites": "1.3.0",
     "@rettangoli/vt": "1.1.0",
     "@rettangoli/ui": "1.16.0"

--- a/packages/rettangoli-fe/package.json
+++ b/packages/rettangoli-fe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rettangoli/fe",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Frontend framework for building reactive web components",
   "type": "module",
   "main": "./src/index.js",

--- a/packages/rettangoli-fe/src/cli/vitePlugin.js
+++ b/packages/rettangoli-fe/src/cli/vitePlugin.js
@@ -29,6 +29,14 @@ const normalizePublicEntryPath = (value) => {
   return normalized.startsWith("/") ? normalized : `/${normalized}`;
 };
 
+export const resolveTransformEntryId = ({ publicEntryPath, servedEntryId }) => {
+  const normalizedPublicEntryPath = normalizePublicEntryPath(publicEntryPath);
+  return servedEntryId === RETTANGOLI_FE_VIRTUAL_ENTRY_ID &&
+    normalizedPublicEntryPath
+    ? normalizedPublicEntryPath
+    : servedEntryId;
+};
+
 const resolveModuleFilePath = (module) => {
   const value = module?.file || module?.id;
   if (typeof value !== "string" || value.startsWith("\0")) {
@@ -65,6 +73,13 @@ export const createRettangoliFeVitePlugin = ({
   const resolvedDirs = dirs.map((directory) => path.resolve(cwd, directory));
   const resolvedSetup = path.resolve(cwd, setup);
   const normalizedPublicEntryPath = normalizePublicEntryPath(publicEntryPath);
+  const transformEntryId = resolveTransformEntryId({
+    publicEntryPath: normalizedPublicEntryPath,
+    servedEntryId,
+  });
+  const resolvesPublicEntryToVirtualModule =
+    servedEntryId === RETTANGOLI_FE_VIRTUAL_ENTRY_ID &&
+    transformEntryId === normalizedPublicEntryPath;
   const i18nContext = loadI18nBuildContext({ cwd, i18n, errorPrefix });
 
   let currentCommand = "build";
@@ -173,7 +188,10 @@ export const createRettangoliFeVitePlugin = ({
       currentCommand = config.command;
     },
     resolveId(id) {
-      if (id === RETTANGOLI_FE_VIRTUAL_ENTRY_ID) {
+      if (
+        id === RETTANGOLI_FE_VIRTUAL_ENTRY_ID ||
+        (resolvesPublicEntryToVirtualModule && id === transformEntryId)
+      ) {
         return RESOLVED_VIRTUAL_ENTRY_ID;
       }
       return null;
@@ -267,14 +285,14 @@ export const createRettangoliFeVitePlugin = ({
 
           try {
             const transformed = await server.transformRequest(
-              servedEntryId,
+              transformEntryId,
             );
 
             if (!transformed) {
               res.statusCode = 500;
               res.setHeader("Content-Type", "text/plain; charset=utf-8");
               res.end(
-                `Failed to transform ${servedEntryId}.`,
+                `Failed to transform ${transformEntryId}.`,
               );
               return;
             }

--- a/packages/rettangoli-fe/src/cli/watch.js
+++ b/packages/rettangoli-fe/src/cli/watch.js
@@ -5,6 +5,7 @@ import { createServer } from "vite";
 import {
   RETTANGOLI_FE_VIRTUAL_ENTRY_ID,
   createRettangoliFeVitePlugin,
+  resolveTransformEntryId,
 } from "./vitePlugin.js";
 
 const toPosixPath = (value) => value.split(path.sep).join("/");
@@ -105,6 +106,10 @@ const startWatching = async (options = {}) => {
   } = options;
   const { root, publicEntryPath } = resolveServeContext({ cwd, outfile });
   const servedEntryId = resolveWatchEntryId({ cwd, watchEntry });
+  const transformEntryId = resolveTransformEntryId({
+    publicEntryPath,
+    servedEntryId,
+  });
 
   console.log(`[Watch] Root: ${root}`);
   console.log(`[Watch] Entry: ${publicEntryPath}`);
@@ -115,7 +120,7 @@ const startWatching = async (options = {}) => {
   try {
     const server = await createWatchServer(options);
     await server.listen();
-    await server.transformRequest(servedEntryId);
+    await server.transformRequest(transformEntryId);
     server.printUrls();
     if (enableCliShortcuts) {
       server.bindCLIShortcuts({ print: true });

--- a/packages/rettangoli-fe/test/cli/vite-plugin.test.js
+++ b/packages/rettangoli-fe/test/cli/vite-plugin.test.js
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   RETTANGOLI_FE_VIRTUAL_ENTRY_ID,
   createRettangoliFeVitePlugin,
+  resolveTransformEntryId,
 } from "../../src/cli/vitePlugin.js";
 
 const createFixtureProject = () => {
@@ -63,6 +64,54 @@ describe("vite plugin", () => {
     const source = plugin.load(resolved);
     expect(source).toContain("import { createComponent } from \"@rettangoli/fe\";");
     expect(source).toContain("customElements.define(elementName, webComponent);");
+  });
+
+  it("resolves the public watch entry to the virtual module", () => {
+    const rootDir = createFixtureProject();
+    createdDirs.push(rootDir);
+
+    const publicEntryPath = "/public/main.js";
+    const plugin = createRettangoliFeVitePlugin({
+      cwd: rootDir,
+      dirs: ["components"],
+      setup: "setup.js",
+      publicEntryPath,
+      errorPrefix: "[Watch]",
+    });
+
+    expect(
+      resolveTransformEntryId({
+        publicEntryPath,
+        servedEntryId: RETTANGOLI_FE_VIRTUAL_ENTRY_ID,
+      }),
+    ).toBe(publicEntryPath);
+    expect(plugin.resolveId(publicEntryPath)).toBe(
+      `\0${RETTANGOLI_FE_VIRTUAL_ENTRY_ID}`,
+    );
+  });
+
+  it("preserves an explicit watch entry as the transformed module", () => {
+    const rootDir = createFixtureProject();
+    createdDirs.push(rootDir);
+
+    const publicEntryPath = "/public/main.js";
+    const servedEntryId = "/@fs/repo/watch-entry.js";
+    const plugin = createRettangoliFeVitePlugin({
+      cwd: rootDir,
+      dirs: ["components"],
+      setup: "setup.js",
+      publicEntryPath,
+      servedEntryId,
+      errorPrefix: "[Watch]",
+    });
+
+    expect(
+      resolveTransformEntryId({
+        publicEntryPath,
+        servedEntryId,
+      }),
+    ).toBe(servedEntryId);
+    expect(plugin.resolveId(publicEntryPath)).toBeNull();
   });
 
   it("switches to /@fs imports in serve mode", () => {

--- a/packages/rettangoli-fe/test/cli/vite-runtime.integration.test.js
+++ b/packages/rettangoli-fe/test/cli/vite-runtime.integration.test.js
@@ -10,7 +10,7 @@ import {
   writeFileSync,
 } from "node:fs";
 
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import build from "../../src/cli/build.js";
 import {
@@ -288,7 +288,29 @@ describe("vite runtime integration", () => {
     expect(response.body).toContain("x-counter");
     expect(response.body).toContain("defineOrUpdateComponent");
     expect(response.body).toContain("import.meta.hot.accept");
+    expect(response.body).toContain(
+      '__vite__createHotContext("/public/main.js")',
+    );
     expect(response.body).not.toContain("__STALE_FE_BUNDLE__");
+
+    const publicEntryModule =
+      server.moduleGraph.urlToModuleMap.get("/public/main.js");
+    expect(publicEntryModule?.id).toBe("\0virtual:rettangoli-fe-entry");
+    expect(
+      server.moduleGraph.urlToModuleMap.get("virtual:rettangoli-fe-entry"),
+    ).toBeUndefined();
+
+    const send = vi.spyOn(server.environments.client.hot, "send");
+    publicEntryModule.lastHMRTimestamp = 1234;
+    publicEntryModule.lastHMRInvalidationReceived = false;
+    server.environments.client.invalidateModule({
+      path: "/public/main.js",
+      message: "component requires a reload",
+      firstInvalidatedBy: "/public/main.js",
+    });
+    expect(send).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "full-reload" }),
+    );
   });
 
   it("serves generated VT pages and overrides their copied bundle with the HMR entry", async () => {

--- a/packages/rettangoli-ui/package.json
+++ b/packages/rettangoli-ui/package.json
@@ -64,7 +64,7 @@
   },
   "homepage": "https://github.com/yuusoft-org/rettangoli#readme",
   "dependencies": {
-    "@rettangoli/fe": "1.4.0",
+    "@rettangoli/fe": "1.4.1",
     "jempl": "1.0.1"
   }
 }


### PR DESCRIPTION
## Summary
- use the configured public entry path as the canonical Vite module identity for the generated watch entry
- preserve explicit physical watch entries while allowing incompatible JS updates to trigger a full page reload
- add Vite plugin/runtime regression coverage for the public entry module graph and invalidation path
- bump @rettangoli/fe to 1.4.1 and rtgl to 2.1.2

## Testing
- bun run test (packages/rettangoli-fe)
- bun run test (packages/rettangoli-cli)
- bun run test:package (packages/rettangoli-fe)
- bun run test:package (packages/rettangoli-cli)
- bunx oxlint on changed JavaScript files
- bunx vitest run packages/rettangoli-fe/test/cli/vite-plugin.test.js packages/rettangoli-fe/test/cli/vite-runtime.integration.test.js
- git diff --check