### PR TITLE
docs(fe): document i18n hot reload

### DIFF
--- a/apps/rettangoli.dev/pages/fe/docs/guides/cli.md
+++ b/apps/rettangoli.dev/pages/fe/docs/guides/cli.md
@@ -40,13 +40,22 @@ The build uses Vite 8 (`vite.build`) with Rolldown and Oxc for production bundli
 
 ## `rtgl fe watch`
 
-Starts a development server that watches for file changes and reloads automatically.
+Starts a development server that watches for file changes and applies updates
+automatically.
 
 ```bash
 rtgl fe watch
 ```
 
-Uses Vite (`vite.createServer`) for dev serving and full reload on FE file changes. Component directories, the setup module, and i18n sources are watched explicitly, including when they are outside the served static root.
+Uses Vite (`vite.createServer`) for dev serving. Compatible component edits use
+HMR, preserving component instances and store state. Locale YAML edits replace
+the development catalogs while retaining the selected locale and existing
+subscriptions. Component directories, the setup module, and i18n sources are
+watched explicitly, including when they are outside the served static root.
+
+Changes to setup files and component or locale file additions/removals perform
+a full page reload. An update that changes an incompatible browser contract,
+such as a component name or observed prop, also falls back to a full reload.
 
 Use `fe.publicDir` to serve a directory of static assets at `/` without Vite
 transformations:
@@ -67,8 +76,10 @@ FE keeps the same CLI interface and integrates Vite internally.
 - Virtual entry: FE generates a virtual module (`virtual:rettangoli-fe-entry`) from configured component files.
 - Plugin hooks used:
   - `resolveId` + `load` to provide generated entry code.
-  - `handleHotUpdate` to invalidate and reload on component/setup file edits.
-  - `configureServer` middleware to serve the configured `outfile` path in watch mode.
+  - `handleHotUpdate` to route compatible component and locale edits through
+    the FE virtual-entry HMR boundary.
+  - `configureServer` middleware to serve the configured `outfile` path in
+    watch mode and handle full-reload fallbacks.
 - Startup behavior:
   - Watch mode warms and validates the virtual entry before reporting the server as ready.
 - Output behavior:
@@ -76,11 +87,10 @@ FE keeps the same CLI interface and integrates Vite internally.
   - Additional chunks may be emitted under a `chunks/` folder when splitting is enabled.
 - Validation behavior:
   - Contract validation and YAML/template parsing run before bundle generation.
-  - Watched YAML changes invalidate the virtual entry before the browser reloads.
+  - Watched YAML changes invalidate the virtual entry before HMR processing.
 
-Current limitations:
+Current limitation:
 
-- Watch mode uses full page reload (not component-level HMR).
 - FE does not enable extra Vite CSS plugin configuration.
 
 ## `rtgl fe scaffold`

--- a/apps/rettangoli.dev/pages/fe/docs/guides/i18n.md
+++ b/apps/rettangoli.dev/pages/fe/docs/guides/i18n.md
@@ -229,3 +229,14 @@ _site/public/i18n/vi.json
 
 The runtime resolves locale JSON URLs relative to the generated FE bundle, so
 apps do not need to configure a separate public path.
+
+## Development Hot Reload
+
+When `rtgl fe watch` is running, editing an existing configured locale YAML file
+updates the development catalogs through HMR. Mounted FE components re-render
+with the new content without replacing the locale runtime, so the current locale
+and existing subscriptions are preserved.
+
+Adding or removing a locale source file performs a full page reload. Changes to
+the configured locale list still require updating `rettangoli.config.yaml` and
+restarting the watcher.

--- a/packages/rettangoli-fe/docs/i18n.md
+++ b/packages/rettangoli-fe/docs/i18n.md
@@ -11,6 +11,7 @@ Internationalization is a frontend framework feature. It covers:
 3. build-time generation of lazy-loadable JSON locale assets
 4. runtime injection of `i18n` and `locale`
 5. automatic re-rendering when the active locale changes
+6. state-preserving catalog updates in watch mode
 
 Application code MUST NOT pass `i18n` or `locale` manually through `setup.js`.
 The FE runtime owns these dependencies in the same way it owns `store` and
@@ -283,7 +284,19 @@ _site/public/i18n/vi.json
 The runtime SHOULD resolve locale JSON URLs relative to the generated FE bundle
 so apps do not need to configure a separate public path.
 
-## 10. Validation
+## 10. Watch Mode
+
+When `rtgl fe watch` is running, editing an existing configured locale YAML file
+MUST update the development catalogs through the FE virtual-entry HMR boundary.
+The update MUST preserve the locale runtime, active locale, and existing
+subscriptions, and MUST notify mounted FE components so they re-render with the
+updated content.
+
+Adding or removing a locale source file MUST trigger a full page reload. Changes
+to the configured locale list require updating `rettangoli.config.yaml` and
+restarting the watcher.
+
+## 11. Validation
 
 The build/check pipeline MUST reject:
 - missing configured locale files


### PR DESCRIPTION
## Summary
- update the FE watch guide to describe state-preserving component and locale HMR
- document that locale catalog updates retain the active locale and subscriptions
- clarify full-page reload fallbacks and add the normative i18n watch-mode contract

## Testing
- `git diff --check`
- `node ../../packages/rettangoli-cli/cli.js sites build` (from `apps/rettangoli.dev`)

## Note
- `bun run build` in `apps/rettangoli.dev` uses the pinned `rtgl@1.1.3` and fails on the existing `sitemap` config key; the repository-local CLI build succeeds.